### PR TITLE
Feature/network policy detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # opscart-k8s-watcher
 
-**Version:** 0.3  
-**Purpose:** Production-grade Kubernetes security auditing with multi-cluster support and HTML reporting  
-**Focus:** CIS compliance, HTML reports, and multi-cluster analysis
+**Version:** 0.4  
+**Purpose:** Production-grade Kubernetes security auditing with multi-cluster support, HTML reporting, and network policy analysis  
+**Focus:** CIS compliance, HTML reports, network isolation, and multi-cluster analysis
 
 ---
 
@@ -19,6 +19,55 @@
 - Resource optimization opportunities
 - War room troubleshooting
 - Executive-ready HTML reports
+
+---
+
+## What's New in v0.4
+
+### Network Policy Detection
+- **Namespace coverage analysis** - Which namespaces have NetworkPolicies and which don't
+- **Smart infrastructure filtering** - Auto-skips system namespaces using 3 strategies (no manual list needed):
+  - **Pattern-based** - Covers `kube-*`, `istio-*`, `calico-*`, `tigera-*`, `cert-manager`, `ingress-nginx`, `flux-system`, `argocd`, `velero`, `longhorn-*`, `cattle-*`, `openshift-*`, `gke-*`, `azure-*`, `karpenter`, `crossplane-*`
+  - **Label-based** - Detects `pod-security.kubernetes.io/enforce=privileged` system namespaces
+  - **User-defined** - `--skip-namespaces ns1,ns2` for anything not covered by patterns
+- **Risk-based sorting** - HIGH risk (production/staging) shown first, sorted by pod count
+- **Coverage percentage bar** - Visual indicator of cluster-wide policy coverage
+- **Default-deny template** - Ready-to-apply kubectl policy in recommendations
+- **Multi-cluster support** - Works with `--all-clusters` and `--cluster-group`
+
+```bash
+# Scan single cluster
+./opscart-scan network --cluster prod
+
+# All clusters
+./opscart-scan network --all-clusters
+
+# Cluster group
+./opscart-scan network --cluster-group production
+
+# Skip additional namespaces not covered by auto-detection
+./opscart-scan network --cluster prod --skip-namespaces monitoring,vault
+
+# Specific namespace only
+./opscart-scan network --cluster prod --namespace production
+```
+
+**Example output:**
+```
+NETWORK POLICY SUMMARY
+Total Namespaces:         8
+Protected (policies):     0
+Unprotected (no policy):  8
+High Risk Namespaces:     3
+
+Coverage: [░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░] 0% 🔴 Poor
+
+🔴 UNPROTECTED NAMESPACES (sorted by risk):
+  🔴 [PROD] production (10 pods) - HIGH RISK
+  🔴 [SYS]  monitoring (5 pods)  - HIGH RISK
+  🔴 [STAGE] staging (3 pods)    - HIGH RISK
+  🟢 [DEV]  development (2 pods) - LOW RISK
+```
 
 ---
 
@@ -62,14 +111,21 @@
 
 ## Features
 
-### Multi-Cluster Support (v0.2)
+### 🌐 Multi-Cluster Support (v0.2)
 - **Config management** - Centralized cluster configuration
 - **Multi-cluster scanning** - Scan all clusters with `--all-clusters`
 - **Cluster groups** - Scan by environment with `--cluster-group production`
 - **Side-by-side comparison** - Compare security posture with `--compare=a,b`
 - **Sequential execution** - Clear, readable output for multiple clusters
 
-### HTML Reports (v0.3)
+### 🌐 Network Policy Detection (v0.4)
+- **Namespace coverage analysis** - Protected vs unprotected namespaces
+- **Smart infrastructure filtering** - Auto-skips 15+ known infrastructure patterns
+- **Risk-based prioritization** - HIGH/LOW risk with clear reasoning per namespace
+- **Actionable output** - Ready-to-apply kubectl default-deny policy template
+- **User-defined skip list** - `--skip-namespaces` for custom infrastructure namespaces
+
+### 📊 HTML Reports (v0.3)
 - **Security Reports** - CIS compliance, findings, remediation steps
 - **Comprehensive Reports** - Security + resources + cost analysis
 - **Date-organized storage** - Easy archival and retention management
@@ -117,8 +173,8 @@
 git clone https://github.com/opscart/opscart-k8s-watcher.git
 cd opscart-k8s-watcher
 
-# Checkout v0.3
-git checkout v0.3
+# Checkout v0.4
+git checkout v0.4
 
 # Build
 go build -o opscart-scan cmd/opscart-scan/main.go
@@ -212,6 +268,18 @@ go build -o opscart-scan cmd/opscart-scan/main.go
 # - Environment-specific findings
 ```
 
+### 5. Network Policy Analysis (v0.4)
+```bash
+# Check network isolation across all namespaces
+./opscart-scan network --cluster prod
+
+# All clusters
+./opscart-scan network --all-clusters
+
+# Skip namespaces not caught by auto-detection
+./opscart-scan network --cluster prod --skip-namespaces monitoring,vault
+```
+
 ---
 
 ## Commands
@@ -262,6 +330,24 @@ go build -o opscart-scan cmd/opscart-scan/main.go
 
 # Cluster group
 ./opscart-scan report --cluster-group production --monthly-cost 50000
+```
+
+### Network Policy Analysis (NEW in v0.4)
+```bash
+# Scan single cluster
+./opscart-scan network --cluster CLUSTER
+
+# All clusters
+./opscart-scan network --all-clusters
+
+# Cluster group
+./opscart-scan network --cluster-group production
+
+# Specific namespace only
+./opscart-scan network --cluster CLUSTER --namespace production
+
+# Skip namespaces not auto-detected
+./opscart-scan network --cluster CLUSTER --skip-namespaces monitoring,vault
 ```
 
 ### Other Commands
@@ -364,6 +450,20 @@ kubectl get pods --all-namespaces -o json | \
 
 ## Use Cases
 
+### Network Policy Audit (v0.4)
+```bash
+# Weekly network isolation check across all clusters
+./opscart-scan network --all-clusters
+
+# Focus on production only
+./opscart-scan network --cluster-group production
+
+# Shows:
+# - Which namespaces have NetworkPolicies
+# - Risk level per namespace (HIGH/LOW)
+# - Ready-to-apply default-deny policy template
+```
+
 ### Multi-Cluster Security Review (v0.2 + v0.3)
 ```bash
 # Generate HTML reports for all production clusters
@@ -434,7 +534,18 @@ This enables powerful multi-cluster workflows with `--all-clusters` and `--clust
 
 ## Version History
 
-### v0.3 (Current - February 2026)
+### v0.4 (Current - February 2026)
+**Network Policy Detection:**
+- Namespace coverage analysis (protected vs unprotected)
+- Smart infrastructure filtering - auto-skips 15+ patterns (`kube-*`, `istio-*`, `calico-*`, `tigera-*`, `cert-manager`, `ingress-nginx`, `flux-system`, `argocd`, `velero`, `longhorn-*`, `cattle-*`, `openshift-*`, `gke-*`, `azure-*`, `karpenter`, `crossplane-*`)
+- Label-based detection (`pod-security.kubernetes.io/enforce=privileged`)
+- User-defined skip list via `--skip-namespaces`
+- Risk-based sorting (HIGH/LOW) with clear reasoning
+- Coverage percentage bar
+- Ready-to-apply default-deny policy template in recommendations
+- Full multi-cluster support
+
+### v0.3 (February 2026)
 **HTML Report Generation:**
 - Security HTML reports with CIS scoring
 - Comprehensive cluster reports with real data
@@ -478,24 +589,19 @@ This enables powerful multi-cluster workflows with `--all-clusters` and `--clust
 
 ## Roadmap
 
-### v0.4 (Planned - 4-6 weeks)
-**From v0.2 Promises:**
-- ~~HTML report generation~~ ✅ Delivered in v0.3
-- ~~JSON/CSV output formats~~ ✅ Delivered in v0.3
-- Full diff view for cluster comparison
-- Network policy detection
+### v0.5 (Next)
+**Waste & Cleanup Detector:**
+- Pod age analysis - all pods sorted by age descending (oldest first)
+- Idle detection - CPU < 5% for extended periods
+- Priority scoring - Age + Idle + Cost combined score
+- Orphaned resources - unused PVCs, services without endpoints, 0-replica deployments, old completed/failed jobs
+- Cost estimation per cleanup candidate with potential monthly savings
+- Ready-to-run `kubectl delete` commands for each candidate
+- Multi-cluster support
 
-**Enhanced Comprehensive Reports:**
-- Per-namespace breakdown with resource metrics
-- Idle workload detection details
-- Enhanced cost optimization breakdown
-- Container image analysis
-- PVC storage analysis
-- Historical trends
+**Full diff view for cluster comparison** (promised in v0.2)
 
-**Goal:** Comprehensive HTML report should have full parity with CLI output detail level.
-
-### v0.5 (Future)
+### v0.6 (Future)
 - Prometheus integration for metrics
 - Grafana dashboard templates
 - Webhook notifications (Slack, email)
@@ -509,9 +615,9 @@ This enables powerful multi-cluster workflows with `--all-clusters` and `--clust
 Key areas for contribution:
 1. Additional security checks
 2. Enhanced report templates
-3. Integration with other tools
-4. Network policy detection
-5. Cluster comparison enhancements
+3. Waste and cleanup detection
+4. Cluster comparison diff view
+5. Integration with other tools
 
 ---
 
@@ -533,6 +639,6 @@ MIT License - See LICENSE file for details
 
 Built for production pharmaceutical environments handling 500+ cores across multiple Fortune 500 clients. Validated in enterprise Kubernetes deployments with strict compliance requirements.
 
-**Version:** v0.3  
-**Status:** Production-ready for multi-cluster security auditing  
+**Version:** v0.4  
+**Status:** Production-ready for multi-cluster security auditing with network policy detection  
 **Last Updated:** February 2026

--- a/cmd/opscart-scan/main.go
+++ b/cmd/opscart-scan/main.go
@@ -32,6 +32,9 @@ var (
 	allClustersFlag  bool
 	clusterGroupFlag string
 	compareFlag      []string
+
+	// NEW v0.4 flags
+	skipNamespacesFlag []string // network command: skip specific namespaces
 )
 
 func main() {
@@ -542,6 +545,50 @@ Examples:
 	reportCmd.Flags().StringVar(&clusterGroupFlag, "cluster-group", "", "Generate reports for cluster group")
 	reportCmd.Flags().Float64Var(&monthlyCost, "monthly-cost", 0, "Monthly cluster cost (optional)")
 
+	// ================================================================
+	// Network command - NEW in v0.4
+	// ================================================================
+	networkCmd := &cobra.Command{
+		Use:   "network",
+		Short: "Analyze NetworkPolicy coverage across namespaces",
+		Long:  "Scan cluster for NetworkPolicy resources and identify namespaces with no network isolation",
+		Run: func(cmd *cobra.Command, args []string) {
+			clusters, isCompare, err := resolveTargetClusters()
+			if err != nil {
+				fmt.Printf("Error: %v\n", err)
+				os.Exit(1)
+			}
+
+			if isCompare {
+				fmt.Println("Error: --compare not supported for network command")
+				os.Exit(1)
+			}
+
+			// Single cluster
+			if len(clusters) == 1 {
+				if err := runNetworkScan(clusters[0].Context); err != nil {
+					fmt.Printf("Error: %v\n", err)
+					os.Exit(1)
+				}
+				return
+			}
+
+			// Multi-cluster
+			scanner.PrintMultiClusterHeader(clusters)
+			for i, cl := range clusters {
+				fmt.Printf("\n🔄 Scanning network policies for %s (%d/%d)...\n", cl.Name, i+1, len(clusters))
+				if err := runNetworkScan(cl.Context); err != nil {
+					fmt.Printf("❌ %s failed: %v\n", cl.Name, err)
+				}
+			}
+		},
+	}
+	networkCmd.Flags().StringVarP(&cluster, "cluster", "c", "", "Cluster context name")
+	networkCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Limit to specific namespace")
+	networkCmd.Flags().BoolVar(&allClustersFlag, "all-clusters", false, "Scan all configured clusters")
+	networkCmd.Flags().StringVar(&clusterGroupFlag, "cluster-group", "", "Scan all clusters in a group")
+	networkCmd.Flags().StringSliceVar(&skipNamespacesFlag, "skip-namespaces", []string{}, "Additional namespaces to skip (comma-separated)")
+
 	// Add all commands
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(emergencyCmd)
@@ -553,6 +600,7 @@ Examples:
 	rootCmd.AddCommand(snapshotCmd)
 	rootCmd.AddCommand(idleCmd)
 	rootCmd.AddCommand(reportCmd)
+	rootCmd.AddCommand(networkCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
@@ -1186,4 +1234,23 @@ func getKubernetesClient(clusterContext string) (*kubernetes.Clientset, error) {
 	}
 
 	return clientset, nil
+}
+
+func runNetworkScan(clusterContext string) error {
+	fmt.Printf("\n🔍 Cluster: %s\n", clusterContext)
+
+	clientset, err := getKubernetesClient(clusterContext)
+	if err != nil {
+		return fmt.Errorf("connecting to cluster: %w", err)
+	}
+
+	npa := analyzer.NewNetworkPolicyAuditor(clientset).
+		WithSkipNamespaces(skipNamespacesFlag)
+	audit, err := npa.AuditNetworkPolicies(namespace)
+	if err != nil {
+		return fmt.Errorf("auditing network policies: %w", err)
+	}
+
+	analyzer.PrintNetworkPolicyAudit(audit)
+	return nil
 }

--- a/pkg/analyzer/network.go
+++ b/pkg/analyzer/network.go
@@ -1,0 +1,471 @@
+package analyzer
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// ================================================================
+// Types
+// ================================================================
+
+type NetworkPolicyAuditor struct {
+	clientset      *kubernetes.Clientset
+	ctx            context.Context
+	skipNamespaces []string // user-provided additional namespaces to skip
+}
+
+type NetworkPolicyAudit struct {
+	TotalNamespaces       int
+	ProtectedNamespaces   []NamespaceNetworkStatus
+	UnprotectedNamespaces []NamespaceNetworkStatus
+	TotalPolicies         int
+	HighRiskNamespaces    int
+}
+
+type NamespaceNetworkStatus struct {
+	Name                  string
+	Environment           string
+	PodCount              int
+	PolicyCount           int
+	HasDefaultDeny        bool
+	HasIngressRestriction bool
+	HasEgressRestriction  bool
+	Policies              []PolicyDetail
+	RiskLevel             string // HIGH, MEDIUM, LOW
+	RiskReason            string
+}
+
+type PolicyDetail struct {
+	Name          string
+	Types         []string
+	IngressRules  int
+	EgressRules   int
+	IsDefaultDeny bool
+}
+
+// ================================================================
+// Constructor
+// ================================================================
+
+func NewNetworkPolicyAuditor(clientset *kubernetes.Clientset) *NetworkPolicyAuditor {
+	return &NetworkPolicyAuditor{
+		clientset:      clientset,
+		ctx:            context.Background(),
+		skipNamespaces: []string{},
+	}
+}
+
+func (n *NetworkPolicyAuditor) WithSkipNamespaces(namespaces []string) *NetworkPolicyAuditor {
+	n.skipNamespaces = namespaces
+	return n
+}
+
+// ================================================================
+// Main Audit
+// ================================================================
+
+func (n *NetworkPolicyAuditor) AuditNetworkPolicies(filterNamespace string) (*NetworkPolicyAudit, error) {
+	audit := &NetworkPolicyAudit{}
+
+	// Get namespaces
+	nsList, err := n.clientset.CoreV1().Namespaces().List(n.ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("listing namespaces: %w", err)
+	}
+
+	audit.TotalNamespaces = len(nsList.Items)
+
+	for _, ns := range nsList.Items {
+		nsName := ns.Name
+
+		// Skip system/infrastructure namespaces using 3 strategies:
+		// 1. Kubernetes official label: kubernetes.io/metadata.name on system namespaces
+		// 2. Well-known name patterns for infrastructure components
+		// 3. User-provided skip list via --skip-namespaces flag
+		if n.shouldSkipNamespace(nsName, ns.Labels) {
+			audit.TotalNamespaces--
+			continue
+		}
+
+		// Apply namespace filter if specified
+		if filterNamespace != "" && filterNamespace != nsName {
+			continue
+		}
+
+		// Get pod count
+		pods, _ := n.clientset.CoreV1().Pods(nsName).List(n.ctx, metav1.ListOptions{})
+		podCount := 0
+		if pods != nil {
+			podCount = len(pods.Items)
+		}
+
+		// Get NetworkPolicies in this namespace
+		policies, err := n.clientset.NetworkingV1().NetworkPolicies(nsName).List(n.ctx, metav1.ListOptions{})
+		if err != nil {
+			continue
+		}
+
+		env := detectEnvironment(nsName)
+		status := NamespaceNetworkStatus{
+			Name:        nsName,
+			Environment: env,
+			PodCount:    podCount,
+			PolicyCount: len(policies.Items),
+		}
+
+		if len(policies.Items) > 0 {
+			audit.TotalPolicies += len(policies.Items)
+			n.analyzeProtected(&status, policies.Items)
+			audit.ProtectedNamespaces = append(audit.ProtectedNamespaces, status)
+		} else {
+			n.analyzeRisk(&status)
+			if status.RiskLevel == "HIGH" {
+				audit.HighRiskNamespaces++
+			}
+			audit.UnprotectedNamespaces = append(audit.UnprotectedNamespaces, status)
+		}
+	}
+
+	// Sort unprotected by risk: HIGH first, then by pod count
+	sort.Slice(audit.UnprotectedNamespaces, func(i, j int) bool {
+		ri, rj := riskScore(audit.UnprotectedNamespaces[i].RiskLevel),
+			riskScore(audit.UnprotectedNamespaces[j].RiskLevel)
+		if ri != rj {
+			return ri > rj
+		}
+		return audit.UnprotectedNamespaces[i].PodCount > audit.UnprotectedNamespaces[j].PodCount
+	})
+
+	return audit, nil
+}
+
+func (n *NetworkPolicyAuditor) analyzeProtected(status *NamespaceNetworkStatus, policies []networkingv1.NetworkPolicy) {
+	for _, policy := range policies {
+		detail := PolicyDetail{
+			Name:  policy.Name,
+			Types: []string{},
+		}
+
+		for _, pType := range policy.Spec.PolicyTypes {
+			detail.Types = append(detail.Types, string(pType))
+			if pType == networkingv1.PolicyTypeIngress {
+				status.HasIngressRestriction = true
+				detail.IngressRules = len(policy.Spec.Ingress)
+			}
+			if pType == networkingv1.PolicyTypeEgress {
+				status.HasEgressRestriction = true
+				detail.EgressRules = len(policy.Spec.Egress)
+			}
+		}
+
+		// Detect default-deny: policy with empty podSelector and no rules
+		if len(policy.Spec.PodSelector.MatchLabels) == 0 &&
+			len(policy.Spec.PodSelector.MatchExpressions) == 0 &&
+			(len(policy.Spec.Ingress) == 0 || len(policy.Spec.Egress) == 0) {
+			detail.IsDefaultDeny = true
+			status.HasDefaultDeny = true
+		}
+
+		status.Policies = append(status.Policies, detail)
+	}
+}
+
+func (n *NetworkPolicyAuditor) analyzeRisk(status *NamespaceNetworkStatus) {
+	env := status.Environment
+
+	switch env {
+	case "PRODUCTION":
+		status.RiskLevel = "HIGH"
+		status.RiskReason = "Production namespace with no network isolation - all pods can communicate freely"
+	case "STAGING":
+		status.RiskLevel = "HIGH"
+		status.RiskReason = "Staging namespace unprotected - can be used as pivot point in attacks"
+	case "SYSTEM":
+		status.RiskLevel = "HIGH"
+		status.RiskReason = "System namespace unprotected - critical infrastructure exposed"
+	default:
+		if status.PodCount > 10 {
+			status.RiskLevel = "MEDIUM"
+			status.RiskReason = fmt.Sprintf("Development namespace with %d pods - consider basic isolation", status.PodCount)
+		} else {
+			status.RiskLevel = "LOW"
+			status.RiskReason = "Development/test namespace - low risk but isolation recommended"
+		}
+	}
+}
+
+// shouldSkipNamespace returns true if namespace should be excluded from analysis.
+// Uses 3 strategies so it works across any Kubernetes distribution (AKS, EKS, GKE, k3s, etc.)
+func (n *NetworkPolicyAuditor) shouldSkipNamespace(name string, labels map[string]string) bool {
+	// Strategy 1: User-provided skip list (highest priority)
+	for _, skip := range n.skipNamespaces {
+		if skip == name {
+			return true
+		}
+	}
+
+	// Strategy 2: Well-known infrastructure namespace patterns
+	// Covers: kube-system, kube-public, kube-node-lease, istio-system,
+	// calico-system, calico-apiserver, tigera-operator, cert-manager,
+	// ingress-nginx, flux-system, argocd, velero, longhorn-system,
+	// cattle-system (Rancher), openshift-* etc.
+	infraPatterns := []string{
+		"kube-",         // kube-system, kube-public, kube-node-lease
+		"istio-",        // istio-system, istio-ingress
+		"calico-",       // calico-system, calico-apiserver
+		"tigera-",       // tigera-operator
+		"cert-manager",  // cert-manager
+		"ingress-nginx", // ingress-nginx
+		"flux-system",   // flux-system
+		"argocd",        // argocd
+		"velero",        // velero
+		"longhorn-",     // longhorn-system
+		"cattle-",       // cattle-system (Rancher)
+		"openshift-",    // openshift-* namespaces
+		"gke-",          // GKE system namespaces
+		"azure-",        // AKS system namespaces
+		"karpenter",     // karpenter
+		"crossplane-",   // crossplane-system
+	}
+
+	for _, pattern := range infraPatterns {
+		if strings.HasPrefix(name, pattern) {
+			return true
+		}
+	}
+
+	// Strategy 3: Kubernetes official label for system namespaces
+	// kubernetes.io/metadata.name is set on all namespaces but
+	// pod-security.kubernetes.io/enforce=privileged marks system namespaces
+	if val, ok := labels["pod-security.kubernetes.io/enforce"]; ok && val == "privileged" {
+		// Only skip if it also looks like an infrastructure namespace
+		// (don't skip user namespaces that happen to use privileged PSA)
+		if _, ok := labels["app.kubernetes.io/managed-by"]; !ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+func podLabel(count int) string {
+	if count == 1 {
+		return "1 pod"
+	}
+	return fmt.Sprintf("%d pods", count)
+}
+
+func riskScore(level string) int {
+	switch level {
+	case "HIGH":
+		return 3
+	case "MEDIUM":
+		return 2
+	default:
+		return 1
+	}
+}
+
+// ================================================================
+// Print Functions
+// ================================================================
+
+func PrintNetworkPolicyAudit(audit *NetworkPolicyAudit) {
+	// Header
+	fmt.Println()
+	fmt.Println("╔════════════════════════════════════════════════════════════╗")
+	fmt.Println("║              NETWORK POLICY ANALYSIS                      ║")
+	fmt.Println("╠════════════════════════════════════════════════════════════╣")
+	fmt.Println("║  • Shows NetworkPolicy coverage across all namespaces      ║")
+	fmt.Println("║  • Missing policies = unrestricted pod-to-pod traffic      ║")
+	fmt.Println("║  • Use with kube-bench for full network security audit     ║")
+	fmt.Println("╚════════════════════════════════════════════════════════════╝")
+	fmt.Println()
+
+	// Summary
+	protected := len(audit.ProtectedNamespaces)
+	unprotected := len(audit.UnprotectedNamespaces)
+	total := protected + unprotected
+
+	fmt.Println("═══════════════════════════════════════════════════════════")
+	fmt.Println("NETWORK POLICY SUMMARY")
+	fmt.Println("═══════════════════════════════════════════════════════════")
+	fmt.Printf("Total Namespaces:         %d\n", total)
+	fmt.Printf("Protected (policies):     %d\n", protected)
+	fmt.Printf("Unprotected (no policy):  %d\n", unprotected)
+	fmt.Printf("Total NetworkPolicies:    %d\n", audit.TotalPolicies)
+	fmt.Printf("High Risk Namespaces:     %d\n", audit.HighRiskNamespaces)
+	fmt.Println()
+
+	// Coverage bar
+	if total > 0 {
+		pct := (protected * 100) / total
+		printCoverageBar(pct)
+	}
+
+	// Protected namespaces
+	if len(audit.ProtectedNamespaces) > 0 {
+		fmt.Println("\n🟢 PROTECTED NAMESPACES:")
+		fmt.Println("───────────────────────────────────────────────────────────")
+		for _, ns := range audit.ProtectedNamespaces {
+			printProtectedNamespace(ns)
+		}
+	}
+
+	// Unprotected namespaces
+	if len(audit.UnprotectedNamespaces) > 0 {
+		fmt.Println("\n🔴 UNPROTECTED NAMESPACES (sorted by risk):")
+		fmt.Println("───────────────────────────────────────────────────────────")
+		for _, ns := range audit.UnprotectedNamespaces {
+			printUnprotectedNamespace(ns)
+		}
+	}
+
+	// Recommendations
+	printNetworkRecommendations(audit)
+}
+
+func printCoverageBar(pct int) {
+	barWidth := 40
+	filled := (pct * barWidth) / 100
+	bar := strings.Repeat("█", filled) + strings.Repeat("░", barWidth-filled)
+
+	status := "🔴 Poor"
+	if pct >= 80 {
+		status = "🟢 Good"
+	} else if pct >= 50 {
+		status = "🟡 Partial"
+	}
+
+	fmt.Printf("Coverage: [%s] %d%% %s\n", bar, pct, status)
+	fmt.Println()
+}
+
+func printProtectedNamespace(ns NamespaceNetworkStatus) {
+	envLabel := envEmoji(ns.Environment)
+	fmt.Printf("  ✅ %s %s (%s, %d policies)\n", envLabel, ns.Name, podLabel(ns.PodCount), ns.PolicyCount)
+
+	ingressStatus := "❌ None"
+	if ns.HasIngressRestriction {
+		ingressStatus = "✅ Restricted"
+	}
+	egressStatus := "❌ None"
+	if ns.HasEgressRestriction {
+		egressStatus = "✅ Restricted"
+	}
+	defaultDeny := ""
+	if ns.HasDefaultDeny {
+		defaultDeny = " | Default-Deny: ✅"
+	}
+
+	fmt.Printf("     Ingress: %s | Egress: %s%s\n", ingressStatus, egressStatus, defaultDeny)
+
+	for _, p := range ns.Policies {
+		types := strings.Join(p.Types, "+")
+		if types == "" {
+			types = "Ingress"
+		}
+		denyNote := ""
+		if p.IsDefaultDeny {
+			denyNote = " [default-deny]"
+		}
+		fmt.Printf("     Policy: %s (%s)%s\n", p.Name, types, denyNote)
+	}
+	fmt.Println()
+}
+
+func printUnprotectedNamespace(ns NamespaceNetworkStatus) {
+	riskEmoji := "🟢"
+	if ns.RiskLevel == "HIGH" {
+		riskEmoji = "🔴"
+	} else if ns.RiskLevel == "MEDIUM" {
+		riskEmoji = "🟡"
+	}
+
+	envLabel := envEmoji(ns.Environment)
+	fmt.Printf("  %s %s %s (%s) - %s RISK\n", riskEmoji, envLabel, ns.Name, podLabel(ns.PodCount), ns.RiskLevel)
+	fmt.Printf("     ⚠️  %s\n", ns.RiskReason)
+	fmt.Println()
+}
+
+func printNetworkRecommendations(audit *NetworkPolicyAudit) {
+	if len(audit.UnprotectedNamespaces) == 0 {
+		fmt.Println("\n🎉 All namespaces have NetworkPolicies! Great security posture.")
+		return
+	}
+
+	fmt.Println("═══════════════════════════════════════════════════════════")
+	fmt.Println("💡 RECOMMENDATIONS")
+	fmt.Println("═══════════════════════════════════════════════════════════")
+
+	// Count high risk
+	highRisk := []NamespaceNetworkStatus{}
+	for _, ns := range audit.UnprotectedNamespaces {
+		if ns.RiskLevel == "HIGH" {
+			highRisk = append(highRisk, ns)
+		}
+	}
+
+	if len(highRisk) > 0 {
+		fmt.Printf("\n🔴 IMMEDIATE ACTION - %d high-risk namespaces:\n", len(highRisk))
+		for i, ns := range highRisk {
+			fmt.Printf("  %d. Add NetworkPolicy to '%s' (%s, %s)\n", i+1, ns.Name, ns.Environment, podLabel(ns.PodCount))
+		}
+	}
+
+	fmt.Println("\n📋 QUICK START - Default deny policy template:")
+	fmt.Println()
+	fmt.Println("  cat <<EOF | kubectl apply -f -")
+	fmt.Println("  apiVersion: networking.k8s.io/v1")
+	fmt.Println("  kind: NetworkPolicy")
+	fmt.Println("  metadata:")
+	fmt.Println("    name: default-deny-all")
+	fmt.Println("    namespace: YOUR_NAMESPACE")
+	fmt.Println("  spec:")
+	fmt.Println("    podSelector: {}   # Applies to all pods")
+	fmt.Println("    policyTypes:")
+	fmt.Println("    - Ingress")
+	fmt.Println("    - Egress")
+	fmt.Println("  EOF")
+	fmt.Println()
+	fmt.Println("  ⚠️  Apply default-deny CAREFULLY - test in staging first!")
+	fmt.Println("  📚 Full guide: https://kubernetes.io/docs/concepts/services-networking/network-policies/")
+
+	if len(audit.ProtectedNamespaces) > 0 && !allHaveDefaultDeny(audit.ProtectedNamespaces) {
+		fmt.Println("\n🟡 ENHANCEMENT - Protected namespaces missing default-deny:")
+		for _, ns := range audit.ProtectedNamespaces {
+			if !ns.HasDefaultDeny {
+				fmt.Printf("  • %s: Has policies but no default-deny rule\n", ns.Name)
+			}
+		}
+	}
+}
+
+func allHaveDefaultDeny(namespaces []NamespaceNetworkStatus) bool {
+	for _, ns := range namespaces {
+		if !ns.HasDefaultDeny {
+			return false
+		}
+	}
+	return true
+}
+
+func envEmoji(env string) string {
+	switch env {
+	case "PRODUCTION":
+		return "[PROD]"
+	case "STAGING":
+		return "[STAGE]"
+	case "SYSTEM":
+		return "[SYS]"
+	default:
+		return "[DEV]"
+	}
+}


### PR DESCRIPTION
- Scans all namespaces for NetworkPolicy coverage
- Smart namespace filtering with 3 strategies:
  * Pattern-based: auto-skips kube-*, istio-*, calico-*,
    tigera-*, cert-manager, ingress-nginx, flux-system,
    argocd, velero, longhorn-*, cattle-*, openshift-*,
    gke-*, azure-*, karpenter, crossplane-*
  * Label-based: pod-security.kubernetes.io/enforce=privileged
  * User flag: --skip-namespaces ns1,ns2
- Risk levels: HIGH (prod/staging/system), LOW (dev)
- Coverage percentage bar
- Sorted by risk then pod count
- kubectl default-deny template in recommendations
- Multi-cluster support (--all-clusters, --cluster-group)
- Namespace filter support (--namespace)