### PR TITLE
Waste cleanup detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # opscart-k8s-watcher
 
-**Version:** 0.4  
-**Purpose:** Production-grade Kubernetes security auditing with multi-cluster support, HTML reporting, and network policy analysis  
-**Focus:** CIS compliance, HTML reports, network isolation, and multi-cluster analysis
+**Version:** 0.5  
+**Purpose:** Production-grade Kubernetes security auditing with multi-cluster support, HTML reporting, network policy analysis, and waste detection  
+**Focus:** CIS compliance, HTML reports, network isolation, waste detection, and multi-cluster analysis
 
 ---
 
@@ -19,6 +19,45 @@
 - Resource optimization opportunities
 - War room troubleshooting
 - Executive-ready HTML reports
+
+---
+
+## What's New in v0.5
+
+### Waste & Drift Detection (`waste` command)
+Detects forgotten, idle, and orphaned resources. **Suggestions only - never modifies the cluster.**
+
+- **Abandoned namespaces** - Old namespaces with no running pods (`dev-john`, `test-2024`, `poc-ai`)
+- **Zombie pods** - CrashLoopBackOff, ImagePullBackOff, OOMKilled for days
+- **Unmanaged pods** - Bare pods with no controller (forgotten `kubectl run` sessions)
+- **Orphaned PVCs** - Unbound, released, or bound-but-no-pod (silent storage cost leaks)
+- **Stale Jobs/CronJobs** - Completed jobs not cleaned up, CronJobs that never ran, no history limits set
+- **Zero-replica workloads** - Deployments and StatefulSets scaled to 0
+- **Old ReplicaSets** - Leftover rollout artifacts accumulating over time
+- **Services with no endpoints** - LoadBalancers flagged with cloud cost warning
+- **Broken Ingresses** - Backends pointing to services with no endpoints
+- **Misconfigured HPAs** - Scaling disabled or always stuck at minReplicas
+
+Every finding includes: observed data, reason it's suspicious, and a `kubectl` command to investigate.
+
+```bash
+./opscart-scan waste --cluster prod                        # default: 7+ days old
+./opscart-scan waste --cluster prod --min-age-days 30      # stricter threshold
+./opscart-scan waste --cluster prod --namespace staging    # single namespace
+./opscart-scan waste --all-clusters --min-age-days 14      # all clusters
+```
+
+**Example scorecard:**
+```
+WASTE SCORECARD
+  🔴 Abandoned Namespaces:           1
+  🔴 Zombie Pods (CrashLoop/OOM):    2
+  🔴 Unmanaged Pods (no controller): 1
+  ✅ Orphaned PVCs:                  0
+  🟢 Old ReplicaSets:                2
+  🟢 Misconfigured HPAs:             1
+  Total waste items found:  7
+```
 
 ---
 
@@ -117,6 +156,13 @@ Coverage: [░░░░░░░░░░░░░░░░░░░░░░░
 - **Cluster groups** - Scan by environment with `--cluster-group production`
 - **Side-by-side comparison** - Compare security posture with `--compare=a,b`
 - **Sequential execution** - Clear, readable output for multiple clusters
+
+### 🗑️ Waste & Drift Detection (v0.5)
+- **9 resource types** - namespaces, pods, PVCs, jobs, deployments, ReplicaSets, services, ingresses, HPAs
+- **Data-driven findings** - every result shows observed data, not assumptions
+- **Smart filtering** - auto-skips infrastructure namespaces (same patterns as `network` command)
+- **Configurable threshold** - `--min-age-days` (default: 7)
+- **Suggestions only** - never modifies the cluster
 
 ### 🌐 Network Policy Detection (v0.4)
 - **Namespace coverage analysis** - Protected vs unprotected namespaces
@@ -280,6 +326,21 @@ go build -o opscart-scan cmd/opscart-scan/main.go
 ./opscart-scan network --cluster prod --skip-namespaces monitoring,vault
 ```
 
+### 6. Waste & Drift Detection (v0.5)
+```bash
+# Detect forgotten/idle/orphaned resources (default: 7+ days old)
+./opscart-scan waste --cluster prod
+
+# Adjust age threshold
+./opscart-scan waste --cluster prod --min-age-days 30
+
+# Focus on specific namespace
+./opscart-scan waste --cluster prod --namespace staging
+
+# All clusters
+./opscart-scan waste --all-clusters --min-age-days 14
+```
+
 ---
 
 ## Commands
@@ -330,6 +391,15 @@ go build -o opscart-scan cmd/opscart-scan/main.go
 
 # Cluster group
 ./opscart-scan report --cluster-group production --monthly-cost 50000
+```
+
+### Waste & Drift Detection (NEW in v0.5)
+```bash
+./opscart-scan waste --cluster CLUSTER
+./opscart-scan waste --cluster CLUSTER --min-age-days 30
+./opscart-scan waste --cluster CLUSTER --namespace NAMESPACE
+./opscart-scan waste --all-clusters
+./opscart-scan waste --cluster-group production --min-age-days 14
 ```
 
 ### Network Policy Analysis (NEW in v0.4)
@@ -450,6 +520,17 @@ kubectl get pods --all-namespaces -o json | \
 
 ## Use Cases
 
+### Weekly Waste Review (v0.5)
+```bash
+./opscart-scan waste --all-clusters --min-age-days 30
+
+# Finds real issues like:
+# - Namespace 'data-processing': 9 pods, none Running, 30 days old
+# - Pod 'kubernetes-dashboard': CrashLoopBackOff, 7792 restarts
+# - HPA 'worker': FailedGetResourceMetric - autoscaling silently broken
+# - Bare pod 'webtest-34210': no controller, sitting in default namespace
+```
+
 ### Network Policy Audit (v0.4)
 ```bash
 # Weekly network isolation check across all clusters
@@ -534,7 +615,18 @@ This enables powerful multi-cluster workflows with `--all-clusters` and `--clust
 
 ## Version History
 
-### v0.4 (Current - February 2026)
+### v0.5 (Current - February 2026)
+**Waste & Drift Detection:**
+- `waste` command - detects forgotten, idle, and orphaned resources across 9 types
+- Abandoned namespaces, zombie pods, unmanaged bare pods
+- Orphaned PVCs, stale jobs, zero-replica workloads, old ReplicaSets
+- Services with no endpoints, broken ingresses, misconfigured HPAs
+- Data-driven findings with kubectl investigation commands
+- Smart infrastructure namespace filtering (same patterns as `network` command)
+- Configurable age threshold (`--min-age-days`, default: 7)
+- Suggestions only - never modifies the cluster
+
+### v0.4 (February 2026)
 **Network Policy Detection:**
 - Namespace coverage analysis (protected vs unprotected)
 - Smart infrastructure filtering - auto-skips 15+ patterns (`kube-*`, `istio-*`, `calico-*`, `tigera-*`, `cert-manager`, `ingress-nginx`, `flux-system`, `argocd`, `velero`, `longhorn-*`, `cattle-*`, `openshift-*`, `gke-*`, `azure-*`, `karpenter`, `crossplane-*`)
@@ -589,20 +681,13 @@ This enables powerful multi-cluster workflows with `--all-clusters` and `--clust
 
 ## Roadmap
 
-### v0.5 (Next)
-**Waste & Cleanup Detector:**
-- Pod age analysis - all pods sorted by age descending (oldest first)
-- Idle detection - CPU < 5% for extended periods
-- Priority scoring - Age + Idle + Cost combined score
-- Orphaned resources - unused PVCs, services without endpoints, 0-replica deployments, old completed/failed jobs
-- Cost estimation per cleanup candidate with potential monthly savings
-- Ready-to-run `kubectl delete` commands for each candidate
-- Multi-cluster support
+### v0.6 (Next)
+- Full diff view for cluster comparison (promised in v0.2)
+- Per-namespace breakdown in comprehensive HTML reports
+- Historical trend tracking
 
-**Full diff view for cluster comparison** (promised in v0.2)
-
-### v0.6 (Future)
-- Prometheus integration for metrics
+### v0.7 (Future)
+- Prometheus integration for CPU/memory idle detection
 - Grafana dashboard templates
 - Webhook notifications (Slack, email)
 - Custom policy definitions
@@ -635,10 +720,6 @@ MIT License - See LICENSE file for details
 
 ---
 
-## Acknowledgments
-
-Built for production pharmaceutical environments handling 500+ cores across multiple Fortune 500 clients. Validated in enterprise Kubernetes deployments with strict compliance requirements.
-
-**Version:** v0.4  
-**Status:** Production-ready for multi-cluster security auditing with network policy detection  
+**Version:** v0.5  
+**Status:** Dev/Stag/Production-ready for multi-cluster security auditing, network policy detection, and waste detection  
 **Last Updated:** February 2026

--- a/cmd/opscart-scan/main.go
+++ b/cmd/opscart-scan/main.go
@@ -35,6 +35,9 @@ var (
 
 	// NEW v0.4 flags
 	skipNamespacesFlag []string // network command: skip specific namespaces
+
+	// NEW v0.5 flags
+	minAgeDays int // waste command: minimum resource age to report
 )
 
 func main() {
@@ -589,6 +592,64 @@ Examples:
 	networkCmd.Flags().StringVar(&clusterGroupFlag, "cluster-group", "", "Scan all clusters in a group")
 	networkCmd.Flags().StringSliceVar(&skipNamespacesFlag, "skip-namespaces", []string{}, "Additional namespaces to skip (comma-separated)")
 
+	// ================================================================
+	// Waste command - NEW in v0.5
+	// ================================================================
+	wasteCmd := &cobra.Command{
+		Use:   "waste",
+		Short: "Detect drifted, idle, and orphaned resources",
+		Long: `Scan cluster for resources that are old, idle, or orphaned.
+Shows data-driven findings and suggestions. Does not delete anything.
+
+Detects:
+  - Abandoned namespaces (no running pods, old creation date)
+  - Zombie pods (CrashLoopBackOff, OOMKilled for days)
+  - Idle pods (old, no restarts, no recent activity)
+  - Orphaned PVCs (unbound, released, or bound with no pod)
+  - Stale Jobs/CronJobs (completed, failed, or never ran)
+  - Zero-replica Deployments and StatefulSets
+  - Old ReplicaSets (leftover from rollouts)
+  - Services with no endpoints
+  - Ingresses with missing backends
+  - Misconfigured HPAs`,
+		Run: func(cmd *cobra.Command, args []string) {
+			clusters, isCompare, err := resolveTargetClusters()
+			if err != nil {
+				fmt.Printf("Error: %v\n", err)
+				os.Exit(1)
+			}
+
+			if isCompare {
+				fmt.Println("Error: --compare not supported for waste command")
+				os.Exit(1)
+			}
+
+			// Single cluster
+			if len(clusters) == 1 {
+				if err := runWasteScan(clusters[0].Context); err != nil {
+					fmt.Printf("Error: %v\n", err)
+					os.Exit(1)
+				}
+				return
+			}
+
+			// Multi-cluster
+			scanner.PrintMultiClusterHeader(clusters)
+			for i, cl := range clusters {
+				fmt.Printf("\n🔄 Scanning waste for %s (%d/%d)...\n", cl.Name, i+1, len(clusters))
+				if err := runWasteScan(cl.Context); err != nil {
+					fmt.Printf("❌ %s failed: %v\n", cl.Name, err)
+				}
+			}
+		},
+	}
+	wasteCmd.Flags().StringVarP(&cluster, "cluster", "c", "", "Cluster context name")
+	wasteCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Limit scan to specific namespace")
+	wasteCmd.Flags().BoolVar(&allClustersFlag, "all-clusters", false, "Scan all configured clusters")
+	wasteCmd.Flags().StringVar(&clusterGroupFlag, "cluster-group", "", "Scan all clusters in a group")
+	wasteCmd.Flags().IntVar(&minAgeDays, "min-age-days", 7, "Minimum resource age in days to report (default: 7)")
+	wasteCmd.Flags().Float64Var(&monthlyCost, "monthly-cost", 0, "Monthly cluster cost for waste estimation (optional)")
+
 	// Add all commands
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(emergencyCmd)
@@ -601,6 +662,7 @@ Examples:
 	rootCmd.AddCommand(idleCmd)
 	rootCmd.AddCommand(reportCmd)
 	rootCmd.AddCommand(networkCmd)
+	rootCmd.AddCommand(wasteCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
@@ -1252,5 +1314,24 @@ func runNetworkScan(clusterContext string) error {
 	}
 
 	analyzer.PrintNetworkPolicyAudit(audit)
+	return nil
+}
+
+func runWasteScan(clusterContext string) error {
+	fmt.Printf("\n🔍 Cluster: %s\n", clusterContext)
+	fmt.Printf("   Minimum age: %d days\n", minAgeDays)
+
+	clientset, err := getKubernetesClient(clusterContext)
+	if err != nil {
+		return fmt.Errorf("connecting to cluster: %w", err)
+	}
+
+	wa := analyzer.NewWasteAuditor(clientset, minAgeDays)
+	audit, err := wa.AuditWaste(namespace)
+	if err != nil {
+		return fmt.Errorf("auditing waste: %w", err)
+	}
+
+	analyzer.PrintWasteAudit(audit, minAgeDays)
 	return nil
 }

--- a/pkg/analyzer/waste.go
+++ b/pkg/analyzer/waste.go
@@ -1,0 +1,1411 @@
+package analyzer
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// ================================================================
+// Types
+// ================================================================
+
+type WasteAuditor struct {
+	clientset  *kubernetes.Clientset
+	ctx        context.Context
+	minAgeDays int
+}
+
+type WasteAudit struct {
+	ClusterContext string
+	ScannedAt      time.Time
+
+	AbandonedNamespaces  []AbandonedNamespace
+	StalePods            []StalePod
+	OrphanedPVCs         []OrphanedPVC
+	StaleJobs            []StaleJob
+	ZeroReplicaWorkloads []ZeroReplicaWorkload
+	OldReplicaSets       []OldReplicaSet
+	OrphanedServices     []OrphanedService
+	BrokenIngresses      []BrokenIngress
+	MisconfiguredHPAs    []MisconfiguredHPA
+
+	TotalWasteItems       int
+	EstimatedMonthlyWaste float64 // 0 if monthly cost not provided
+}
+
+// ----------------------------------------------------------------
+// Abandoned Namespaces
+// ----------------------------------------------------------------
+
+type AbandonedNamespace struct {
+	Name        string
+	AgeDays     int
+	PodCount    int
+	AllPodsIdle bool
+	Reason      string // data-driven explanation
+	Score       float64
+}
+
+// ----------------------------------------------------------------
+// Stale Pods - two distinct categories
+// ----------------------------------------------------------------
+
+type StalePodKind string
+
+const (
+	StalePodIdle   StalePodKind = "IDLE"   // old + no recent activity
+	StalePodZombie StalePodKind = "ZOMBIE" // CrashLoopBackOff / OOMKilled for days
+)
+
+type StalePod struct {
+	Name      string
+	Namespace string
+	Kind      StalePodKind
+	AgeDays   int
+	// For IDLE pods:
+	LastActivityDays int // days since last restart (or age if never restarted)
+	RestartCount     int32
+	// For ZOMBIE pods:
+	Status string // CrashLoopBackOff, OOMKilled, etc.
+	Reason string // data-driven explanation
+	Score  float64
+}
+
+// ----------------------------------------------------------------
+// Orphaned PVCs
+// ----------------------------------------------------------------
+
+type PVCStatus string
+
+const (
+	PVCNeverBound PVCStatus = "Never bound"               // Available - created but never used
+	PVCReleased   PVCStatus = "Released (pod deleted)"    // Released - pod gone
+	PVCBoundNoPod PVCStatus = "Bound but no pod using it" // Bound but no pod references it
+)
+
+type OrphanedPVC struct {
+	Name      string
+	Namespace string
+	SizeGB    int
+	Status    PVCStatus
+	AgeDays   int
+	Reason    string
+	Score     float64
+}
+
+// ----------------------------------------------------------------
+// Stale Jobs / CronJobs
+// ----------------------------------------------------------------
+
+type StaleJob struct {
+	Name      string
+	Namespace string
+	IsCronJob bool
+	JobStatus string // Completed, Failed, NeverRan, NoHistoryLimit
+	AgeDays   int
+	Reason    string
+	Score     float64
+}
+
+// ----------------------------------------------------------------
+// Zero-Replica Workloads (Deployments + StatefulSets)
+// ----------------------------------------------------------------
+
+type ZeroReplicaWorkload struct {
+	Name      string
+	Namespace string
+	Kind      string // Deployment, StatefulSet
+	AgeDays   int
+	Reason    string
+	Score     float64
+}
+
+// ----------------------------------------------------------------
+// Old ReplicaSets (leftover from rollouts)
+// ----------------------------------------------------------------
+
+type OldReplicaSet struct {
+	Name            string
+	Namespace       string
+	AgeDays         int
+	OwnerDeployment string
+	Reason          string
+	Score           float64
+}
+
+// ----------------------------------------------------------------
+// Orphaned Services
+// ----------------------------------------------------------------
+
+type OrphanedService struct {
+	Name      string
+	Namespace string
+	Type      string // ClusterIP, LoadBalancer, NodePort
+	AgeDays   int
+	IsLB      bool
+	Reason    string
+	Score     float64
+}
+
+// ----------------------------------------------------------------
+// Broken Ingresses
+// ----------------------------------------------------------------
+
+type BrokenIngress struct {
+	Name      string
+	Namespace string
+	AgeDays   int
+	Hosts     []string
+	Reason    string // which backend is missing
+	Score     float64
+}
+
+// ----------------------------------------------------------------
+// Misconfigured HPAs
+// ----------------------------------------------------------------
+
+type MisconfiguredHPA struct {
+	Name        string
+	Namespace   string
+	TargetName  string
+	MinReplicas int32
+	MaxReplicas int32
+	AgeDays     int
+	Condition   string // ScalingDisabled, MetricNotAvailable, AlwaysAtMin
+	Reason      string
+	Score       float64
+}
+
+// ================================================================
+// Constructor
+// ================================================================
+
+func NewWasteAuditor(clientset *kubernetes.Clientset, minAgeDays int) *WasteAuditor {
+	return &WasteAuditor{
+		clientset:  clientset,
+		ctx:        context.Background(),
+		minAgeDays: minAgeDays,
+	}
+}
+
+// ================================================================
+// Main Audit
+// ================================================================
+
+func (w *WasteAuditor) AuditWaste(filterNamespace string) (*WasteAudit, error) {
+	audit := &WasteAudit{
+		ScannedAt: time.Now(),
+	}
+
+	// Run all detectors
+	if err := w.detectAbandonedNamespaces(audit, filterNamespace); err != nil {
+		fmt.Printf("⚠️  Namespace scan skipped: %v\n", err)
+	}
+
+	if err := w.detectStalePods(audit, filterNamespace); err != nil {
+		fmt.Printf("⚠️  Pod scan skipped: %v\n", err)
+	}
+
+	if err := w.detectOrphanedPVCs(audit, filterNamespace); err != nil {
+		fmt.Printf("⚠️  PVC scan skipped: %v\n", err)
+	}
+
+	if err := w.detectStaleJobs(audit, filterNamespace); err != nil {
+		fmt.Printf("⚠️  Job scan skipped: %v\n", err)
+	}
+
+	if err := w.detectZeroReplicaWorkloads(audit, filterNamespace); err != nil {
+		fmt.Printf("⚠️  Deployment scan skipped: %v\n", err)
+	}
+
+	if err := w.detectOldReplicaSets(audit, filterNamespace); err != nil {
+		fmt.Printf("⚠️  ReplicaSet scan skipped: %v\n", err)
+	}
+
+	if err := w.detectOrphanedServices(audit, filterNamespace); err != nil {
+		fmt.Printf("⚠️  Service scan skipped: %v\n", err)
+	}
+
+	if err := w.detectBrokenIngresses(audit, filterNamespace); err != nil {
+		fmt.Printf("⚠️  Ingress scan skipped: %v\n", err)
+	}
+
+	if err := w.detectMisconfiguredHPAs(audit, filterNamespace); err != nil {
+		fmt.Printf("⚠️  HPA scan skipped: %v\n", err)
+	}
+
+	// Count totals
+	audit.TotalWasteItems = len(audit.AbandonedNamespaces) +
+		len(audit.StalePods) +
+		len(audit.OrphanedPVCs) +
+		len(audit.StaleJobs) +
+		len(audit.ZeroReplicaWorkloads) +
+		len(audit.OldReplicaSets) +
+		len(audit.OrphanedServices) +
+		len(audit.BrokenIngresses) +
+		len(audit.MisconfiguredHPAs)
+
+	return audit, nil
+}
+
+// ================================================================
+// 1. Abandoned Namespaces
+// ================================================================
+
+func (w *WasteAuditor) detectAbandonedNamespaces(audit *WasteAudit, filterNamespace string) error {
+	if filterNamespace != "" {
+		return nil // namespace filter means we're already scoped
+	}
+
+	nsList, err := w.clientset.CoreV1().Namespaces().List(w.ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+
+	for _, ns := range nsList.Items {
+		nsName := ns.Name
+
+		// Skip infrastructure namespaces (reuse same logic as network command)
+		if isInfraPattern(nsName) {
+			continue
+		}
+
+		ageDays := int(now.Sub(ns.CreationTimestamp.Time).Hours() / 24)
+		if ageDays < w.minAgeDays {
+			continue
+		}
+
+		// Count running pods
+		pods, err := w.clientset.CoreV1().Pods(nsName).List(w.ctx, metav1.ListOptions{})
+		if err != nil {
+			continue
+		}
+
+		podCount := len(pods.Items)
+		runningCount := 0
+		for _, p := range pods.Items {
+			if p.Status.Phase == corev1.PodRunning {
+				runningCount++
+			}
+		}
+
+		// Build data-driven reason
+		var reason string
+		var score float64
+
+		if podCount == 0 {
+			reason = fmt.Sprintf("No pods found. Namespace is %d days old with zero workloads", ageDays)
+			score = float64(ageDays) * 0.8
+		} else if runningCount == 0 {
+			reason = fmt.Sprintf("%d pod(s) exist but none are Running (all Pending/Failed/Completed). Namespace is %d days old", podCount, ageDays)
+			score = float64(ageDays)*0.6 + float64(podCount)*2
+		} else {
+			continue // has running pods, not abandoned
+		}
+
+		if score < 10 {
+			continue
+		}
+
+		audit.AbandonedNamespaces = append(audit.AbandonedNamespaces, AbandonedNamespace{
+			Name:     nsName,
+			AgeDays:  ageDays,
+			PodCount: podCount,
+			Reason:   reason,
+			Score:    score,
+		})
+	}
+
+	sort.Slice(audit.AbandonedNamespaces, func(i, j int) bool {
+		return audit.AbandonedNamespaces[i].Score > audit.AbandonedNamespaces[j].Score
+	})
+
+	return nil
+}
+
+// ================================================================
+// 2. Stale Pods
+// ================================================================
+
+func (w *WasteAuditor) detectStalePods(audit *WasteAudit, filterNamespace string) error {
+	pods, err := w.clientset.CoreV1().Pods(filterNamespace).List(w.ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+
+	for _, pod := range pods.Items {
+		// Skip system namespaces
+		if isInfraPattern(pod.Namespace) {
+			continue
+		}
+
+		ageDays := int(now.Sub(pod.CreationTimestamp.Time).Hours() / 24)
+		if ageDays < w.minAgeDays {
+			continue
+		}
+
+		// ── ZOMBIE detection: CrashLoopBackOff / OOMKilled ──────────
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.State.Waiting != nil {
+				reason := cs.State.Waiting.Reason
+				if reason == "CrashLoopBackOff" || reason == "OOMKilled" ||
+					reason == "Error" || reason == "ImagePullBackOff" {
+
+					explanation := fmt.Sprintf(
+						"Container '%s' has been in %s state. Pod is %d days old with %d restarts. "+
+							"This workload is not functioning and consuming scheduling resources.",
+						cs.Name, reason, ageDays, cs.RestartCount,
+					)
+
+					audit.StalePods = append(audit.StalePods, StalePod{
+						Name:         pod.Name,
+						Namespace:    pod.Namespace,
+						Kind:         StalePodZombie,
+						AgeDays:      ageDays,
+						RestartCount: cs.RestartCount,
+						Status:       reason,
+						Reason:       explanation,
+						Score:        float64(ageDays)*0.4 + float64(cs.RestartCount)*0.3,
+					})
+					goto nextPod
+				}
+			}
+		}
+
+		// ── IDLE detection: old pod, no recent restart activity ──────
+		{
+			// Key insight: creationTimestamp never resets on restart.
+			// We check LAST restart time to exclude recently-active pods.
+			lastActivityDays := ageDays // assume as old as pod if never restarted
+			totalRestarts := int32(0)
+
+			for _, cs := range pod.Status.ContainerStatuses {
+				totalRestarts += cs.RestartCount
+
+				// If it restarted recently, it IS active - skip idle check
+				if cs.LastTerminationState.Terminated != nil {
+					lastRestart := cs.LastTerminationState.Terminated.FinishedAt.Time
+					daysSinceRestart := int(now.Sub(lastRestart).Hours() / 24)
+					if daysSinceRestart < lastActivityDays {
+						lastActivityDays = daysSinceRestart
+					}
+				}
+			}
+
+			// Only flag as idle if last activity was also old
+			// A pod that restarted 2 days ago is NOT idle even if created 90 days ago
+			if lastActivityDays < w.minAgeDays {
+				goto nextPod
+			}
+
+			// IDLE signal = bare pod with no owning controller.
+			// A pod managed by Deployment/DaemonSet/StatefulSet is actively maintained -
+			// 0 restarts on those is healthy, NOT a waste signal.
+			// Real waste = manually created pods (kubectl run, raw Pod manifest)
+			// that someone forgot about.
+			isBarePod := true
+			for _, ref := range pod.OwnerReferences {
+				if ref.Kind == "ReplicaSet" || ref.Kind == "DaemonSet" ||
+					ref.Kind == "StatefulSet" || ref.Kind == "Job" ||
+					ref.Kind == "CronJob" {
+					isBarePod = false
+					break
+				}
+			}
+
+			if isBarePod && pod.Status.Phase == corev1.PodRunning {
+				explanation := fmt.Sprintf(
+					"Pod is %d days old and has no owning controller - it is not managed by any "+
+						"Deployment, DaemonSet, or StatefulSet. Manually-created pods are often "+
+						"used for debugging or testing and left running. Restart count: %d.",
+					ageDays, totalRestarts,
+				)
+
+				audit.StalePods = append(audit.StalePods, StalePod{
+					Name:             pod.Name,
+					Namespace:        pod.Namespace,
+					Kind:             StalePodIdle,
+					AgeDays:          ageDays,
+					LastActivityDays: lastActivityDays,
+					RestartCount:     totalRestarts,
+					Reason:           explanation,
+					Score:            float64(ageDays) * 0.5,
+				})
+			}
+		}
+
+	nextPod:
+	}
+
+	sort.Slice(audit.StalePods, func(i, j int) bool {
+		return audit.StalePods[i].Score > audit.StalePods[j].Score
+	})
+
+	return nil
+}
+
+// ================================================================
+// 3. Orphaned PVCs
+// ================================================================
+
+func (w *WasteAuditor) detectOrphanedPVCs(audit *WasteAudit, filterNamespace string) error {
+	pvcs, err := w.clientset.CoreV1().PersistentVolumeClaims(filterNamespace).List(w.ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	// Build set of PVCs actively used by pods
+	pods, err := w.clientset.CoreV1().Pods(filterNamespace).List(w.ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	usedPVCs := map[string]bool{}
+	for _, pod := range pods.Items {
+		for _, vol := range pod.Spec.Volumes {
+			if vol.PersistentVolumeClaim != nil {
+				key := pod.Namespace + "/" + vol.PersistentVolumeClaim.ClaimName
+				usedPVCs[key] = true
+			}
+		}
+	}
+
+	now := time.Now()
+
+	for _, pvc := range pvcs.Items {
+		if isInfraPattern(pvc.Namespace) {
+			continue
+		}
+
+		ageDays := int(now.Sub(pvc.CreationTimestamp.Time).Hours() / 24)
+		if ageDays < w.minAgeDays {
+			continue
+		}
+
+		// Get size
+		sizeGB := 0
+		if storage, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]; ok {
+			sizeGB = int(storage.Value() / (1024 * 1024 * 1024))
+			if sizeGB == 0 {
+				sizeGB = int(storage.Value() / (1024 * 1024)) // check MB
+			}
+		}
+
+		pvcKey := pvc.Namespace + "/" + pvc.Name
+
+		var status PVCStatus
+		var reason string
+		var score float64
+
+		switch pvc.Status.Phase {
+		case corev1.ClaimPending:
+			// PVC pending for longer than minAgeDays = never successfully bound
+			// (normal PVCs bind within seconds/minutes)
+			status = PVCNeverBound
+			reason = fmt.Sprintf(
+				"PVC has been in 'Pending' state for %d days - it was never successfully bound to a PV. "+
+					"This usually means no matching PersistentVolume exists or the StorageClass cannot provision one. "+
+					"Storage may or may not be provisioned depending on the provisioner.",
+				ageDays,
+			)
+			score = float64(ageDays)*0.6 + float64(sizeGB)*0.4
+
+		case corev1.ClaimLost:
+			status = PVCReleased
+			reason = fmt.Sprintf(
+				"PVC is in 'Lost' state for %d days - the underlying PV no longer exists. "+
+					"Data may already be gone. Safe to delete the PVC object.",
+				ageDays,
+			)
+			score = float64(ageDays) * 0.7
+
+		case corev1.ClaimBound:
+			// Check if any pod is actually using it
+			if !usedPVCs[pvcKey] {
+				status = PVCBoundNoPod
+				reason = fmt.Sprintf(
+					"PVC is Bound to a PV but no running pod is mounting it (checked %d pods in namespace). "+
+						"%dGB of storage is allocated but idle for %d days. "+
+						"Common cause: StatefulSet scaled down or pod deleted without removing PVC.",
+					len(pods.Items), sizeGB, ageDays,
+				)
+				score = float64(ageDays)*0.5 + float64(sizeGB)*0.3
+			} else {
+				continue // actively used
+			}
+		}
+
+		audit.OrphanedPVCs = append(audit.OrphanedPVCs, OrphanedPVC{
+			Name:      pvc.Name,
+			Namespace: pvc.Namespace,
+			SizeGB:    sizeGB,
+			Status:    status,
+			AgeDays:   ageDays,
+			Reason:    reason,
+			Score:     score,
+		})
+	}
+
+	sort.Slice(audit.OrphanedPVCs, func(i, j int) bool {
+		return audit.OrphanedPVCs[i].Score > audit.OrphanedPVCs[j].Score
+	})
+
+	return nil
+}
+
+// ================================================================
+// 4. Stale Jobs & CronJobs
+// ================================================================
+
+func (w *WasteAuditor) detectStaleJobs(audit *WasteAudit, filterNamespace string) error {
+	jobs, err := w.clientset.BatchV1().Jobs(filterNamespace).List(w.ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+
+	for _, job := range jobs.Items {
+		if isInfraPattern(job.Namespace) {
+			continue
+		}
+
+		ageDays := int(now.Sub(job.CreationTimestamp.Time).Hours() / 24)
+		if ageDays < w.minAgeDays {
+			continue
+		}
+
+		// Skip jobs owned by a CronJob (handled separately)
+		ownedByCronJob := false
+		for _, ref := range job.OwnerReferences {
+			if ref.Kind == "CronJob" {
+				ownedByCronJob = true
+				break
+			}
+		}
+		if ownedByCronJob {
+			continue
+		}
+
+		var jobStatus string
+		var reason string
+		var score float64
+
+		if job.Status.Succeeded > 0 {
+			jobStatus = "Completed"
+			reason = fmt.Sprintf(
+				"Job completed successfully %d days ago and has not been cleaned up. "+
+					"Completed jobs consume namespace quota and clutter `kubectl get jobs` output. "+
+					"Consider setting ttlSecondsAfterFinished on future jobs.",
+				ageDays,
+			)
+			score = float64(ageDays) * 0.6
+		} else if job.Status.Failed > 0 {
+			jobStatus = "Failed"
+			reason = fmt.Sprintf(
+				"Job has %d failed attempt(s) and is %d days old. "+
+					"It is not retrying and will not succeed without intervention. "+
+					"Investigate the failure reason then remove.",
+				job.Status.Failed, ageDays,
+			)
+			score = float64(ageDays)*0.5 + float64(job.Status.Failed)*5
+		} else {
+			continue
+		}
+
+		audit.StaleJobs = append(audit.StaleJobs, StaleJob{
+			Name:      job.Name,
+			Namespace: job.Namespace,
+			JobStatus: jobStatus,
+			AgeDays:   ageDays,
+			Reason:    reason,
+			Score:     score,
+		})
+	}
+
+	// CronJobs - detect misconfigured ones
+	cronJobs, err := w.clientset.BatchV1().CronJobs(filterNamespace).List(w.ctx, metav1.ListOptions{})
+	if err == nil {
+		for _, cj := range cronJobs.Items {
+			if isInfraPattern(cj.Namespace) {
+				continue
+			}
+
+			ageDays := int(now.Sub(cj.CreationTimestamp.Time).Hours() / 24)
+			if ageDays < w.minAgeDays {
+				continue
+			}
+
+			// CronJob that has never run
+			if cj.Status.LastScheduleTime == nil {
+				reason := fmt.Sprintf(
+					"CronJob is %d days old but has never been scheduled. "+
+						"This may indicate a misconfigured schedule, suspended state, or the CronJob controller cannot reach it. "+
+						"Schedule: '%s', Suspended: %v",
+					ageDays, cj.Spec.Schedule, cj.Spec.Suspend != nil && *cj.Spec.Suspend,
+				)
+				audit.StaleJobs = append(audit.StaleJobs, StaleJob{
+					Name:      cj.Name,
+					Namespace: cj.Namespace,
+					IsCronJob: true,
+					JobStatus: "NeverScheduled",
+					AgeDays:   ageDays,
+					Reason:    reason,
+					Score:     float64(ageDays) * 0.4,
+				})
+			}
+
+			// CronJob with no history limits (will pile up jobs forever)
+			if cj.Spec.SuccessfulJobsHistoryLimit == nil && cj.Spec.FailedJobsHistoryLimit == nil {
+				reason := fmt.Sprintf(
+					"CronJob has no successfulJobsHistoryLimit or failedJobsHistoryLimit set. " +
+						"This means completed/failed jobs will accumulate indefinitely. " +
+						"Recommend setting successfulJobsHistoryLimit: 3 and failedJobsHistoryLimit: 1.",
+				)
+				audit.StaleJobs = append(audit.StaleJobs, StaleJob{
+					Name:      cj.Name,
+					Namespace: cj.Namespace,
+					IsCronJob: true,
+					JobStatus: "NoHistoryLimit",
+					AgeDays:   ageDays,
+					Reason:    reason,
+					Score:     float64(ageDays) * 0.2,
+				})
+			}
+		}
+	}
+
+	sort.Slice(audit.StaleJobs, func(i, j int) bool {
+		return audit.StaleJobs[i].Score > audit.StaleJobs[j].Score
+	})
+
+	return nil
+}
+
+// ================================================================
+// 5. Zero-Replica Workloads
+// ================================================================
+
+func (w *WasteAuditor) detectZeroReplicaWorkloads(audit *WasteAudit, filterNamespace string) error {
+	now := time.Now()
+
+	// Deployments
+	deployments, err := w.clientset.AppsV1().Deployments(filterNamespace).List(w.ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, d := range deployments.Items {
+		if isInfraPattern(d.Namespace) {
+			continue
+		}
+
+		ageDays := int(now.Sub(d.CreationTimestamp.Time).Hours() / 24)
+		if ageDays < w.minAgeDays {
+			continue
+		}
+
+		if d.Spec.Replicas != nil && *d.Spec.Replicas == 0 {
+			reason := fmt.Sprintf(
+				"Deployment has been set to 0 replicas for %d days. "+
+					"It is not running any pods but still consumes a Deployment object, "+
+					"ConfigMaps, and namespace quota. "+
+					"If intentionally disabled, consider archiving it instead.",
+				ageDays,
+			)
+			audit.ZeroReplicaWorkloads = append(audit.ZeroReplicaWorkloads, ZeroReplicaWorkload{
+				Name:      d.Name,
+				Namespace: d.Namespace,
+				Kind:      "Deployment",
+				AgeDays:   ageDays,
+				Reason:    reason,
+				Score:     float64(ageDays) * 0.5,
+			})
+		}
+	}
+
+	// StatefulSets
+	statefulsets, err := w.clientset.AppsV1().StatefulSets(filterNamespace).List(w.ctx, metav1.ListOptions{})
+	if err == nil {
+		for _, s := range statefulsets.Items {
+			if isInfraPattern(s.Namespace) {
+				continue
+			}
+
+			ageDays := int(now.Sub(s.CreationTimestamp.Time).Hours() / 24)
+			if ageDays < w.minAgeDays {
+				continue
+			}
+
+			if s.Spec.Replicas != nil && *s.Spec.Replicas == 0 {
+				reason := fmt.Sprintf(
+					"StatefulSet has been set to 0 replicas for %d days. "+
+						"Its PVCs may still exist and incur storage costs even with no running pods. "+
+						"Check associated PVCs before removing.",
+					ageDays,
+				)
+				audit.ZeroReplicaWorkloads = append(audit.ZeroReplicaWorkloads, ZeroReplicaWorkload{
+					Name:      s.Name,
+					Namespace: s.Namespace,
+					Kind:      "StatefulSet",
+					AgeDays:   ageDays,
+					Reason:    reason,
+					Score:     float64(ageDays)*0.5 + 10, // StatefulSet scores higher due to PVC risk
+				})
+			}
+		}
+	}
+
+	sort.Slice(audit.ZeroReplicaWorkloads, func(i, j int) bool {
+		return audit.ZeroReplicaWorkloads[i].Score > audit.ZeroReplicaWorkloads[j].Score
+	})
+
+	return nil
+}
+
+// ================================================================
+// 6. Old ReplicaSets (leftover from rollouts)
+// ================================================================
+
+func (w *WasteAuditor) detectOldReplicaSets(audit *WasteAudit, filterNamespace string) error {
+	rsList, err := w.clientset.AppsV1().ReplicaSets(filterNamespace).List(w.ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+
+	for _, rs := range rsList.Items {
+		if isInfraPattern(rs.Namespace) {
+			continue
+		}
+
+		// Only care about old RSes with 0 desired replicas
+		if rs.Spec.Replicas != nil && *rs.Spec.Replicas != 0 {
+			continue
+		}
+
+		ageDays := int(now.Sub(rs.CreationTimestamp.Time).Hours() / 24)
+		if ageDays < w.minAgeDays {
+			continue
+		}
+
+		// Find owner deployment name
+		ownerDeploy := ""
+		for _, ref := range rs.OwnerReferences {
+			if ref.Kind == "Deployment" {
+				ownerDeploy = ref.Name
+				break
+			}
+		}
+
+		reason := fmt.Sprintf(
+			"ReplicaSet has 0 desired replicas and is %d days old. "+
+				"This is a leftover from a previous deployment rollout of '%s'. "+
+				"Kubernetes retains old ReplicaSets for rollback history but they accumulate over time.",
+			ageDays, ownerDeploy,
+		)
+
+		audit.OldReplicaSets = append(audit.OldReplicaSets, OldReplicaSet{
+			Name:            rs.Name,
+			Namespace:       rs.Namespace,
+			AgeDays:         ageDays,
+			OwnerDeployment: ownerDeploy,
+			Reason:          reason,
+			Score:           float64(ageDays) * 0.3,
+		})
+	}
+
+	sort.Slice(audit.OldReplicaSets, func(i, j int) bool {
+		return audit.OldReplicaSets[i].Score > audit.OldReplicaSets[j].Score
+	})
+
+	return nil
+}
+
+// ================================================================
+// 7. Orphaned Services
+// ================================================================
+
+func (w *WasteAuditor) detectOrphanedServices(audit *WasteAudit, filterNamespace string) error {
+	services, err := w.clientset.CoreV1().Services(filterNamespace).List(w.ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+
+	for _, svc := range services.Items {
+		if isInfraPattern(svc.Namespace) {
+			continue
+		}
+
+		// Skip kubernetes default service
+		if svc.Name == "kubernetes" && svc.Namespace == "default" {
+			continue
+		}
+
+		ageDays := int(now.Sub(svc.CreationTimestamp.Time).Hours() / 24)
+		if ageDays < w.minAgeDays {
+			continue
+		}
+
+		// Check endpoints
+		endpoints, err := w.clientset.CoreV1().Endpoints(svc.Namespace).Get(w.ctx, svc.Name, metav1.GetOptions{})
+		hasEndpoints := err == nil && len(endpoints.Subsets) > 0
+
+		if !hasEndpoints {
+			isLB := svc.Spec.Type == corev1.ServiceTypeLoadBalancer
+
+			var reason string
+			if isLB {
+				reason = fmt.Sprintf(
+					"LoadBalancer service has no active endpoints for %d days. "+
+						"Cloud load balancers incur hourly cost even with zero traffic. "+
+						"The selector '%v' does not match any running pod.",
+					ageDays, svc.Spec.Selector,
+				)
+			} else {
+				reason = fmt.Sprintf(
+					"Service (type: %s) has no active endpoints for %d days. "+
+						"The selector '%v' does not match any running pod. "+
+						"This service cannot route traffic to anything.",
+					svc.Spec.Type, ageDays, svc.Spec.Selector,
+				)
+			}
+
+			score := float64(ageDays) * 0.4
+			if isLB {
+				score += 30 // LoadBalancers score higher due to cloud cost
+			}
+
+			audit.OrphanedServices = append(audit.OrphanedServices, OrphanedService{
+				Name:      svc.Name,
+				Namespace: svc.Namespace,
+				Type:      string(svc.Spec.Type),
+				AgeDays:   ageDays,
+				IsLB:      isLB,
+				Reason:    reason,
+				Score:     score,
+			})
+		}
+	}
+
+	sort.Slice(audit.OrphanedServices, func(i, j int) bool {
+		return audit.OrphanedServices[i].Score > audit.OrphanedServices[j].Score
+	})
+
+	return nil
+}
+
+// ================================================================
+// 8. Broken Ingresses
+// ================================================================
+
+func (w *WasteAuditor) detectBrokenIngresses(audit *WasteAudit, filterNamespace string) error {
+	ingresses, err := w.clientset.NetworkingV1().Ingresses(filterNamespace).List(w.ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+
+	for _, ing := range ingresses.Items {
+		if isInfraPattern(ing.Namespace) {
+			continue
+		}
+
+		ageDays := int(now.Sub(ing.CreationTimestamp.Time).Hours() / 24)
+		if ageDays < w.minAgeDays {
+			continue
+		}
+
+		missingBackends := []string{}
+
+		// Check each rule's backend service exists and has endpoints
+		for _, rule := range ing.Spec.Rules {
+			if rule.HTTP == nil {
+				continue
+			}
+			for _, path := range rule.HTTP.Paths {
+				if path.Backend.Service == nil {
+					continue
+				}
+				svcName := path.Backend.Service.Name
+				ep, err := w.clientset.CoreV1().Endpoints(ing.Namespace).Get(w.ctx, svcName, metav1.GetOptions{})
+				if err != nil || len(ep.Subsets) == 0 {
+					missingBackends = append(missingBackends, fmt.Sprintf("%s → %s (no endpoints)", rule.Host, svcName))
+				}
+			}
+		}
+
+		// Also check default backend
+		if ing.Spec.DefaultBackend != nil && ing.Spec.DefaultBackend.Service != nil {
+			svcName := ing.Spec.DefaultBackend.Service.Name
+			ep, err := w.clientset.CoreV1().Endpoints(ing.Namespace).Get(w.ctx, svcName, metav1.GetOptions{})
+			if err != nil || len(ep.Subsets) == 0 {
+				missingBackends = append(missingBackends, fmt.Sprintf("default-backend → %s (no endpoints)", svcName))
+			}
+		}
+
+		if len(missingBackends) > 0 {
+			hosts := []string{}
+			for _, rule := range ing.Spec.Rules {
+				if rule.Host != "" {
+					hosts = append(hosts, rule.Host)
+				}
+			}
+
+			reason := fmt.Sprintf(
+				"Ingress is %d days old and has %d backend(s) with no active endpoints: %s. "+
+					"Traffic arriving at %v will return errors.",
+				ageDays, len(missingBackends),
+				strings.Join(missingBackends, "; "),
+				hosts,
+			)
+
+			audit.BrokenIngresses = append(audit.BrokenIngresses, BrokenIngress{
+				Name:      ing.Name,
+				Namespace: ing.Namespace,
+				AgeDays:   ageDays,
+				Hosts:     hosts,
+				Reason:    reason,
+				Score:     float64(ageDays)*0.4 + float64(len(missingBackends))*10,
+			})
+		}
+	}
+
+	sort.Slice(audit.BrokenIngresses, func(i, j int) bool {
+		return audit.BrokenIngresses[i].Score > audit.BrokenIngresses[j].Score
+	})
+
+	return nil
+}
+
+// ================================================================
+// 9. Misconfigured HPAs
+// ================================================================
+
+func (w *WasteAuditor) detectMisconfiguredHPAs(audit *WasteAudit, filterNamespace string) error {
+	hpas, err := w.clientset.AutoscalingV2().HorizontalPodAutoscalers(filterNamespace).List(w.ctx, metav1.ListOptions{})
+	if err != nil {
+		// Try v1 if v2 not available
+		return nil
+	}
+
+	now := time.Now()
+
+	for _, hpa := range hpas.Items {
+		if isInfraPattern(hpa.Namespace) {
+			continue
+		}
+
+		ageDays := int(now.Sub(hpa.CreationTimestamp.Time).Hours() / 24)
+		if ageDays < w.minAgeDays {
+			continue
+		}
+
+		minReplicas := int32(1)
+		if hpa.Spec.MinReplicas != nil {
+			minReplicas = *hpa.Spec.MinReplicas
+		}
+
+		// Check HPA conditions for issues
+		for _, cond := range hpa.Status.Conditions {
+			if cond.Type == "ScalingActive" && cond.Status == "False" {
+				reason := fmt.Sprintf(
+					"HPA targeting '%s' has been inactive for %d days. "+
+						"Condition: %s - %s. "+
+						"The HPA exists but cannot function, so autoscaling is disabled effectively.",
+					hpa.Spec.ScaleTargetRef.Name, ageDays,
+					cond.Reason, cond.Message,
+				)
+				audit.MisconfiguredHPAs = append(audit.MisconfiguredHPAs, MisconfiguredHPA{
+					Name:        hpa.Name,
+					Namespace:   hpa.Namespace,
+					TargetName:  hpa.Spec.ScaleTargetRef.Name,
+					MinReplicas: minReplicas,
+					MaxReplicas: hpa.Spec.MaxReplicas,
+					AgeDays:     ageDays,
+					Condition:   string(cond.Reason),
+					Reason:      reason,
+					Score:       float64(ageDays) * 0.3,
+				})
+				break
+			}
+		}
+
+		// HPA where current == min for a very long time (not scaling up)
+		if hpa.Status.CurrentReplicas == minReplicas &&
+			hpa.Status.DesiredReplicas == minReplicas &&
+			ageDays > 30 {
+			reason := fmt.Sprintf(
+				"HPA targeting '%s' has been at minReplicas (%d) for %d days and never scaled up. "+
+					"Either the workload has no traffic/load, the metric source is wrong, "+
+					"or the HPA thresholds are set too high.",
+				hpa.Spec.ScaleTargetRef.Name, minReplicas, ageDays,
+			)
+			audit.MisconfiguredHPAs = append(audit.MisconfiguredHPAs, MisconfiguredHPA{
+				Name:        hpa.Name,
+				Namespace:   hpa.Namespace,
+				TargetName:  hpa.Spec.ScaleTargetRef.Name,
+				MinReplicas: minReplicas,
+				MaxReplicas: hpa.Spec.MaxReplicas,
+				AgeDays:     ageDays,
+				Condition:   "AlwaysAtMin",
+				Reason:      reason,
+				Score:       float64(ageDays) * 0.2,
+			})
+		}
+	}
+
+	return nil
+}
+
+// ================================================================
+// Print Functions
+// ================================================================
+
+func PrintWasteAudit(audit *WasteAudit, minAgeDays int) {
+	fmt.Println()
+	fmt.Println("╔════════════════════════════════════════════════════════════╗")
+	fmt.Println("║           CLUSTER WASTE & DRIFT ANALYSIS                  ║")
+	fmt.Println("╠════════════════════════════════════════════════════════════╣")
+	fmt.Printf("║  Resources older than %2d days  │  Suggestions only - no changes made  ║\n", minAgeDays)
+	fmt.Println("╚════════════════════════════════════════════════════════════╝")
+	fmt.Println()
+
+	if audit.TotalWasteItems == 0 {
+		fmt.Println("✅ No waste detected! Cluster looks clean.")
+		return
+	}
+
+	// Scorecard
+	printWasteScorecard(audit)
+
+	// Details by category
+	printAbandonedNamespaces(audit)
+	printStalePods(audit)
+	printOrphanedPVCs(audit)
+	printStaleJobs(audit)
+	printZeroReplicaWorkloads(audit)
+	printOldReplicaSets(audit)
+	printOrphanedServices(audit)
+	printBrokenIngresses(audit)
+	printMisconfiguredHPAs(audit)
+
+	// Summary actions
+	printWasteSummary(audit)
+}
+
+func printWasteScorecard(audit *WasteAudit) {
+	fmt.Println("WASTE SCORECARD")
+	fmt.Println("═══════════════════════════════════════════════════════════")
+
+	printScoreRow("Abandoned Namespaces", len(audit.AbandonedNamespaces), "🔴")
+	zombieCount := 0
+	bareCount := 0
+	for _, p := range audit.StalePods {
+		if p.Kind == StalePodZombie {
+			zombieCount++
+		} else {
+			bareCount++
+		}
+	}
+	printScoreRow("Zombie Pods (CrashLoop/OOM)", zombieCount, "🔴")
+	printScoreRow("Unmanaged Pods (no controller)", bareCount, "🔴")
+	printScoreRow("Orphaned PVCs", len(audit.OrphanedPVCs), "🔴")
+	printScoreRow("Orphaned Services", len(audit.OrphanedServices), "🟡")
+	printScoreRow("Broken Ingresses", len(audit.BrokenIngresses), "🟡")
+	printScoreRow("Stale Jobs/CronJobs", len(audit.StaleJobs), "🟡")
+	printScoreRow("Zero-Replica Workloads", len(audit.ZeroReplicaWorkloads), "🟡")
+	printScoreRow("Old ReplicaSets", len(audit.OldReplicaSets), "🟢")
+	printScoreRow("Misconfigured HPAs", len(audit.MisconfiguredHPAs), "🟢")
+
+	fmt.Println("───────────────────────────────────────────────────────────")
+	fmt.Printf("  Total waste items found:  %d\n", audit.TotalWasteItems)
+	fmt.Println()
+}
+
+func printScoreRow(label string, count int, emoji string) {
+	if count == 0 {
+		fmt.Printf("  ✅ %-28s 0\n", label+":")
+	} else {
+		fmt.Printf("  %s %-28s %d\n", emoji, label+":", count)
+	}
+}
+
+func printAbandonedNamespaces(audit *WasteAudit) {
+	if len(audit.AbandonedNamespaces) == 0 {
+		return
+	}
+	fmt.Println("═══════════════════════════════════════════════════════════")
+	fmt.Printf("🔴 ABANDONED NAMESPACES (%d)\n", len(audit.AbandonedNamespaces))
+	fmt.Println("═══════════════════════════════════════════════════════════")
+	for _, ns := range audit.AbandonedNamespaces {
+		fmt.Printf("\n  📁 %s\n", ns.Name)
+		fmt.Printf("     Age:      %d days\n", ns.AgeDays)
+		fmt.Printf("     Pods:     %s\n", podLabel(ns.PodCount))
+		fmt.Printf("     Finding:  %s\n", ns.Reason)
+		fmt.Printf("     Suggest:  Confirm with team if namespace is still needed.\n")
+		fmt.Printf("               kubectl get all -n %s\n", ns.Name)
+	}
+	fmt.Println()
+}
+
+func printStalePods(audit *WasteAudit) {
+	if len(audit.StalePods) == 0 {
+		return
+	}
+
+	// Separate zombies from idle
+	zombies := []StalePod{}
+	idle := []StalePod{}
+	for _, p := range audit.StalePods {
+		if p.Kind == StalePodZombie {
+			zombies = append(zombies, p)
+		} else {
+			idle = append(idle, p)
+		}
+	}
+
+	if len(zombies) > 0 {
+		fmt.Println("═══════════════════════════════════════════════════════════")
+		fmt.Printf("🔴 ZOMBIE PODS - not functioning (%d)\n", len(zombies))
+		fmt.Println("═══════════════════════════════════════════════════════════")
+		for _, p := range zombies {
+			fmt.Printf("\n  💀 %s (namespace: %s)\n", p.Name, p.Namespace)
+			fmt.Printf("     Status:   %s\n", p.Status)
+			fmt.Printf("     Age:      %d days\n", p.AgeDays)
+			fmt.Printf("     Restarts: %d\n", p.RestartCount)
+			fmt.Printf("     Finding:  %s\n", p.Reason)
+			fmt.Printf("     Suggest:  Check logs: kubectl logs %s -n %s --previous\n", p.Name, p.Namespace)
+		}
+		fmt.Println()
+	}
+
+	if len(idle) > 0 {
+		fmt.Println("═══════════════════════════════════════════════════════════")
+		fmt.Printf("🔴 UNMANAGED PODS - no owning controller (%d)\n", len(idle))
+		fmt.Println("═══════════════════════════════════════════════════════════")
+		for _, p := range idle {
+			fmt.Printf("\n  [BARE] %s (namespace: %s)\n", p.Name, p.Namespace)
+			fmt.Printf("     Age:           %d days\n", p.AgeDays)
+			fmt.Printf("     Restarts:      %d (total)\n", p.RestartCount)
+			fmt.Printf("     Finding:       %s\n", p.Reason)
+			fmt.Printf("     Suggest:       Verify with owner: kubectl describe pod %s -n %s\n", p.Name, p.Namespace)
+		}
+		fmt.Println()
+	}
+}
+
+func printOrphanedPVCs(audit *WasteAudit) {
+	if len(audit.OrphanedPVCs) == 0 {
+		return
+	}
+	fmt.Println("═══════════════════════════════════════════════════════════")
+	fmt.Printf("🔴 ORPHANED PVCs - storage waste (%d)\n", len(audit.OrphanedPVCs))
+	fmt.Println("═══════════════════════════════════════════════════════════")
+	for _, pvc := range audit.OrphanedPVCs {
+		sizeStr := "unknown size"
+		if pvc.SizeGB > 0 {
+			sizeStr = fmt.Sprintf("%dGB", pvc.SizeGB)
+		}
+		fmt.Printf("\n  💾 %s (namespace: %s)\n", pvc.Name, pvc.Namespace)
+		fmt.Printf("     Status:  %s\n", pvc.Status)
+		fmt.Printf("     Size:    %s\n", sizeStr)
+		fmt.Printf("     Age:     %d days\n", pvc.AgeDays)
+		fmt.Printf("     Finding: %s\n", pvc.Reason)
+		fmt.Printf("     Suggest: Verify data is backed up before removing.\n")
+		fmt.Printf("              kubectl get pvc %s -n %s -o yaml\n", pvc.Name, pvc.Namespace)
+	}
+	fmt.Println()
+}
+
+func printStaleJobs(audit *WasteAudit) {
+	if len(audit.StaleJobs) == 0 {
+		return
+	}
+	fmt.Println("═══════════════════════════════════════════════════════════")
+	fmt.Printf("🟡 STALE JOBS & CRONJOBS (%d)\n", len(audit.StaleJobs))
+	fmt.Println("═══════════════════════════════════════════════════════════")
+	for _, job := range audit.StaleJobs {
+		kind := "Job"
+		if job.IsCronJob {
+			kind = "CronJob"
+		}
+		fmt.Printf("\n  ⏰ %s [%s] (namespace: %s)\n", job.Name, kind, job.Namespace)
+		fmt.Printf("     Status:  %s\n", job.JobStatus)
+		fmt.Printf("     Age:     %d days\n", job.AgeDays)
+		fmt.Printf("     Finding: %s\n", job.Reason)
+		if job.JobStatus == "Completed" {
+			fmt.Printf("     Suggest: Safe to delete: kubectl delete job %s -n %s\n", job.Name, job.Namespace)
+		} else {
+			fmt.Printf("     Suggest: kubectl describe job %s -n %s\n", job.Name, job.Namespace)
+		}
+	}
+	fmt.Println()
+}
+
+func printZeroReplicaWorkloads(audit *WasteAudit) {
+	if len(audit.ZeroReplicaWorkloads) == 0 {
+		return
+	}
+	fmt.Println("═══════════════════════════════════════════════════════════")
+	fmt.Printf("🟡 ZERO-REPLICA WORKLOADS (%d)\n", len(audit.ZeroReplicaWorkloads))
+	fmt.Println("═══════════════════════════════════════════════════════════")
+	for _, w := range audit.ZeroReplicaWorkloads {
+		fmt.Printf("\n  📦 %s [%s] (namespace: %s)\n", w.Name, w.Kind, w.Namespace)
+		fmt.Printf("     Age:     %d days\n", w.AgeDays)
+		fmt.Printf("     Finding: %s\n", w.Reason)
+		fmt.Printf("     Suggest: kubectl get %s %s -n %s -o yaml\n",
+			strings.ToLower(w.Kind), w.Name, w.Namespace)
+	}
+	fmt.Println()
+}
+
+func printOldReplicaSets(audit *WasteAudit) {
+	if len(audit.OldReplicaSets) == 0 {
+		return
+	}
+	fmt.Println("═══════════════════════════════════════════════════════════")
+	fmt.Printf("🟢 OLD REPLICASETS - rollout leftovers (%d)\n", len(audit.OldReplicaSets))
+	fmt.Println("═══════════════════════════════════════════════════════════")
+	// Show top 10 only - these can be numerous
+	shown := audit.OldReplicaSets
+	remaining := 0
+	if len(shown) > 10 {
+		remaining = len(shown) - 10
+		shown = shown[:10]
+	}
+	for _, rs := range shown {
+		fmt.Printf("  📋 %s (owner: %s, age: %d days)\n", rs.Name, rs.OwnerDeployment, rs.AgeDays)
+	}
+	if remaining > 0 {
+		fmt.Printf("  ... and %d more old ReplicaSets\n", remaining)
+		fmt.Printf("  Suggest: kubectl get rs -A | awk '$3==0 && $4==0'\n")
+	}
+	fmt.Println()
+}
+
+func printOrphanedServices(audit *WasteAudit) {
+	if len(audit.OrphanedServices) == 0 {
+		return
+	}
+	fmt.Println("═══════════════════════════════════════════════════════════")
+	fmt.Printf("🟡 SERVICES WITH NO ENDPOINTS (%d)\n", len(audit.OrphanedServices))
+	fmt.Println("═══════════════════════════════════════════════════════════")
+	for _, svc := range audit.OrphanedServices {
+		lbNote := ""
+		if svc.IsLB {
+			lbNote = " ⚠️  LoadBalancer - incurring cloud cost!"
+		}
+		fmt.Printf("\n  🔌 %s [%s]%s (namespace: %s)\n", svc.Name, svc.Type, lbNote, svc.Namespace)
+		fmt.Printf("     Age:     %d days\n", svc.AgeDays)
+		fmt.Printf("     Finding: %s\n", svc.Reason)
+		fmt.Printf("     Suggest: kubectl get endpoints %s -n %s\n", svc.Name, svc.Namespace)
+	}
+	fmt.Println()
+}
+
+func printBrokenIngresses(audit *WasteAudit) {
+	if len(audit.BrokenIngresses) == 0 {
+		return
+	}
+	fmt.Println("═══════════════════════════════════════════════════════════")
+	fmt.Printf("🟡 INGRESSES WITH MISSING BACKENDS (%d)\n", len(audit.BrokenIngresses))
+	fmt.Println("═══════════════════════════════════════════════════════════")
+	for _, ing := range audit.BrokenIngresses {
+		fmt.Printf("\n  🌐 %s (namespace: %s)\n", ing.Name, ing.Namespace)
+		fmt.Printf("     Hosts:   %s\n", strings.Join(ing.Hosts, ", "))
+		fmt.Printf("     Age:     %d days\n", ing.AgeDays)
+		fmt.Printf("     Finding: %s\n", ing.Reason)
+		fmt.Printf("     Suggest: kubectl describe ingress %s -n %s\n", ing.Name, ing.Namespace)
+	}
+	fmt.Println()
+}
+
+func printMisconfiguredHPAs(audit *WasteAudit) {
+	if len(audit.MisconfiguredHPAs) == 0 {
+		return
+	}
+	fmt.Println("═══════════════════════════════════════════════════════════")
+	fmt.Printf("🟢 MISCONFIGURED HPAs (%d)\n", len(audit.MisconfiguredHPAs))
+	fmt.Println("═══════════════════════════════════════════════════════════")
+	for _, hpa := range audit.MisconfiguredHPAs {
+		fmt.Printf("\n  📈 %s → %s (namespace: %s)\n", hpa.Name, hpa.TargetName, hpa.Namespace)
+		fmt.Printf("     Replicas: min=%d max=%d  Condition: %s\n", hpa.MinReplicas, hpa.MaxReplicas, hpa.Condition)
+		fmt.Printf("     Age:      %d days\n", hpa.AgeDays)
+		fmt.Printf("     Finding:  %s\n", hpa.Reason)
+		fmt.Printf("     Suggest:  kubectl describe hpa %s -n %s\n", hpa.Name, hpa.Namespace)
+	}
+	fmt.Println()
+}
+
+func printWasteSummary(audit *WasteAudit) {
+	fmt.Println("═══════════════════════════════════════════════════════════")
+	fmt.Println("📋 NEXT STEPS")
+	fmt.Println("═══════════════════════════════════════════════════════════")
+	fmt.Println()
+	fmt.Println("  ⚠️  This report shows SUGGESTIONS based on observed data.")
+	fmt.Println("  Always verify with the owning team before removing resources.")
+	fmt.Println()
+
+	if len(audit.StaleJobs) > 0 {
+		// Count only completed jobs (safest to delete)
+		completed := 0
+		for _, j := range audit.StaleJobs {
+			if j.JobStatus == "Completed" {
+				completed++
+			}
+		}
+		if completed > 0 {
+			fmt.Printf("  ✅ SAFE TO DELETE: %d completed Jobs (no data loss risk)\n", completed)
+		}
+	}
+
+	if len(audit.OldReplicaSets) > 0 {
+		fmt.Printf("  ✅ SAFE TO DELETE: %d old ReplicaSets (Kubernetes manages these)\n", len(audit.OldReplicaSets))
+	}
+
+	if len(audit.AbandonedNamespaces) > 0 || len(audit.OrphanedPVCs) > 0 || len(audit.StalePods) > 0 {
+		fmt.Println("  🔍 VERIFY FIRST:   Namespaces, PVCs, and Pods - confirm with owners")
+	}
+
+	fmt.Println()
+	fmt.Println("  💡 Re-run with --min-age-days to adjust the age threshold.")
+	fmt.Println("  💡 Use --namespace to focus on a specific namespace.")
+	fmt.Println()
+}
+
+// ================================================================
+// Helpers
+// ================================================================
+
+// isInfraPattern checks well-known infrastructure namespace prefixes.
+// Reuses the same logic as the network command for consistency.
+func isInfraPattern(name string) bool {
+	infraPatterns := []string{
+		"kube-", "istio-", "calico-", "tigera-", "cert-manager",
+		"ingress-nginx", "flux-system", "argocd", "velero",
+		"longhorn-", "cattle-", "openshift-", "gke-", "azure-",
+		"karpenter", "crossplane-",
+	}
+	for _, pattern := range infraPatterns {
+		if strings.HasPrefix(name, pattern) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Detects 9 resource types:
- Abandoned namespaces (no running pods)
- Zombie pods (CrashLoopBackOff, ImagePullBackOff, OOMKilled)
- Unmanaged pods (no owning controller)
- Orphaned PVCs (unbound, released, bound with no pod)
- Stale Jobs/CronJobs
- Zero-replica Deployments and StatefulSets
- Old ReplicaSets (rollout leftovers)
- Services with no endpoints
- Broken Ingresses
- Misconfigured HPAs