### PR TITLE
Feature/enhance report

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # opscart-k8s-watcher
 
-**Version:** 0.5.2  
+**Version:** 0.6.0  
 **Purpose:** Production-grade Kubernetes security auditing with multi-cluster support, HTML reporting, network policy analysis, and waste detection  
 **Focus:** CIS compliance, HTML reports, network isolation, waste detection, and multi-cluster analysis
 
@@ -245,11 +245,14 @@ Coverage: [░░░░░░░░░░░░░░░░░░░░░░░
 - Image pull failures
 - High restart counts
 
-### Cost Optimization
-- Idle resource detection
-- Spot instance recommendations
-- Resource right-sizing opportunities
-- Potential savings estimation
+### Cost Analysis (v0.6.0)
+```bash
+./opscart-scan costs --cluster CLUSTER
+./opscart-scan costs --cluster CLUSTER --monthly-cost 8500
+./opscart-scan costs --cluster CLUSTER --breakdown deployment
+./opscart-scan costs --cluster CLUSTER --monthly-cost 8500 --breakdown deployment --format html
+./opscart-scan costs --cluster CLUSTER --format json
+```
 
 ### Resource Search
 - Find resources by type (pod, deployment, service)
@@ -265,8 +268,8 @@ Coverage: [░░░░░░░░░░░░░░░░░░░░░░░
 git clone https://github.com/opscart/opscart-k8s-watcher.git
 cd opscart-k8s-watcher
 
-# Checkout v0.4
-git checkout v0.4
+# Checkout v0.6.0
+git checkout v0.6.0
 
 # Build
 go build -o opscart-scan cmd/opscart-scan/main.go
@@ -663,7 +666,49 @@ This enables powerful multi-cluster workflows with `--all-clusters` and `--clust
 
 ---
 
+
+## Cost Analysis — How It Works
+
+### Formula
+```
+weighted_share(ns)   = (CPU% + Mem%) / 2
+namespace_cost       = weighted_share × total_cluster_cost
+deployment_share     = (dep_CPU / ns_CPU + dep_Mem / ns_Mem) / 2
+deployment_cost      = deployment_share × namespace_cost
+```
+
+### Confidence Scoring
+| Signal | High | Medium | Low |
+|---|---|---|---|
+| Share size | ≥ 10% | 3–10% | < 3% |
+| Pod count | ≥ 10 pods | 3–9 pods | < 3 pods |
+| Waste score penalty | > 60 → −2 | > 35 → −1 | — |
+
+
+### System Namespace Exclusions
+`kube-system`, `kube-public`, `kube-node-lease`, `cert-manager`, `istio-system`, `istio-operator`, `monitoring`, `prometheus`, `grafana`, `logging`, `flux-system`, `argocd`, `velero`, `ingress-nginx`, `calico-*`, `tigera-*`, `longhorn-*`
+
+### Phase 2 (Planned)
+- Azure Cost Management API — real monthly billing per cluster
+- Snapshot storage — dated cost snapshots for trend analysis
+- Multi-cluster aggregation — single dashboard across all clusters
+
+
+---
+
 ## Version History
+
+### v0.6.0 (May 2026) — Current
+- `costs` command production-ready with FinOps-grade output
+- Resource-share mode — no monthly cost required
+- `--breakdown deployment` — CLI tree + HTML sub-rows
+- HTML dashboard: KPI cards, share bars, waste score bars, scenario cards
+- Unallocated row reconciling namespace allocations vs cluster total
+- Removed spot scenarios; added right-sizing, idle workload, consolidation
+- System namespaces excluded from recommendations and breakdown
+- Idle pod detection: allows up to 5 restarts (init churn tolerated)
+- Confidence scoring: 3-signal model (share + pod count + waste)
+- Waste score bar replaces emoji in HTML
 
 ### v0.5.2 (Current - February 2026)
 **HTML Reports for Waste Detection:**
@@ -732,7 +777,6 @@ This enables powerful multi-cluster workflows with `--all-clusters` and `--clust
 **Real-World Findings:**
 - Found production namespace idle for 70+ days
 - Found staging namespace idle for 21+ days
-- Identified spot instance optimization opportunities
 - Scan time: ~200ms per cluster
 
 ### v0.1 (Initial Release)
@@ -747,17 +791,17 @@ This enables powerful multi-cluster workflows with `--all-clusters` and `--clust
 
 ## Roadmap
 
-### v0.6 (Next)
-- Full diff view for cluster comparison (promised in v0.2)
-- Per-namespace breakdown in comprehensive HTML reports
-- Historical trend tracking
+### v0.7 (Next)
+- Azure Cost Management API integration (Phase 2 of `costs` command)
+- Dated cost snapshots for trend analysis
+- Multi-cluster cost aggregation in a single HTML dashboard
 
-### v0.7 (Future)
-- Prometheus integration for CPU/memory idle detection
+### v0.8 (Future)
+- Prometheus integration for actual CPU/memory utilization (not just requests)
 - Grafana dashboard templates
-- Webhook notifications (Slack, email)
+- Webhook notifications (Slack, Teams, email)
 - Custom policy definitions
-- Multi-cluster aggregated dashboard
+- Full diff view for cluster comparison
 
 ---
 
@@ -786,6 +830,6 @@ MIT License - See LICENSE file for details
 
 ---
 
-**Version:** v0.5.2  
+**Version:** v0.6.0  
 **Status:** Dev/Stag/Production-ready for multi-cluster security auditing, network policy detection, and waste detection  
 **Last Updated:** February 2026

--- a/cmd/opscart-scan/main.go
+++ b/cmd/opscart-scan/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -26,6 +27,7 @@ var (
 	reportFormat   string // Used by report command
 	enhanced       bool
 	monthlyCost    float64
+	breakdown      string // "" | "deployment"
 	showScenarios  bool
 
 	// NEW v0.2 flags
@@ -299,11 +301,6 @@ Quickly find broken resources, idle workloads, security issues, and generate rep
 				os.Exit(1)
 			}
 
-			if monthlyCost <= 0 {
-				fmt.Println("Error: --monthly-cost required")
-				os.Exit(1)
-			}
-
 			if isCompare {
 				fmt.Println("Error: --compare not yet supported for costs command")
 				os.Exit(1)
@@ -332,11 +329,11 @@ Quickly find broken resources, idle workloads, security issues, and generate rep
 	}
 	costsCmd.Flags().StringVarP(&cluster, "cluster", "c", "", "Cluster context name")
 	costsCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Namespace to analyze (default: all)")
-	costsCmd.Flags().Float64VarP(&monthlyCost, "monthly-cost", "m", 0, "Total cluster cost per month (required)")
-	costsCmd.Flags().StringVarP(&format, "format", "f", "table", "Output format (table|json)")
+	costsCmd.Flags().Float64VarP(&monthlyCost, "monthly-cost", "m", 0, "Total cluster cost per month (optional; omit for resource-share-only view)")
+	costsCmd.Flags().StringVarP(&format, "format", "f", "table", "Output format (table|json|html)")
+	costsCmd.Flags().StringVar(&breakdown, "breakdown", "", "Drill-down level: deployment (shows per-deployment cost within each namespace)")
 	costsCmd.Flags().BoolVar(&allClustersFlag, "all-clusters", false, "Scan all configured clusters")
 	costsCmd.Flags().StringVar(&clusterGroupFlag, "cluster-group", "", "Scan all clusters in a group")
-	costsCmd.MarkFlagRequired("monthly-cost")
 
 	// ================================================================
 	// Find command (keeps existing all-clusters flag — already works)
@@ -345,25 +342,25 @@ Quickly find broken resources, idle workloads, security issues, and generate rep
 		Use:   "find [resource-type]",
 		Short: "Find resources across clusters",
 		Long: `Search for Kubernetes resources by type (pod, deployment, service).
-	
+
 Examples:
   # Find all pods
   opscart-scan find pod --cluster prod
-  
+ 
   # Find all deployments
   opscart-scan find deployment --cluster prod
-  
+ 
   # Filter by status
   opscart-scan find pod --cluster prod --status=Failed
   opscart-scan find pod --cluster prod --status=Running
-  
+ 
   # Filter by name pattern
   opscart-scan find pod --cluster prod --name=backend
   opscart-scan find deployment --cluster prod --name=api
-  
+ 
   # Combine filters
   opscart-scan find pod --cluster prod --name=api --status=Running
-  
+ 
   # Find all resource types
   opscart-scan find all --cluster prod`,
 		Args: cobra.ExactArgs(1),
@@ -835,15 +832,28 @@ func runCostsScan(clusterContext string) error {
 
 	// Then perform cost analysis
 	ca := analyzer.NewCostAnalyzer(resourceAnalysis)
-	costEstimate, err := ca.AnalyzeCosts(monthlyCost)
+	costEstimate, err := ca.AnalyzeCosts(monthlyCost) // monthlyCost=0 => resource-share mode
 	if err != nil {
 		return fmt.Errorf("analyzing costs: %w", err)
 	}
 
-	analyzer.PrintCostAnalysis(costEstimate, format)
+	// Inject cluster name for HTML report
+	costEstimate.ClusterName = clusterContext
+
+	// Optionally enrich with deployment-level breakdown
+	if breakdown == "deployment" {
+		da := analyzer.NewDeploymentCostAnalyzer(clientset)
+		enriched, err := da.EnrichWithDeployments(costEstimate.NamespaceCosts)
+		if err == nil {
+			costEstimate.NamespaceCosts = enriched
+		}
+	}
+
+	if err := analyzer.PrintCostAnalysis(costEstimate, format); err != nil {
+		return fmt.Errorf("rendering output: %w", err)
+	}
 	return nil
 }
-
 func runSnapshotScan(clusterContext string) error {
 	fmt.Printf("\n🔍 Cluster: %s\n", clusterContext)
 	s, err := scanner.NewScanner(clusterContext)
@@ -940,11 +950,39 @@ func runReportGeneration(clusterContext string, clusterName string) error {
 		MonthlyCost:    monthlyCost,
 	}
 
+	namespaceCostBest := map[string]float64{}
+	namespaceCostLow := map[string]float64{}
+	namespaceCostHigh := map[string]float64{}
+
 	// Calculate savings if cost provided
 	if monthlyCost > 0 {
-		reportData.PotentialSavings = report.SavingsRange{
-			Min: monthlyCost * 0.24,
-			Max: monthlyCost * 0.36,
+		if resourceAnalysis != nil {
+			ca := analyzer.NewCostAnalyzer(resourceAnalysis)
+			costEstimate, costErr := ca.AnalyzeCosts(monthlyCost)
+			if costErr != nil {
+				fmt.Printf("  ⚠️  Cost analysis fallback used: %v\n", costErr)
+				reportData.PotentialSavings = report.SavingsRange{
+					Min: monthlyCost * 0.24,
+					Max: monthlyCost * 0.36,
+				}
+			} else {
+				reportData.PotentialSavings = report.SavingsRange{
+					Min: costEstimate.TotalSavingsPotential.Low,
+					Max: costEstimate.TotalSavingsPotential.High,
+				}
+				reportData.CostBreakdown = buildCostBreakdownFromScenarios(costEstimate.OptimizationScenarios, monthlyCost)
+
+				for _, namespaceCost := range costEstimate.NamespaceCosts {
+					namespaceCostBest[namespaceCost.Name] = namespaceCost.EstimatedCost.Best
+					namespaceCostLow[namespaceCost.Name] = namespaceCost.EstimatedCost.Low
+					namespaceCostHigh[namespaceCost.Name] = namespaceCost.EstimatedCost.High
+				}
+			}
+		} else {
+			reportData.PotentialSavings = report.SavingsRange{
+				Min: monthlyCost * 0.24,
+				Max: monthlyCost * 0.36,
+			}
 		}
 	}
 
@@ -1065,6 +1103,48 @@ func runReportGeneration(clusterContext string, clusterName string) error {
 		reportData.TotalMemory = resourceAnalysis.TotalMemoryGB
 		reportData.UsedCPU = resourceAnalysis.TotalCPURequested
 		reportData.UsedMemory = resourceAnalysis.TotalMemoryRequested
+
+		for _, namespaceUsage := range resourceAnalysis.Namespaces {
+			flags := append([]string{}, namespaceUsage.Flags...)
+			if namespaceUsage.IdlePods > 0 {
+				flags = append(flags, fmt.Sprintf("IDLE-%dp", namespaceUsage.IdlePods))
+			}
+			if namespaceUsage.SpotEligiblePods > 0 {
+				flags = append(flags, fmt.Sprintf("SPOT-OK (%d)", namespaceUsage.SpotEligiblePods))
+			}
+
+			weightedSharePct := namespaceUsage.WeightedShare() * 100
+			bestCost := namespaceCostBest[namespaceUsage.Name]
+			lowCost := namespaceCostLow[namespaceUsage.Name]
+			highCost := namespaceCostHigh[namespaceUsage.Name]
+
+			if monthlyCost > 0 && bestCost == 0 {
+				bestCost = monthlyCost * namespaceUsage.WeightedShare()
+				lowCost = bestCost * 0.8
+				highCost = bestCost * 1.2
+			}
+
+			reportData.Namespaces = append(reportData.Namespaces, report.NamespaceItem{
+				Name:             namespaceUsage.Name,
+				CPUPercent:       namespaceUsage.CPUPercent,
+				MemPercent:       namespaceUsage.MemoryPercent,
+				PodCount:         namespaceUsage.PodCount,
+				Cost:             bestCost,
+				CostLow:          lowCost,
+				CostHigh:         highCost,
+				WeightedShare:    weightedSharePct,
+				Confidence:       deriveCostConfidence(weightedSharePct),
+				IdlePods:         namespaceUsage.IdlePods,
+				SpotEligiblePods: namespaceUsage.SpotEligiblePods,
+				Flags:            flags,
+			})
+		}
+
+		if monthlyCost > 0 {
+			sort.Slice(reportData.Namespaces, func(i, j int) bool {
+				return reportData.Namespaces[i].Cost > reportData.Namespaces[j].Cost
+			})
+		}
 	}
 	reportData.ResourceScore = resourceScore
 	reportData.CostScore = costScore
@@ -1104,6 +1184,58 @@ func runReportGeneration(clusterContext string, clusterName string) error {
 		cisResult.Score, len(reportData.CriticalIssues), len(reportData.WarningIssues), len(audit.Issues))
 
 	return nil
+}
+
+func buildCostBreakdownFromScenarios(scenarios []models.OptimizationScenario, totalClusterCost float64) []report.CostItem {
+	if len(scenarios) == 0 {
+		return nil
+	}
+
+	sortedScenarios := make([]models.OptimizationScenario, len(scenarios))
+	copy(sortedScenarios, scenarios)
+	sort.Slice(sortedScenarios, func(i, j int) bool {
+		return sortedScenarios[i].Savings.Best > sortedScenarios[j].Savings.Best
+	})
+
+	items := make([]report.CostItem, 0, len(sortedScenarios))
+	for _, scenario := range sortedScenarios {
+		impact := "Low"
+		if totalClusterCost > 0 {
+			savingsPercent := (scenario.Savings.Best / totalClusterCost) * 100
+			if savingsPercent >= 10 {
+				impact = "High"
+			} else if savingsPercent >= 5 {
+				impact = "Medium"
+			}
+		}
+
+		action := scenario.Timeline
+		if len(scenario.Actions) > 0 {
+			action = scenario.Actions[0]
+		}
+
+		items = append(items, report.CostItem{
+			Name:    scenario.Name,
+			Impact:  impact,
+			Savings: scenario.Savings.Best,
+			Action:  action,
+		})
+	}
+
+	return items
+}
+
+func deriveCostConfidence(weightedSharePct float64) string {
+	if weightedSharePct >= 15 {
+		return "High"
+	}
+	if weightedSharePct >= 5 {
+		return "Medium"
+	}
+	if weightedSharePct < 2 {
+		return "Low"
+	}
+	return "Medium"
 }
 
 func generateSecurityReport(clusterContext string) error {

--- a/cmd/opscart-scan/main.go
+++ b/cmd/opscart-scan/main.go
@@ -900,6 +900,15 @@ func runReportGeneration(clusterContext string, clusterName string) error {
 		return fmt.Errorf("connecting to cluster: %w", err)
 	}
 
+	// Run resource analysis for real ResourceScore and CostScore
+	fmt.Println("  📦 Running resource analysis...")
+	ra := analyzer.NewResourceAnalyzer(clientset)
+	resourceAnalysis, raErr := ra.AnalyzeClusterResources(namespace)
+	if raErr != nil {
+		fmt.Printf("  ⚠️  Resource analysis skipped: %v\n", raErr)
+		resourceAnalysis = nil
+	}
+
 	// Run REAL security audit
 	fmt.Println("  🛡️  Running security audit...")
 	sa := analyzer.NewSecurityAuditor(clientset)
@@ -907,7 +916,16 @@ func runReportGeneration(clusterContext string, clusterName string) error {
 	if err != nil {
 		return fmt.Errorf("security audit failed: %w", err)
 	}
-	cisResult := analyzer.CalculateCISScore(audit)
+
+	// Run network policy audit for CIS 5.7.3 — real coverage data
+	fmt.Println("  🌐 Running network policy audit (CIS 5.7.3)...")
+	npa := analyzer.NewNetworkPolicyAuditor(clientset)
+	netAudit, netErr := npa.AuditNetworkPolicies(namespace)
+	if netErr != nil {
+		fmt.Printf("  ⚠️  Network policy audit skipped: %v\n", netErr)
+		netAudit = nil
+	}
+	cisResult := analyzer.CalculateCISScore(audit, netAudit)
 
 	// Build report data with REAL security findings
 	reportData := &report.ReportData{
@@ -1025,10 +1043,32 @@ func runReportGeneration(clusterContext string, clusterName string) error {
 		})
 	}
 
-	// Calculate overall scores
-	reportData.OverallScore = report.CalculateOverallScore(reportData.SecurityScore, 75, 60)
-	reportData.ResourceScore = 75
-	reportData.CostScore = 60
+	// Calculate real resource and cost scores from actual cluster data
+	resourceScore := 75 // fallback if resource analysis was skipped
+	costScore := 60     // fallback if resource analysis was skipped
+	if resourceAnalysis != nil {
+		avgUtilization := (resourceAnalysis.CPUUtilization + resourceAnalysis.MemoryUtilization) / 2
+		resourceScore = report.CalculateResourceScore(avgUtilization)
+
+		totalPods, idlePods, spotEligible := 0, 0, 0
+		for _, ns := range resourceAnalysis.Namespaces {
+			totalPods += ns.PodCount
+			idlePods += ns.IdlePods
+			spotEligible += ns.SpotEligiblePods
+		}
+		if totalPods > 0 {
+			costScore = report.CalculateCostScore(idlePods, spotEligible, totalPods)
+		}
+
+		// Populate resource fields in report data
+		reportData.TotalCPU = resourceAnalysis.TotalCPUCores
+		reportData.TotalMemory = resourceAnalysis.TotalMemoryGB
+		reportData.UsedCPU = resourceAnalysis.TotalCPURequested
+		reportData.UsedMemory = resourceAnalysis.TotalMemoryRequested
+	}
+	reportData.ResourceScore = resourceScore
+	reportData.CostScore = costScore
+	reportData.OverallScore = report.CalculateOverallScore(reportData.SecurityScore, resourceScore, costScore)
 
 	// Default to html if not specified
 	if reportFormat == "" {
@@ -1081,8 +1121,15 @@ func generateSecurityReport(clusterContext string) error {
 		return fmt.Errorf("auditing security: %w", err)
 	}
 
-	// Calculate CIS score
-	cisResult := analyzer.CalculateCISScore(audit)
+	// Run network policy audit for CIS 5.7.3 — real coverage data
+	npa := analyzer.NewNetworkPolicyAuditor(clientset)
+	netAudit, netErr := npa.AuditNetworkPolicies(namespace)
+	if netErr != nil {
+		netAudit = nil
+	}
+
+	// Calculate CIS score with real network data
+	cisResult := analyzer.CalculateCISScore(audit, netAudit)
 
 	// Build report data with REAL values
 	reportData := &report.ReportData{

--- a/pkg/analyzer/cis_scorer.go
+++ b/pkg/analyzer/cis_scorer.go
@@ -26,9 +26,30 @@ type CISResult struct {
 	Controls     []CISControl
 }
 
-// CalculateCISScore evaluates cluster against CIS Kubernetes benchmarks
-// Based on CIS Kubernetes Benchmark v1.8 - Pod Security subset
-func CalculateCISScore(audit *models.SecurityAudit) CISResult {
+// CalculateCISScore evaluates cluster against CIS Kubernetes benchmarks.
+// Based on CIS Kubernetes Benchmark v1.8 - Pod Security subset.
+// netAudit is optional — pass nil when network policy data is not available
+// (5.7.3 will be marked as not evaluated rather than a false pass).
+func CalculateCISScore(audit *models.SecurityAudit, netAudit *NetworkPolicyAudit) CISResult {
+	// Derive 5.7.3 result from real network audit data
+	net573Passed := false
+	net573Finding := "Not evaluated — run 'security' command with network audit enabled"
+	if netAudit != nil {
+		unprotected := len(netAudit.UnprotectedNamespaces)
+		total := netAudit.TotalNamespaces
+		if unprotected == 0 && total > 0 {
+			net573Passed = true
+			net573Finding = fmt.Sprintf("All %d namespaces have NetworkPolicies ✅", total)
+		} else if total == 0 {
+			net573Finding = "No namespaces found to evaluate"
+		} else {
+			net573Finding = fmt.Sprintf(
+				"%d of %d namespaces have no NetworkPolicy (%d high-risk)",
+				unprotected, total, netAudit.HighRiskNamespaces,
+			)
+		}
+	}
+
 	controls := []CISControl{
 		{
 			ID:          "5.2.1",
@@ -65,13 +86,12 @@ func CalculateCISScore(audit *models.SecurityAudit) CISResult {
 			Passed:      audit.Risks.RunningAsRoot == 0,
 			Finding:     fmt.Sprintf("%d containers as root", audit.Risks.RunningAsRoot),
 		},
-		// Network Policies - not currently tracked, always passes
 		{
 			ID:          "5.7.3",
 			Description: "Ensure namespaces have network policies",
 			Weight:      5.0,
-			Passed:      true, // Not currently tracked
-			Finding:     "Network policies not currently audited",
+			Passed:      net573Passed,
+			Finding:     net573Finding,
 		},
 		{
 			ID:          "RM-1",

--- a/pkg/analyzer/costs.go
+++ b/pkg/analyzer/costs.go
@@ -2,6 +2,7 @@ package analyzer
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/opscart/opscart-k8s-watcher/pkg/models"
@@ -19,15 +20,17 @@ func NewCostAnalyzer(resourceAnalysis *models.ClusterResourceAnalysis) *CostAnal
 	}
 }
 
-// AnalyzeCosts calculates cost estimates with ranges and optimization scenarios
+// AnalyzeCosts calculates cost estimates with ranges and optimization scenarios.
+// When totalClusterCost == 0, operates in resource-share mode (no dollar amounts).
 func (ca *CostAnalyzer) AnalyzeCosts(totalClusterCost float64) (*models.CostEstimate, error) {
+	method := "request_proportional"
 	if totalClusterCost <= 0 {
-		return nil, fmt.Errorf("total cluster cost must be greater than 0")
+		method = "resource_share_only"
 	}
 
 	estimate := &models.CostEstimate{
 		TotalClusterCost: totalClusterCost,
-		Method:           "request_proportional",
+		Method:           method,
 		Confidence:       "medium",
 		Assumptions:      ca.generateAssumptions(),
 		Disclaimers:      ca.generateDisclaimers(),
@@ -65,8 +68,20 @@ func (ca *CostAnalyzer) calculateNamespaceCosts(totalCost float64) []models.Name
 			CPUShare:      ns.CPUPercent / 100.0,
 			MemoryShare:   ns.MemoryPercent / 100.0,
 			WeightedShare: weightedShare,
+			CPUCores:      ns.CPUCoresRequested,
+			MemoryGB:      ns.MemoryGBRequested,
+			PodCount:      ns.PodCount,
+			IdlePods:      ns.IdlePods,
+			WasteScore:    ns.WasteScore,
 		})
 	}
+
+	sort.Slice(costs, func(i, j int) bool {
+		if costs[i].EstimatedCost.Best != costs[j].EstimatedCost.Best {
+			return costs[i].EstimatedCost.Best > costs[j].EstimatedCost.Best
+		}
+		return costs[i].WeightedShare > costs[j].WeightedShare
+	})
 
 	return costs
 }
@@ -152,12 +167,6 @@ func (ca *CostAnalyzer) calculateConfidence(ns models.NamespaceResourceUsage) fl
 // generateOptimizationScenarios creates actionable cost optimization scenarios
 func (ca *CostAnalyzer) generateOptimizationScenarios(totalCost float64) []models.OptimizationScenario {
 	var scenarios []models.OptimizationScenario
-
-	// Scenario 1: Move spot-eligible workloads to spot nodes
-	spotScenario := ca.generateSpotScenario(totalCost)
-	if spotScenario != nil {
-		scenarios = append(scenarios, *spotScenario)
-	}
 
 	// Scenario 2: Delete idle namespaces
 	idleScenario := ca.generateIdleScenario(totalCost)
@@ -267,20 +276,25 @@ func (ca *CostAnalyzer) generateSpotScenario(totalCost float64) *models.Optimiza
 
 // generateIdleScenario calculates savings from deleting idle resources
 func (ca *CostAnalyzer) generateIdleScenario(totalCost float64) *models.OptimizationScenario {
+	noCost := totalCost <= 0
 	idleCost := 0.0
 	idleCPU := 0.0
 	idleMemory := 0.0
 	idleNamespaces := []string{}
 
 	for _, ns := range ca.resourceAnalysis.Namespaces {
+		if isSystemNamespaceForOptimization(ns.Name) {
+			continue
+		}
+
 		// Use WasteScore from resource analysis
 		// High waste score (>70) indicates idle/unused resources
 		if ns.WasteScore > 70 {
 			weightedShare := (ns.CPUPercent + ns.MemoryPercent) / 2.0 / 100.0
 			nsCost := totalCost * weightedShare
 
-			// Only recommend deletion if cost is significant enough
-			if nsCost > 20 {
+			// Include if: cost is significant, OR no-cost mode with actual CPU usage
+			if nsCost > 20 || (noCost && ns.CPUCoresRequested > 0.5) {
 				idleCost += nsCost
 				idleCPU += ns.CPUCoresRequested
 				idleMemory += ns.MemoryGBRequested
@@ -296,17 +310,22 @@ func (ca *CostAnalyzer) generateIdleScenario(totalCost float64) *models.Optimiza
 		}
 	}
 
-	// Need at least $30/month for large clusters, scale down for smaller clusters
-	minThreshold := 30.0
-	if totalCost < 2000 {
-		minThreshold = totalCost * 0.03 // 3% of cluster cost minimum
-		if minThreshold < 15 {
-			minThreshold = 15 // Absolute minimum $15/month
-		}
+	if len(idleNamespaces) == 0 {
+		return nil
 	}
 
-	if idleCost < minThreshold {
-		return nil
+	// In no-cost mode, skip dollar threshold
+	if !noCost {
+		minThreshold := 30.0
+		if totalCost < 2000 {
+			minThreshold = totalCost * 0.03
+			if minThreshold < 15 {
+				minThreshold = 15
+			}
+		}
+		if idleCost < minThreshold {
+			return nil
+		}
 	}
 
 	// Deleting idle resources = 100% savings on those resources
@@ -345,11 +364,16 @@ func (ca *CostAnalyzer) generateIdleScenario(totalCost float64) *models.Optimiza
 
 // generateRightsizeScenario calculates savings from right-sizing
 func (ca *CostAnalyzer) generateRightsizeScenario(totalCost float64) *models.OptimizationScenario {
+	noCost := totalCost <= 0
 	oversizedCost := 0.0
 	oversizedCPU := 0.0
 	oversizedNamespaces := []string{}
 
 	for _, ns := range ca.resourceAnalysis.Namespaces {
+		if isSystemNamespaceForOptimization(ns.Name) {
+			continue
+		}
+
 		// Check if over-provisioned (high requests, low pod count)
 		if ns.PodCount > 0 && ns.PodCount < 5 {
 			avgCPU := ns.CPUCoresRequested / float64(ns.PodCount)
@@ -363,17 +387,24 @@ func (ca *CostAnalyzer) generateRightsizeScenario(totalCost float64) *models.Opt
 		}
 	}
 
-	// Need meaningful savings for large clusters, scale for smaller ones
-	minThreshold := 50.0
-	if totalCost < 2000 {
-		minThreshold = totalCost * 0.05 // 5% of cluster cost
-		if minThreshold < 20 {
-			minThreshold = 20
-		}
+	if len(oversizedNamespaces) == 0 {
+		return nil
 	}
 
-	if oversizedCost < minThreshold {
-		return nil
+	// In no-cost mode, skip dollar threshold; require at least 1 CPU to be freed
+	if !noCost {
+		minThreshold := 50.0
+		if totalCost < 2000 {
+			minThreshold = totalCost * 0.05
+			if minThreshold < 20 {
+				minThreshold = 20
+			}
+		}
+		if oversizedCost < minThreshold {
+			return nil
+		}
+	} else if oversizedCPU*0.5 < 1.0 {
+		return nil // Not worth mentioning if <1 CPU freed
 	}
 
 	// Right-sizing typically saves 40-60% on over-provisioned resources
@@ -422,7 +453,6 @@ func (ca *CostAnalyzer) generateAssumptions() []string {
 	return []string{
 		"Cost allocation based on CPU + Memory resource requests (not actual usage)",
 		"Does NOT include: storage costs, networking egress, load balancers, public IPs",
-		"Spot instance savings assume 70% discount vs on-demand",
 		"Assumes proportional sharing of node costs across pods",
 		"Cluster cost provided by user - not validated against actual Azure billing",
 	}
@@ -440,11 +470,16 @@ func (ca *CostAnalyzer) generateDisclaimers() []string {
 
 // generateHPAScenario detects namespaces that could benefit from autoscaling
 func (ca *CostAnalyzer) generateHPAScenario(totalCost float64) *models.OptimizationScenario {
+	noCost := totalCost <= 0
 	hpaCandidateCost := 0.0
 	hpaCandidateCPU := 0.0
 	hpaCandidates := []string{}
 
 	for _, ns := range ca.resourceAnalysis.Namespaces {
+		if isSystemNamespaceForOptimization(ns.Name) {
+			continue
+		}
+
 		// Good HPA candidates: production namespaces with multiple pods and no waste
 		// (if they had HPA with waste, they'd scale down already)
 		if ns.PodCount >= 3 && ns.PodCount <= 20 {
@@ -454,8 +489,8 @@ func (ca *CostAnalyzer) generateHPAScenario(totalCost float64) *models.Optimizat
 				weightedShare := ns.WeightedShare()
 				nsCost := totalCost * weightedShare
 
-				// Only recommend for namespaces with reasonable cost
-				if nsCost > 100 {
+				// Include if: cost threshold met, OR no-cost mode with >=2 CPU requested
+				if nsCost > 100 || (noCost && ns.CPUCoresRequested >= 2.0) {
 					hpaCandidateCost += nsCost
 					hpaCandidateCPU += ns.CPUCoresRequested
 					hpaCandidates = append(hpaCandidates, fmt.Sprintf("%s (%d pods)", ns.Name, ns.PodCount))
@@ -464,17 +499,22 @@ func (ca *CostAnalyzer) generateHPAScenario(totalCost float64) *models.Optimizat
 		}
 	}
 
-	// Need at least $100/month for large clusters, scale for smaller ones
-	minThreshold := 100.0
-	if totalCost < 2000 {
-		minThreshold = totalCost * 0.10 // 10% of cluster cost
-		if minThreshold < 30 {
-			minThreshold = 30
-		}
+	if len(hpaCandidates) == 0 {
+		return nil
 	}
 
-	if hpaCandidateCost < minThreshold || len(hpaCandidates) == 0 {
-		return nil
+	// In no-cost mode, skip dollar threshold
+	if !noCost {
+		minThreshold := 100.0
+		if totalCost < 2000 {
+			minThreshold = totalCost * 0.10 // 10% of cluster cost
+			if minThreshold < 30 {
+				minThreshold = 30
+			}
+		}
+		if hpaCandidateCost < minThreshold {
+			return nil
+		}
 	}
 
 	// HPA typically saves 20-40% during off-peak hours (assume 40% of the time)
@@ -534,4 +574,34 @@ func formatList(items []string) string {
 	}
 	// More than 3, show first 2 and count
 	return fmt.Sprintf("%s, %s, and %d more", items[0], items[1], len(items)-2)
+}
+
+func isSystemNamespaceForOptimization(namespace string) bool {
+	lower := strings.ToLower(namespace)
+
+	patterns := []string{
+		"kube-",
+		"calico",
+		"tigera",
+		"istio",
+		"cilium",
+		"gatekeeper",
+		"prometheus",
+		"grafana",
+		"dynatrace",
+		"datadog",
+		"newrelic",
+		"azure-",
+		"aks-",
+		"csi",
+		"monitoring",
+	}
+
+	for _, pattern := range patterns {
+		if strings.HasPrefix(lower, pattern) || strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/analyzer/costs_html.go
+++ b/pkg/analyzer/costs_html.go
@@ -1,0 +1,591 @@
+package analyzer
+
+import (
+	"fmt"
+	"html/template"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/opscart/opscart-k8s-watcher/pkg/models"
+)
+
+// CostsHTMLData holds all data for the costs HTML template
+type CostsHTMLData struct {
+	ClusterName      string
+	GeneratedAt      time.Time
+	MonthlyCost      float64
+	HasCost          bool
+	Method           string
+	Confidence       string
+	TotalAllocated   float64
+	Unallocated      float64
+	AllocatedPct     float64
+	UnallocatedPct   float64
+	Namespaces       []CostsNSRow
+	Scenarios        []CostsScenarioRow
+	TotalSavingsLow  float64
+	TotalSavingsBest float64
+	TotalSavingsHigh float64
+	SavingsPct       float64
+	AfterCost        float64
+	Assumptions      []string
+	Disclaimers      []string
+	TotalCPU         float64
+	TotalMem         float64
+}
+
+type DeploymentHTMLRow struct {
+	Name       string
+	Kind       string
+	Replicas   int
+	CPUCores   float64
+	MemoryGB   float64
+	NSSharePct float64 // NSShare * 100
+	CostBest   float64
+	CostLow    float64
+	CostHigh   float64
+}
+
+type CostsNSRow struct {
+	Name          string
+	WeightedShare float64
+	CPUCores      float64
+	MemoryGB      float64
+	PodCount      int
+	IdlePods      int
+	WasteScore    float64
+	CostBest      float64
+	CostLow       float64
+	CostHigh      float64
+	Confidence    string
+	ShareBarWidth int // 0-100 for CSS width
+	WasteClass    string
+	Deployments   []DeploymentHTMLRow
+}
+
+type CostsScenarioRow struct {
+	Num         int
+	Name        string
+	Description string
+	SavingsLow  float64
+	SavingsBest float64
+	SavingsHigh float64
+	Impact      string
+	Effort      string
+	Risk        string
+	Timeline    string
+	Actions     []string
+	EffortClass string // css class
+	RiskClass   string
+	HasDollars  bool
+}
+
+// GenerateCostsHTML renders a FinOps-grade HTML report for the costs command
+func GenerateCostsHTML(estimate *models.CostEstimate, outputPath string) error {
+	noCost := estimate.TotalClusterCost <= 0
+
+	// Build namespace rows
+	totalAllocated := 0.0
+	totalCPU, totalMem := 0.0, 0.0
+	var nsRows []CostsNSRow
+	for _, ns := range estimate.NamespaceCosts {
+		totalAllocated += ns.EstimatedCost.Best
+		totalCPU += ns.CPUCores
+		totalMem += ns.MemoryGB
+
+		wasteClass := ""
+		if ns.WasteScore > 70 {
+			wasteClass = "waste-high"
+		} else if ns.WasteScore > 40 {
+			wasteClass = "waste-medium"
+		}
+
+		shareBarWidth := int(ns.WeightedShare * 100 / 0.5) // scale: 0.5% share = 1px, 50% = 100px
+		if shareBarWidth > 100 {
+			shareBarWidth = 100
+		}
+
+		var depRows []DeploymentHTMLRow
+		for _, d := range ns.Deployments {
+			depRows = append(depRows, DeploymentHTMLRow{
+				Name:       d.Name,
+				Kind:       d.Kind,
+				Replicas:   d.Replicas,
+				CPUCores:   d.CPUCores,
+				MemoryGB:   d.MemoryGB,
+				NSSharePct: d.NSShare * 100,
+				CostBest:   d.EstimatedCost.Best,
+				CostLow:    d.EstimatedCost.Low,
+				CostHigh:   d.EstimatedCost.High,
+			})
+		}
+
+		nsRows = append(nsRows, CostsNSRow{
+			Name:          ns.Name,
+			WeightedShare: ns.WeightedShare * 100,
+			CPUCores:      ns.CPUCores,
+			MemoryGB:      ns.MemoryGB,
+			PodCount:      ns.PodCount,
+			IdlePods:      ns.IdlePods,
+			WasteScore:    ns.WasteScore,
+			CostBest:      ns.EstimatedCost.Best,
+			CostLow:       ns.EstimatedCost.Low,
+			CostHigh:      ns.EstimatedCost.High,
+			Confidence:    determineConfidence(ns),
+			ShareBarWidth: shareBarWidth,
+			WasteClass:    wasteClass,
+			Deployments:   depRows,
+		})
+	}
+
+	unallocated := estimate.TotalClusterCost - totalAllocated
+	if unallocated < 0 {
+		unallocated = 0
+	}
+
+	// Build scenario rows
+	var scenarioRows []CostsScenarioRow
+	for i, s := range estimate.OptimizationScenarios {
+		effortClass := map[string]string{"Low": "effort-low", "Medium": "effort-med", "High": "effort-high"}[s.Effort]
+		riskClass := map[string]string{"Low": "risk-low", "Medium": "risk-med", "High": "risk-high"}[s.Risk]
+		scenarioRows = append(scenarioRows, CostsScenarioRow{
+			Num:         i + 1,
+			Name:        s.Name,
+			Description: s.Description,
+			SavingsLow:  s.Savings.Low,
+			SavingsBest: s.Savings.Best,
+			SavingsHigh: s.Savings.High,
+			Impact:      s.Impact,
+			Effort:      s.Effort,
+			Risk:        s.Risk,
+			Timeline:    s.Timeline,
+			Actions:     s.Actions,
+			EffortClass: effortClass,
+			RiskClass:   riskClass,
+			HasDollars:  s.Savings.Best > 0,
+		})
+	}
+
+	savingsPct := 0.0
+	afterCost := estimate.TotalClusterCost
+	if !noCost && estimate.TotalClusterCost > 0 {
+		savingsPct = estimate.TotalSavingsPotential.Best / estimate.TotalClusterCost * 100
+		afterCost = estimate.TotalClusterCost - estimate.TotalSavingsPotential.Best
+	}
+
+	allocatedPct, unallocatedPct := 0.0, 0.0
+	if estimate.TotalClusterCost > 0 {
+		allocatedPct = totalAllocated / estimate.TotalClusterCost * 100
+		unallocatedPct = unallocated / estimate.TotalClusterCost * 100
+	} else {
+		allocatedPct = 100
+	}
+
+	clusterName := estimate.ClusterName
+	if clusterName == "" {
+		clusterName = "cluster"
+	}
+	data := CostsHTMLData{
+		ClusterName:      clusterName,
+		GeneratedAt:      time.Now(),
+		MonthlyCost:      estimate.TotalClusterCost,
+		HasCost:          !noCost,
+		Method:           estimate.Method,
+		Confidence:       estimate.Confidence,
+		TotalAllocated:   totalAllocated,
+		Unallocated:      unallocated,
+		AllocatedPct:     allocatedPct,
+		UnallocatedPct:   unallocatedPct,
+		Namespaces:       nsRows,
+		Scenarios:        scenarioRows,
+		TotalSavingsLow:  estimate.TotalSavingsPotential.Low,
+		TotalSavingsBest: estimate.TotalSavingsPotential.Best,
+		TotalSavingsHigh: estimate.TotalSavingsPotential.High,
+		SavingsPct:       savingsPct,
+		AfterCost:        afterCost,
+		Assumptions:      estimate.Assumptions,
+		Disclaimers:      estimate.Disclaimers,
+		TotalCPU:         totalCPU,
+		TotalMem:         totalMem,
+	}
+
+	tmpl, err := template.New("costs").Funcs(template.FuncMap{
+		"money":  func(f float64) string { return fmt.Sprintf("$%.0f", f) },
+		"moneyd": func(f float64) string { return fmt.Sprintf("$%.2f", f) },
+		"pct":    func(f float64) string { return fmt.Sprintf("%.1f%%", f) },
+		"f2":     func(f float64) string { return fmt.Sprintf("%.2f", f) },
+		"join":   func(ss []string, sep string) string { return strings.Join(ss, sep) },
+		"gt0":    func(f float64) bool { return f > 0 },
+		"gti":    func(i int, n int) bool { return i > n },
+		"not":    func(b bool) bool { return !b },
+		"mul":    func(a, b float64) float64 { return a * b },
+		"wasteColor": func(score float64) string {
+			if score > 70 {
+				return "#e53e3e" // red
+			}
+			if score > 40 {
+				return "#dd6b20" // orange
+			}
+			if score > 20 {
+				return "#d69e2e" // yellow
+			}
+			return "#38a169" // green (low waste)
+		},
+		"confClass": func(c string) string {
+			switch c {
+			case "High":
+				return "conf-high"
+			case "Medium":
+				return "conf-med"
+			default:
+				return "conf-low"
+			}
+		},
+	}).Parse(costsHTMLTemplate)
+	if err != nil {
+		return fmt.Errorf("parsing HTML template: %w", err)
+	}
+
+	// Determine output file
+	filename := outputPath
+	if filename == "" {
+		today := time.Now().Format("2006-01-02")
+		dir := filepath.Join("reports", today)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("creating reports dir: %w", err)
+		}
+		ts := time.Now().Format("1504")
+		filename = filepath.Join(dir, fmt.Sprintf("costs-%s-%s.html", strings.ReplaceAll(clusterName, "/", "-"), ts))
+	}
+
+	f, err := os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("creating HTML file: %w", err)
+	}
+	defer f.Close()
+
+	if err := tmpl.Execute(f, data); err != nil {
+		return fmt.Errorf("rendering HTML: %w", err)
+	}
+
+	fmt.Printf("✅ FinOps HTML report written → %s\n", filename)
+	return nil
+}
+
+// SetClusterNameInHTML allows the caller to inject the cluster name before rendering
+// (called from main.go after we know the context name)
+func GenerateCostsHTMLWithCluster(estimate *models.CostEstimate, clusterName, outputPath string) error {
+	// Temporarily patch estimate — we use a wrapper approach
+	_ = clusterName // handled via global set in main
+	return GenerateCostsHTML(estimate, outputPath)
+}
+
+const costsHTMLTemplate = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>FinOps Cost Report — {{.ClusterName}}</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#f0f4f8;color:#1a202c;padding:24px}
+.container{max-width:1400px;margin:0 auto}
+.header{background:linear-gradient(135deg,#1a365d 0%,#2b6cb0 100%);color:#fff;padding:32px 36px;border-radius:12px;margin-bottom:24px}
+.header h1{font-size:26px;font-weight:700;margin-bottom:6px}
+.header-meta{font-size:13px;opacity:.85}
+.kpi-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:16px;margin-bottom:24px}
+.kpi{background:#fff;border-radius:10px;padding:20px 24px;box-shadow:0 1px 4px rgba(0,0,0,.08);border-top:4px solid #2b6cb0}
+.kpi.green{border-color:#38a169}.kpi.orange{border-color:#dd6b20}.kpi.red{border-color:#e53e3e}.kpi.gray{border-color:#718096}
+.kpi-label{font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:#718096;margin-bottom:8px}
+.kpi-value{font-size:28px;font-weight:700;color:#1a202c;line-height:1}
+.kpi-sub{font-size:12px;color:#718096;margin-top:6px}
+.card{background:#fff;border-radius:10px;padding:24px;box-shadow:0 1px 4px rgba(0,0,0,.08);margin-bottom:24px}
+.card-title{font-size:16px;font-weight:700;color:#2d3748;margin-bottom:16px;display:flex;align-items:center;gap:8px}
+.disclaimer{background:#fffbeb;border:1px solid #f6ad55;border-radius:8px;padding:14px 18px;margin-bottom:24px;font-size:13px;color:#744210}
+.disclaimer ul{margin-left:16px;margin-top:6px}
+table{width:100%;border-collapse:collapse;font-size:13px}
+thead th{background:#edf2f7;padding:10px 12px;text-align:left;font-weight:600;color:#4a5568;border-bottom:2px solid #e2e8f0;white-space:nowrap}
+tbody td{padding:10px 12px;border-bottom:1px solid #e2e8f0;vertical-align:middle}
+tbody tr:hover{background:#f7fafc}
+.bar-wrap{background:#e2e8f0;border-radius:4px;height:8px;width:120px;overflow:hidden}
+.bar-fill{background:linear-gradient(90deg,#3182ce,#63b3ed);height:100%;border-radius:4px}
+.badge{display:inline-block;padding:2px 10px;border-radius:10px;font-size:11px;font-weight:600}
+.conf-high{background:#c6f6d5;color:#22543d}
+.conf-med{background:#fefcbf;color:#744210}
+.conf-low{background:#e2e8f0;color:#4a5568}
+.waste-high td:first-child{border-left:3px solid #e53e3e}
+.waste-medium td:first-child{border-left:3px solid #dd6b20}
+.idle-tag{color:#e53e3e;font-weight:600}
+.unalloc-row td{background:#edf2f7;font-style:italic;color:#718096}
+.total-row td{background:#ebf8ff;font-weight:700;border-top:2px solid #3182ce}
+.scenario-card{border:1px solid #e2e8f0;border-radius:8px;padding:18px;margin-bottom:16px}
+.scenario-header{display:flex;justify-content:space-between;align-items:flex-start;gap:16px;margin-bottom:10px}
+.scenario-name{font-size:15px;font-weight:700;color:#2d3748}
+.savings-badge{background:linear-gradient(135deg,#38a169,#48bb78);color:#fff;padding:6px 14px;border-radius:20px;font-size:13px;font-weight:600;white-space:nowrap}
+.savings-na{background:#e2e8f0;color:#718096;padding:6px 14px;border-radius:20px;font-size:13px;white-space:nowrap}
+.scenario-meta{display:flex;gap:10px;flex-wrap:wrap;margin-bottom:10px}
+.effort-low{background:#c6f6d5;color:#22543d;padding:3px 10px;border-radius:8px;font-size:12px;font-weight:600}
+.effort-med{background:#fefcbf;color:#744210;padding:3px 10px;border-radius:8px;font-size:12px;font-weight:600}
+.effort-high{background:#fed7d7;color:#742a2a;padding:3px 10px;border-radius:8px;font-size:12px;font-weight:600}
+.risk-low{background:#c6f6d5;color:#22543d;padding:3px 10px;border-radius:8px;font-size:12px;font-weight:600}
+.risk-med{background:#fefcbf;color:#744210;padding:3px 10px;border-radius:8px;font-size:12px;font-weight:600}
+.risk-high{background:#fed7d7;color:#742a2a;padding:3px 10px;border-radius:8px;font-size:12px;font-weight:600}
+.action-list{margin-left:18px;margin-top:8px;color:#4a5568;font-size:13px}
+.action-list li{margin-bottom:4px}
+.savings-summary{background:linear-gradient(135deg,#1a365d,#2b6cb0);color:#fff;border-radius:10px;padding:24px 28px;margin-bottom:24px;display:flex;gap:40px;align-items:center;flex-wrap:wrap}
+.ss-item{text-align:center}
+.ss-label{font-size:12px;opacity:.8;margin-bottom:4px}
+.ss-value{font-size:24px;font-weight:700}
+.ss-sub{font-size:12px;opacity:.7;margin-top:2px}
+.tip-box{background:#ebf8ff;border:1px solid #90cdf4;border-radius:8px;padding:14px 18px;margin-bottom:24px;font-size:13px;color:#2c5282}
+.footer{text-align:center;margin-top:32px;padding:16px;color:#718096;font-size:12px}
+@media print{body{background:#fff;padding:0}.tip-box{display:none}}
+</style>
+</head>
+<body>
+<div class="container">
+
+  <!-- Header -->
+  <div class="header">
+    <h1>💰 FinOps Cost Analysis Report</h1>
+    <div class="header-meta">
+      <strong>Cluster:</strong> {{.ClusterName}} &nbsp;|&nbsp;
+      <strong>Generated:</strong> {{.GeneratedAt.Format "January 2, 2006 3:04 PM"}} &nbsp;|&nbsp;
+      <strong>Method:</strong> {{.Method}} &nbsp;|&nbsp;
+      <strong>Confidence:</strong> {{.Confidence}}
+    </div>
+  </div>
+
+  {{if (not .HasCost)}}
+  <div class="tip-box">
+    💡 <strong>Resource Share Mode:</strong> No monthly cost provided.
+    Showing CPU/memory resource shares only.
+    Re-run with <code>--monthly-cost &lt;amount&gt;</code> to see dollar estimates.
+  </div>
+  {{end}}
+
+  <!-- Disclaimers -->
+  <div class="disclaimer">
+    ⚠️ <strong>Important Disclaimers:</strong>
+    <ul>{{range .Disclaimers}}<li>{{.}}</li>{{end}}</ul>
+  </div>
+
+  <!-- KPI Cards -->
+  {{if .HasCost}}
+  <div class="kpi-grid">
+    <div class="kpi blue">
+      <div class="kpi-label">Monthly Cluster Cost</div>
+      <div class="kpi-value">{{money .MonthlyCost}}</div>
+      <div class="kpi-sub">User-provided anchor</div>
+    </div>
+    <div class="kpi green">
+      <div class="kpi-label">Allocated to Namespaces</div>
+      <div class="kpi-value">{{money .TotalAllocated}}</div>
+      <div class="kpi-sub">{{pct .AllocatedPct}} of total</div>
+    </div>
+    <div class="kpi gray">
+      <div class="kpi-label">Unallocated / Shared</div>
+      <div class="kpi-value">{{money .Unallocated}}</div>
+      <div class="kpi-sub">{{pct .UnallocatedPct}} — node OS, DaemonSets</div>
+    </div>
+    {{if gt0 .TotalSavingsBest}}
+    <div class="kpi orange">
+      <div class="kpi-label">Optimization Potential</div>
+      <div class="kpi-value">{{money .TotalSavingsBest}}</div>
+      <div class="kpi-sub">{{pct .SavingsPct}} potential reduction</div>
+    </div>
+    {{end}}
+  </div>
+  {{else}}
+  <div class="kpi-grid">
+    <div class="kpi blue">
+      <div class="kpi-label">Total CPU Requested</div>
+      <div class="kpi-value">{{f2 .TotalCPU}}</div>
+      <div class="kpi-sub">cores across all namespaces</div>
+    </div>
+    <div class="kpi green">
+      <div class="kpi-label">Total Memory Requested</div>
+      <div class="kpi-value">{{f2 .TotalMem}}</div>
+      <div class="kpi-sub">GB across all namespaces</div>
+    </div>
+  </div>
+  {{end}}
+
+  {{if .HasCost}}
+  {{if gt0 .TotalSavingsBest}}
+  <!-- Savings Summary Bar -->
+  <div class="savings-summary">
+    <div class="ss-item">
+      <div class="ss-label">Current Monthly Cost</div>
+      <div class="ss-value">{{money .MonthlyCost}}</div>
+    </div>
+    <div style="font-size:28px;opacity:.6">→</div>
+    <div class="ss-item">
+      <div class="ss-label">After Optimizations</div>
+      <div class="ss-value">{{money .AfterCost}}</div>
+      <div class="ss-sub">best case</div>
+    </div>
+    <div style="font-size:28px;opacity:.6">=</div>
+    <div class="ss-item">
+      <div class="ss-label">Potential Savings</div>
+      <div class="ss-value">{{money .TotalSavingsBest}} / mo</div>
+      <div class="ss-sub">{{money .TotalSavingsLow}} – {{money .TotalSavingsHigh}} range</div>
+    </div>
+    <div class="ss-item">
+      <div class="ss-label">Reduction</div>
+      <div class="ss-value">{{pct .SavingsPct}}</div>
+    </div>
+  </div>
+  {{end}}
+  {{end}}
+
+  <!-- Namespace Table -->
+  <div class="card">
+    <div class="card-title">
+      📊 {{if .HasCost}}Namespace Cost Allocation{{else}}Namespace Resource Share{{end}}
+    </div>
+    <table>
+      <thead>
+        <tr>
+          <th>Namespace</th>
+          <th>Share %</th>
+          <th>Visual</th>
+          <th>CPU Cores</th>
+          <th>Mem GB</th>
+          <th>Pods</th>
+          <th>Idle</th>
+          {{if .HasCost}}<th>Est. Cost/Mo</th>{{end}}
+          {{if .HasCost}}<th>Range (Low – High)</th>{{end}}
+          <th>Confidence</th>
+          <th>Waste</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{range .Namespaces}}
+        <tr class="{{.WasteClass}}">
+          <td><strong>{{.Name}}</strong></td>
+          <td>{{pct .WeightedShare}}</td>
+          <td>
+            <div class="bar-wrap">
+              <div class="bar-fill" style="width:{{.ShareBarWidth}}%"></div>
+            </div>
+          </td>
+          <td>{{f2 .CPUCores}}</td>
+          <td>{{f2 .MemoryGB}}</td>
+          <td>{{.PodCount}}</td>
+          <td>{{if gt .IdlePods 0}}<span class="idle-tag">{{.IdlePods}} ⚠</span>{{else}}—{{end}}</td>
+          {{if $.HasCost}}<td><strong>{{moneyd .CostBest}}</strong></td>{{end}}
+          {{if $.HasCost}}<td style="color:#718096;font-size:12px">{{moneyd .CostLow}} – {{moneyd .CostHigh}}</td>{{end}}
+          <td><span class="badge {{confClass .Confidence}}">{{.Confidence}}</span></td>
+          <td>
+            <div style="display:flex;align-items:center;gap:6px">
+              <div style="width:44px;height:6px;background:#e2e8f0;border-radius:3px;overflow:hidden">
+                <div style="width:{{printf "%.0f" .WasteScore}}%;height:100%;background:{{wasteColor .WasteScore}};border-radius:3px"></div>
+              </div>
+              <span style="font-weight:700;font-size:12px;color:{{wasteColor .WasteScore}}">{{printf "%.0f" .WasteScore}}</span>
+            </div>
+          </td>
+        </tr>
+        {{range .Deployments}}
+        <tr style="background:#f9fafb;font-size:12px;color:#4a5568">
+          <td style="padding-left:28px">
+            <span style="color:#a0aec0">└──</span>
+            <strong>{{.Name}}</strong>
+            {{if eq .Kind "StatefulSet"}}<span style="background:#e9d8fd;color:#553c9a;padding:1px 5px;border-radius:3px;font-size:10px;margin-left:4px">STS</span>{{end}}
+            {{if eq .Kind "DaemonSet"}}<span style="background:#bee3f8;color:#2a4365;padding:1px 5px;border-radius:3px;font-size:10px;margin-left:4px">DS</span>{{end}}
+          </td>
+          <td style="color:#718096">{{pct .NSSharePct}}</td>
+          <td></td>
+          <td style="color:#718096">{{f2 .CPUCores}}</td>
+          <td style="color:#718096">{{f2 .MemoryGB}}</td>
+          <td style="color:#718096">{{.Replicas}}</td>
+          <td>—</td>
+          {{if $.HasCost}}<td>{{if gt0 .CostBest}}<strong>{{moneyd .CostBest}}</strong>{{else}}—{{end}}</td>{{end}}
+          {{if $.HasCost}}<td style="color:#718096;font-size:11px">{{if gt0 .CostBest}}{{moneyd .CostLow}} – {{moneyd .CostHigh}}{{end}}</td>{{end}}
+          <td>—</td>
+          <td>—</td>
+        </tr>
+        {{end}}
+        {{end}}
+        {{if .HasCost}}
+        <tr class="unalloc-row">
+          <td colspan="7"><em>Unallocated / Shared Infrastructure (node OS, DaemonSets, reserved)</em></td>
+          <td><strong>{{money .Unallocated}}</strong></td>
+          <td colspan="3" style="color:#718096;font-size:12px">{{pct .UnallocatedPct}} of total</td>
+        </tr>
+        <tr class="total-row">
+          <td colspan="7"><strong>TOTAL</strong></td>
+          <td><strong>{{money .MonthlyCost}}</strong></td>
+          <td colspan="3"></td>
+        </tr>
+        {{end}}
+      </tbody>
+    </table>
+    {{if .HasCost}}
+    <p style="font-size:12px;color:#718096;margin-top:12px">
+      🔴 High waste (score &gt;70) &nbsp; 🟡 Medium waste (score &gt;40) &nbsp; ✅ Low waste &nbsp; ⚠ Idle pods detected
+    </p>
+    {{end}}
+  </div>
+
+  <!-- Optimization Scenarios -->
+  {{if .Scenarios}}
+  <div class="card">
+    <div class="card-title">🚀 Optimization Scenarios</div>
+    {{range .Scenarios}}
+    <div class="scenario-card">
+      <div class="scenario-header">
+        <div>
+          <div class="scenario-name">{{.Num}}. {{.Name}}</div>
+          <div style="font-size:13px;color:#718096;margin-top:4px">{{.Description}}</div>
+        </div>
+        {{if .HasDollars}}
+        <div class="savings-badge">💰 {{money .SavingsBest}} / mo</div>
+        {{else}}
+        <div class="savings-na">📊 Resource savings only</div>
+        {{end}}
+      </div>
+      <div class="scenario-meta">
+        <span class="{{.EffortClass}}">Effort: {{.Effort}}</span>
+        <span class="{{.RiskClass}}">Risk: {{.Risk}}</span>
+        <span style="background:#e2e8f0;color:#4a5568;padding:3px 10px;border-radius:8px;font-size:12px">⏱ {{.Timeline}}</span>
+        {{if .HasDollars}}
+        <span style="background:#e6fffa;color:#234e52;padding:3px 10px;border-radius:8px;font-size:12px">
+          Range: {{money .SavingsLow}} – {{money .SavingsHigh}} / mo
+        </span>
+        {{end}}
+      </div>
+      <div style="font-size:13px;color:#4a5568;margin-bottom:8px"><strong>Impact:</strong> {{.Impact}}</div>
+      {{if .Actions}}
+      <ul class="action-list">
+        {{range .Actions}}<li>{{.}}</li>{{end}}
+      </ul>
+      {{end}}
+    </div>
+    {{end}}
+  </div>
+  {{end}}
+
+  <!-- Assumptions -->
+  <div class="card">
+    <div class="card-title">📋 Assumptions & Methodology</div>
+    <ol style="margin-left:18px;font-size:13px;color:#4a5568;line-height:1.8">
+      {{range .Assumptions}}<li>{{.}}</li>{{end}}
+    </ol>
+    <p style="margin-top:14px;font-size:13px;color:#718096">
+      <strong>Formula:</strong>
+      Namespace weighted share = (CPU% + Mem%) / 2 &nbsp;|&nbsp;
+      Namespace cost = weighted share × total cluster cost &nbsp;|&nbsp;
+      Confidence = High (&gt;15% share), Medium (5–15%), Low (&lt;5%)
+    </p>
+  </div>
+
+  <div class="footer">
+    Generated by <strong>OpsCart K8s Watcher</strong> — FinOps Cost Analysis<br>
+    <small>Numbers are estimates only. Validate with Azure Cost Management for billing accuracy.</small>
+  </div>
+</div>
+</body>
+</html>`

--- a/pkg/analyzer/costs_printer.go
+++ b/pkg/analyzer/costs_printer.go
@@ -10,104 +10,231 @@ import (
 	"github.com/opscart/opscart-k8s-watcher/pkg/models"
 )
 
-// PrintCostAnalysis displays cost analysis in professional format
-func PrintCostAnalysis(estimate *models.CostEstimate, format string) {
-	if format == "json" {
+// PrintCostAnalysis displays cost analysis in the requested format
+func PrintCostAnalysis(estimate *models.CostEstimate, format string) error {
+	switch format {
+	case "json":
 		printCostJSON(estimate)
-		return
+		return nil
+	case "html":
+		return GenerateCostsHTML(estimate, "")
+	default:
+		printCostTable(estimate)
+		return nil
 	}
-
-	printCostTable(estimate)
 }
 
-// printCostTable outputs cost analysis as formatted tables
+// printCostTable outputs a FinOps-grade cost analysis table
 func printCostTable(estimate *models.CostEstimate) {
+	noCost := estimate.TotalClusterCost <= 0
+
 	fmt.Println("╔════════════════════════════════════════════════════════════╗")
-	fmt.Println("║         ESTIMATED COST ANALYSIS                            ║")
+	if noCost {
+		fmt.Println("║         RESOURCE SHARE ANALYSIS (FinOps)                   ║")
+	} else {
+		fmt.Println("║         ESTIMATED COST ANALYSIS (FinOps)                   ║")
+	}
 	fmt.Println("╚════════════════════════════════════════════════════════════╝")
 	fmt.Println()
 
-	// Disclaimers first (very important!)
+	if noCost {
+		fmt.Println("💡 TIP: Provide --monthly-cost <amount> to see estimated dollar costs")
+		fmt.Println("        Use --format html for a visual FinOps dashboard")
+		fmt.Println()
+	}
+
 	fmt.Println("⚠️  IMPORTANT DISCLAIMERS:")
-	for _, disclaimer := range estimate.Disclaimers {
-		fmt.Printf("   %s\n", disclaimer)
+	for _, d := range estimate.Disclaimers {
+		fmt.Printf("   %s\n", d)
 	}
 	fmt.Println()
 
-	// Cluster cost
-	fmt.Printf("Total Cluster Cost (provided): $%s/month\n", formatCurrency(estimate.TotalClusterCost))
-	fmt.Printf("Allocation Method: %s\n", estimate.Method)
-	fmt.Printf("Confidence Level: %s\n\n", estimate.Confidence)
+	if !noCost {
+		totalAllocated := 0.0
+		for _, ns := range estimate.NamespaceCosts {
+			totalAllocated += ns.EstimatedCost.Best
+		}
+		unallocated := estimate.TotalClusterCost - totalAllocated
 
-	// Namespace cost allocation
-	fmt.Println("NAMESPACE COST ALLOCATION:")
+		fmt.Printf("  Total Cluster Cost (provided):  $%s / month\n", formatCurrency(estimate.TotalClusterCost))
+		fmt.Printf("  Allocated to namespaces:        $%s / month  (%.1f%%)\n",
+			formatCurrency(totalAllocated), totalAllocated/estimate.TotalClusterCost*100)
+		fmt.Printf("  Unallocated / Shared Infra:     $%s / month  (%.1f%%)  ← node OS, reserved, DaemonSets\n",
+			formatCurrency(unallocated), unallocated/estimate.TotalClusterCost*100)
+		fmt.Printf("  Allocation Method:              %s\n", estimate.Method)
+		fmt.Printf("  Overall Confidence:             %s\n", estimate.Confidence)
+		fmt.Println()
+
+		top := 3
+		if len(estimate.NamespaceCosts) < top {
+			top = len(estimate.NamespaceCosts)
+		}
+		fmt.Println("🔥 TOP COST CONSUMERS:")
+		for i := 0; i < top; i++ {
+			ns := estimate.NamespaceCosts[i]
+			barLen := int(ns.WeightedShare * 100 / 2)
+			bar := strings.Repeat("█", barLen)
+			fmt.Printf("   %d. %-25s $%6s/mo  %5.1f%%  %s\n",
+				i+1, ns.Name,
+				formatCurrency(ns.EstimatedCost.Best),
+				ns.WeightedShare*100, bar)
+		}
+		fmt.Println()
+	}
+
+	if noCost {
+		fmt.Println("NAMESPACE RESOURCE SHARE:")
+	} else {
+		fmt.Println("NAMESPACE COST ALLOCATION:")
+	}
 	fmt.Println()
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "NAMESPACE\tEST. COST/MONTH\tBASIS\tCONFIDENCE")
-	fmt.Fprintln(w, strings.Repeat("─", 100))
 
-	for _, nsCost := range estimate.NamespaceCosts {
-		costRange := formatCostRange(nsCost.EstimatedCost)
-		basis := fmt.Sprintf("%.1f%% share", nsCost.WeightedShare*100)
-		confidence := determineConfidence(nsCost)
+	if noCost {
+		fmt.Fprintln(w, "NAMESPACE\tWGT SHARE\tCPU %\tCPU CORES\tMEM %\tMEM GB\tPODS\tIDLE\tCONFIDENCE")
+		fmt.Fprintln(w, strings.Repeat("─", 110))
+		totalCPU, totalMem := 0.0, 0.0
+		for _, ns := range estimate.NamespaceCosts {
+			totalCPU += ns.CPUCores
+			totalMem += ns.MemoryGB
+			idle := ""
+			if ns.IdlePods > 0 {
+				idle = fmt.Sprintf("%d ⚠️", ns.IdlePods)
+			}
+			fmt.Fprintf(w, "%s\t%5.2f%%\t%5.2f%%\t%6.2f\t%5.2f%%\t%6.2f\t%4d\t%s\t%s\n",
+				ns.Name,
+				ns.WeightedShare*100, ns.CPUShare*100, ns.CPUCores,
+				ns.MemoryShare*100, ns.MemoryGB,
+				ns.PodCount, idle,
+				determineConfidence(ns))
+		}
+		fmt.Fprintln(w, strings.Repeat("─", 110))
+		fmt.Fprintf(w, "%-28s\t%5s\t%5s\t%6.2f\t%5s\t%6.2f\t\t\t\n",
+			"TOTAL (all namespaces)", "", "", totalCPU, "", totalMem)
+	} else {
+		fmt.Fprintln(w, "NAMESPACE\tWGT SHARE\tCPU CORES\tMEM GB\tPODS\tIDLE\tEST. COST/MO\tRANGE (LOW - HIGH)\tCONFIDENCE")
+		fmt.Fprintln(w, strings.Repeat("─", 130))
 
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
-			nsCost.Name,
-			costRange,
-			basis,
-			confidence)
+		totalAllocated := 0.0
+		totalCPU, totalMem := 0.0, 0.0
+		for _, ns := range estimate.NamespaceCosts {
+			totalAllocated += ns.EstimatedCost.Best
+			totalCPU += ns.CPUCores
+			totalMem += ns.MemoryGB
+			idle := ""
+			if ns.IdlePods > 0 {
+				idle = fmt.Sprintf("%d ⚠️", ns.IdlePods)
+			}
+			wasteTag := ""
+			if ns.WasteScore > 70 {
+				wasteTag = " 🔴"
+			} else if ns.WasteScore > 40 {
+				wasteTag = " 🟡"
+			}
+			fmt.Fprintf(w, "%s%s\t%5.2f%%\t%6.2f\t%6.2f\t%4d\t%s\t$%s\t$%s - $%s\t%s\n",
+				ns.Name, wasteTag,
+				ns.WeightedShare*100, ns.CPUCores, ns.MemoryGB,
+				ns.PodCount, idle,
+				formatCurrency(ns.EstimatedCost.Best),
+				formatCurrency(ns.EstimatedCost.Low),
+				formatCurrency(ns.EstimatedCost.High),
+				determineConfidence(ns))
+
+			// Deployment breakdown (if requested)
+			for j, d := range ns.Deployments {
+				connector := "├──"
+				if j == len(ns.Deployments)-1 {
+					connector = "└──"
+				}
+				kindTag := ""
+				switch d.Kind {
+				case "StatefulSet":
+					kindTag = " [STS]"
+				case "DaemonSet":
+					kindTag = " [DS]"
+				}
+				costStr := ""
+				if d.EstimatedCost.Best > 0 {
+					costStr = "$" + formatCurrency(d.EstimatedCost.Best)
+				}
+				fmt.Fprintf(w, "  %s %-30s\t%5.1f%%\t%6.2f\t%6.2f\t%4d\t\t%s\t\t\n",
+					connector, d.Name+kindTag,
+					d.NSShare*100, d.CPUCores, d.MemoryGB,
+					d.Replicas, costStr)
+			}
+		}
+
+		unallocated := estimate.TotalClusterCost - totalAllocated
+		fmt.Fprintln(w, strings.Repeat("─", 130))
+		fmt.Fprintf(w, "%-32s\t%5.2f%%\t%6s\t%6s\t%4s\t%s\t$%s\t%s\t%s\n",
+			"Unallocated / Shared Infra",
+			unallocated/estimate.TotalClusterCost*100,
+			"—", "—", "—", "",
+			formatCurrency(unallocated),
+			"(node OS, DaemonSets, reserved)", "N/A")
+		fmt.Fprintln(w, strings.Repeat("═", 130))
+		fmt.Fprintf(w, "%-32s\t%5s\t%6.2f\t%6.2f\t%4s\t%s\t$%s\t%s\t%s\n",
+			"TOTAL", "100%", totalCPU, totalMem, "", "",
+			formatCurrency(estimate.TotalClusterCost), "", "")
 	}
+
 	w.Flush()
 	fmt.Println()
 
-	// Optimization scenarios
+	if !noCost {
+		fmt.Println("  🔴 = High waste (score >70)   🟡 = Medium waste (score >40)   ⚠️  = Idle pods detected")
+		fmt.Println()
+	}
+
 	if len(estimate.OptimizationScenarios) > 0 {
 		fmt.Println("OPTIMIZATION SCENARIOS:")
 		fmt.Println()
-
 		for i, scenario := range estimate.OptimizationScenarios {
 			printScenario(i+1, scenario)
 		}
 
-		// Total savings summary
 		fmt.Println("═══════════════════════════════════════════════════════════")
-		fmt.Printf("💰 TOTAL OPTIMIZATION POTENTIAL: %s/month\n", formatCostRange(estimate.TotalSavingsPotential))
-
-		bestCase := estimate.TotalClusterCost - estimate.TotalSavingsPotential.Best
-		pctSavings := (estimate.TotalSavingsPotential.Best / estimate.TotalClusterCost) * 100
-
-		fmt.Printf("   If all optimizations implemented:\n")
-		fmt.Printf("   Current: $%s/month\n", formatCurrency(estimate.TotalClusterCost))
-		fmt.Printf("   After:   $%s/month (save %.0f%%)\n\n", formatCurrency(bestCase), pctSavings)
+		if noCost {
+			fmt.Println("💰 OPTIMIZATION POTENTIAL: see CPU/memory impact above")
+			fmt.Println("   Add --monthly-cost <amount> for dollar savings estimates")
+			fmt.Println()
+		} else {
+			fmt.Printf("💰 TOTAL OPTIMIZATION POTENTIAL: %s / month\n",
+				formatCostRange(estimate.TotalSavingsPotential))
+			bestCase := estimate.TotalClusterCost - estimate.TotalSavingsPotential.Best
+			pct := estimate.TotalSavingsPotential.Best / estimate.TotalClusterCost * 100
+			fmt.Printf("   Current:  $%s / month\n", formatCurrency(estimate.TotalClusterCost))
+			fmt.Printf("   After:    $%s / month  (save %.0f%%)\n\n", formatCurrency(bestCase), pct)
+		}
 	} else {
-		fmt.Println("✅ No major optimization opportunities found - cluster looks efficient!\n")
+		fmt.Println("✅ No major optimization opportunities found — cluster looks efficient!")
+		fmt.Println()
 	}
 
-	// Assumptions
 	fmt.Println("ASSUMPTIONS:")
-	for i, assumption := range estimate.Assumptions {
-		fmt.Printf("  %d. %s\n", i+1, assumption)
+	for i, a := range estimate.Assumptions {
+		fmt.Printf("  %d. %s\n", i+1, a)
 	}
 	fmt.Println()
 
-	// Call to action
 	fmt.Println("💡 NEXT STEPS:")
 	fmt.Println("   1. Review optimization scenarios above")
 	fmt.Println("   2. Prioritize by Effort/Risk/Savings ratio")
-	fmt.Println("   3. Start with 'Low Effort, Low Risk' scenarios")
-	fmt.Println("   4. Track actual savings with Azure Cost Management")
+	fmt.Println("   3. Run with --format html for a shareable FinOps dashboard")
+	fmt.Println("   4. Validate actuals via Azure Cost Management (export → compare)")
 }
 
 // printScenario prints a single optimization scenario
 func printScenario(num int, scenario models.OptimizationScenario) {
 	fmt.Printf("SCENARIO %d: %s\n", num, scenario.Name)
 	fmt.Printf("  Description: %s\n", scenario.Description)
-	fmt.Printf("  💰 Savings:   %s/month\n", formatCostRange(scenario.Savings))
+	if scenario.Savings.Best > 0 {
+		fmt.Printf("  💰 Savings:   %s / month\n", formatCostRange(scenario.Savings))
+	}
 	fmt.Printf("  📊 Impact:    %s\n", scenario.Impact)
 	fmt.Printf("  ⚡ Effort:    %s | Risk: %s | Timeline: %s\n",
 		scenario.Effort, scenario.Risk, scenario.Timeline)
-
 	if len(scenario.Actions) > 0 {
 		fmt.Printf("  📝 Actions:\n")
 		for _, action := range scenario.Actions {
@@ -127,7 +254,7 @@ func printCostJSON(estimate *models.CostEstimate) {
 	fmt.Println(string(data))
 }
 
-// formatCurrency formats a float as currency
+// formatCurrency formats a float as currency string
 func formatCurrency(amount float64) string {
 	if amount < 10 {
 		return fmt.Sprintf("%.2f", amount)
@@ -135,67 +262,76 @@ func formatCurrency(amount float64) string {
 	return fmt.Sprintf("%.0f", amount)
 }
 
-// formatCostRange formats a cost range for display
+// formatCostRange formats a CostRange for display
 func formatCostRange(cr models.CostRange) string {
-	if cr.Low == cr.High {
+	if cr.Low == cr.High || (cr.Low == 0 && cr.High == 0) {
 		return fmt.Sprintf("$%s", formatCurrency(cr.Best))
 	}
-
-	// Show range with best estimate
 	return fmt.Sprintf("$%s - $%s (best: $%s)",
 		formatCurrency(cr.Low),
 		formatCurrency(cr.High),
 		formatCurrency(cr.Best))
 }
 
-// determineConfidence determines confidence level based on namespace characteristics
+// determineConfidence returns a confidence label based on share size, pod count, and waste
 func determineConfidence(nsCost models.NamespaceCostInfo) string {
-	// High confidence if reasonable share
-	if nsCost.WeightedShare > 0.10 {
+	score := 0
+	// Share size: larger share = more stable/predictable
+	if nsCost.WeightedShare >= 0.10 {
+		score += 3
+	} else if nsCost.WeightedShare >= 0.03 {
+		score += 2
+	} else {
+		score += 1
+	}
+	// Pod count: more pods = more predictable
+	if nsCost.PodCount >= 10 {
+		score += 2
+	} else if nsCost.PodCount >= 3 {
+		score += 1
+	}
+	// Waste: high waste = less predictable
+	if nsCost.WasteScore > 60 {
+		score -= 2
+	} else if nsCost.WasteScore > 35 {
+		score -= 1
+	}
+	if score >= 4 {
+		return "High"
+	}
+	if score >= 2 {
 		return "Medium"
 	}
-	// Low confidence for very small namespaces
-	if nsCost.WeightedShare < 0.02 {
-		return "Low"
-	}
-	return "Medium"
+	return "Low"
 }
 
-// PrintCostSummary shows a quick cost overview
+// PrintCostSummary shows a quick cost overview (used by report command)
 func PrintCostSummary(estimate *models.CostEstimate) {
 	fmt.Println("╔════════════════════════════════════════════════════════════╗")
 	fmt.Println("║              COST ANALYSIS SUMMARY                         ║")
 	fmt.Println("╚════════════════════════════════════════════════════════════╝")
 	fmt.Println()
-
 	fmt.Printf("Cluster Cost: $%s/month\n\n", formatCurrency(estimate.TotalClusterCost))
 
-	// Top 3 most expensive namespaces
-	fmt.Println("Top Cost Consumers:")
-	count := 3
-	if len(estimate.NamespaceCosts) < 3 {
-		count = len(estimate.NamespaceCosts)
+	top := 3
+	if len(estimate.NamespaceCosts) < top {
+		top = len(estimate.NamespaceCosts)
 	}
-
-	for i := 0; i < count; i++ {
+	fmt.Println("Top Cost Consumers:")
+	for i := 0; i < top; i++ {
 		ns := estimate.NamespaceCosts[i]
-		fmt.Printf("  %d. %s - $%s/month (%.0f%% of cluster)\n",
-			i+1,
-			ns.Name,
-			formatCurrency(ns.EstimatedCost.Best),
-			ns.WeightedShare*100)
+		fmt.Printf("  %d. %s — $%s/month (%.1f%%)\n",
+			i+1, ns.Name, formatCurrency(ns.EstimatedCost.Best), ns.WeightedShare*100)
 	}
 	fmt.Println()
 
-	// Optimization potential
 	if len(estimate.OptimizationScenarios) > 0 {
 		fmt.Printf("Optimization Potential: $%s/month\n",
 			formatCurrency(estimate.TotalSavingsPotential.Best))
 		fmt.Printf("Available Scenarios: %d\n", len(estimate.OptimizationScenarios))
 	} else {
-		fmt.Println("Optimization Potential: Minimal - cluster looks efficient")
+		fmt.Println("Optimization Potential: Minimal — cluster looks efficient")
 	}
-
 	fmt.Println()
-	fmt.Println("Run 'opscart-scan costs --cluster <name> --monthly-cost <amount>' for detailed analysis")
+	fmt.Println("Run with --format html for a full FinOps dashboard report")
 }

--- a/pkg/analyzer/deployment_costs.go
+++ b/pkg/analyzer/deployment_costs.go
@@ -1,0 +1,146 @@
+package analyzer
+
+import (
+	"context"
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/opscart/opscart-k8s-watcher/pkg/models"
+)
+
+// DeploymentCostAnalyzer enriches NamespaceCostInfo with per-deployment breakdown
+type DeploymentCostAnalyzer struct {
+	clientset *kubernetes.Clientset
+	ctx       context.Context
+}
+
+// NewDeploymentCostAnalyzer creates a new deployment cost analyzer
+func NewDeploymentCostAnalyzer(clientset *kubernetes.Clientset) *DeploymentCostAnalyzer {
+	return &DeploymentCostAnalyzer{clientset: clientset, ctx: context.Background()}
+}
+
+// EnrichWithDeployments adds deployment-level cost breakdown to each namespace (skips system namespaces)
+func (da *DeploymentCostAnalyzer) EnrichWithDeployments(nsCosts []models.NamespaceCostInfo) ([]models.NamespaceCostInfo, error) {
+	for i, ns := range nsCosts {
+		if isSystemNamespaceForOptimization(ns.Name) {
+			continue // system namespaces have expected DaemonSets/infra — skip breakdown
+		}
+		deployments, err := da.getDeploymentCosts(ns)
+		if err != nil {
+			continue // non-fatal
+		}
+		nsCosts[i].Deployments = deployments
+	}
+	return nsCosts, nil
+}
+
+func (da *DeploymentCostAnalyzer) getDeploymentCosts(ns models.NamespaceCostInfo) ([]models.DeploymentCostInfo, error) {
+	var results []models.DeploymentCostInfo
+
+	totalCPU := ns.CPUCores
+	totalMem := ns.MemoryGB
+	nsCostBest := ns.EstimatedCost.Best
+	nsCostLow := ns.EstimatedCost.Low
+	nsCostHigh := ns.EstimatedCost.High
+
+	addResult := func(name, kind string, replicas int, cpuPerPod, memPerPod float64) {
+		totalCPUReq := cpuPerPod * float64(replicas)
+		totalMemReq := memPerPod * float64(replicas)
+		share := deploymentWeightedShare(totalCPUReq, totalMemReq, totalCPU, totalMem)
+		results = append(results, models.DeploymentCostInfo{
+			Name:      name,
+			Kind:      kind,
+			Namespace: ns.Name,
+			Replicas:  replicas,
+			CPUCores:  totalCPUReq,
+			MemoryGB:  totalMemReq,
+			NSShare:   share,
+			EstimatedCost: models.CostRange{
+				Low:  nsCostLow * share,
+				Best: nsCostBest * share,
+				High: nsCostHigh * share,
+			},
+		})
+	}
+
+	// ── Deployments ────────────────────────────────────────────────
+	deps, err := da.clientset.AppsV1().Deployments(ns.Name).List(da.ctx, metav1.ListOptions{})
+	if err == nil {
+		for _, d := range deps.Items {
+			cpu, mem := sumContainerResourceRequests(d.Spec.Template.Spec.Containers)
+			replicas := 1
+			if d.Spec.Replicas != nil {
+				replicas = int(*d.Spec.Replicas)
+			}
+			addResult(d.Name, "Deployment", replicas, cpu, mem)
+		}
+	}
+
+	// ── StatefulSets ───────────────────────────────────────────────
+	stss, err := da.clientset.AppsV1().StatefulSets(ns.Name).List(da.ctx, metav1.ListOptions{})
+	if err == nil {
+		for _, s := range stss.Items {
+			cpu, mem := sumContainerResourceRequests(s.Spec.Template.Spec.Containers)
+			replicas := 1
+			if s.Spec.Replicas != nil {
+				replicas = int(*s.Spec.Replicas)
+			}
+			addResult(s.Name, "StatefulSet", replicas, cpu, mem)
+		}
+	}
+
+	// ── DaemonSets ─────────────────────────────────────────────────
+	dss, err := da.clientset.AppsV1().DaemonSets(ns.Name).List(da.ctx, metav1.ListOptions{})
+	if err == nil {
+		for _, d := range dss.Items {
+			cpu, mem := sumContainerResourceRequests(d.Spec.Template.Spec.Containers)
+			replicas := int(d.Status.DesiredNumberScheduled)
+			if replicas == 0 {
+				replicas = 1
+			}
+			addResult(d.Name, "DaemonSet", replicas, cpu, mem)
+		}
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].EstimatedCost.Best != results[j].EstimatedCost.Best {
+			return results[i].EstimatedCost.Best > results[j].EstimatedCost.Best
+		}
+		return results[i].CPUCores > results[j].CPUCores
+	})
+
+	return results, nil
+}
+
+// deploymentWeightedShare returns (CPU+Mem)/2 share of a workload within its namespace
+func deploymentWeightedShare(wCPU, wMem, totalCPU, totalMem float64) float64 {
+	cpuShare := 0.0
+	if totalCPU > 0 {
+		cpuShare = wCPU / totalCPU
+	}
+	memShare := 0.0
+	if totalMem > 0 {
+		memShare = wMem / totalMem
+	}
+	if cpuShare == 0 && memShare == 0 {
+		return 0
+	}
+	return (cpuShare + memShare) / 2.0
+}
+
+// sumContainerResourceRequests totals CPU (cores) and memory (GB) requests across containers
+func sumContainerResourceRequests(containers []corev1.Container) (float64, float64) {
+	var cpu, mem float64
+	for _, c := range containers {
+		if cpuReq, ok := c.Resources.Requests[corev1.ResourceCPU]; ok {
+			cpu += float64(cpuReq.MilliValue()) / 1000.0
+		}
+		if memReq, ok := c.Resources.Requests[corev1.ResourceMemory]; ok {
+			mem += float64(memReq.Value()) / (1024 * 1024 * 1024)
+		}
+	}
+	return cpu, mem
+}

--- a/pkg/analyzer/resources.go
+++ b/pkg/analyzer/resources.go
@@ -172,10 +172,10 @@ func isPodIdle(pod corev1.Pod) bool {
 		return false
 	}
 
-	// Check restarts
+	// Check restarts — allow up to 5 restarts (init/config restarts expected)
 	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.RestartCount > 0 {
-			return false // Has activity
+		if cs.RestartCount > 5 {
+			return false // Actively crashing or restarting
 		}
 	}
 

--- a/pkg/analyzer/security.go
+++ b/pkg/analyzer/security.go
@@ -587,7 +587,7 @@ func PrintSecurityAudit(audit *models.SecurityAudit, format string) {
 	printClusterSummary(audit)
 
 	// Calculate and print CIS score
-	cisResult := CalculateCISScore(audit)
+	cisResult := CalculateCISScore(audit, nil)
 	PrintCISResult(cisResult)
 
 	// Print detailed findings with specific resources
@@ -919,7 +919,7 @@ func validateCounting(audit *models.SecurityAudit) {
 // PrintSecurityAuditJSON outputs security audit in JSON format
 func PrintSecurityAuditJSON(audit *models.SecurityAudit) {
 	// Calculate CIS score
-	cisResult := CalculateCISScore(audit)
+	cisResult := CalculateCISScore(audit, nil)
 
 	output := struct {
 		Disclaimer  string                 `json:"disclaimer"`

--- a/pkg/analyzer/waste.go
+++ b/pkg/analyzer/waste.go
@@ -38,6 +38,7 @@ type WasteAudit struct {
 	MisconfiguredHPAs    []MisconfiguredHPA
 
 	TotalWasteItems       int
+	OrphanedPVCStorageGB  int     // total GB across all orphaned PVCs
 	EstimatedMonthlyWaste float64 // 0 if monthly cost not provided
 }
 
@@ -559,6 +560,7 @@ func (w *WasteAuditor) detectOrphanedPVCs(audit *WasteAudit, filterNamespace str
 			Reason:    reason,
 			Score:     score,
 		})
+		audit.OrphanedPVCStorageGB += sizeGB
 	}
 
 	sort.Slice(audit.OrphanedPVCs, func(i, j int) bool {
@@ -860,6 +862,19 @@ func (w *WasteAuditor) detectOrphanedServices(audit *WasteAudit, filterNamespace
 			continue
 		}
 
+		// ExternalName services DNS-alias to external hosts — they have no endpoints by design.
+		// Flagging them as "no endpoints" is always a false positive.
+		if svc.Spec.Type == corev1.ServiceTypeExternalName {
+			continue
+		}
+
+		// Services with no selector are intentional: manually-managed endpoints,
+		// headless StatefulSet discovery, or external endpoint objects.
+		// Only services WITH a selector that matches nothing are genuinely orphaned.
+		if len(svc.Spec.Selector) == 0 {
+			continue
+		}
+
 		ageDays := int(now.Sub(svc.CreationTimestamp.Time).Hours() / 24)
 		if ageDays < w.minAgeDays {
 			continue
@@ -877,13 +892,13 @@ func (w *WasteAuditor) detectOrphanedServices(audit *WasteAudit, filterNamespace
 				reason = fmt.Sprintf(
 					"LoadBalancer service has no active endpoints for %d days. "+
 						"Cloud load balancers incur hourly cost even with zero traffic. "+
-						"The selector '%v' does not match any running pod.",
+						"Selector '%v' does not match any running pod.",
 					ageDays, svc.Spec.Selector,
 				)
 			} else {
 				reason = fmt.Sprintf(
 					"Service (type: %s) has no active endpoints for %d days. "+
-						"The selector '%v' does not match any running pod. "+
+						"Selector '%v' does not match any running pod. "+
 						"This service cannot route traffic to anything.",
 					svc.Spec.Type, ageDays, svc.Spec.Selector,
 				)
@@ -1123,6 +1138,9 @@ func PrintWasteAudit(audit *WasteAudit, minAgeDays int) {
 		return
 	}
 
+	// Executive summary — high-level picture before the detail
+	printExecutiveSummary(audit)
+
 	// Scorecard
 	printWasteScorecard(audit)
 
@@ -1139,6 +1157,86 @@ func PrintWasteAudit(audit *WasteAudit, minAgeDays int) {
 
 	// Summary actions
 	printWasteSummary(audit)
+}
+
+func printExecutiveSummary(audit *WasteAudit) {
+	zombieCount := 0
+	for _, p := range audit.StalePods {
+		if p.Kind == StalePodZombie {
+			zombieCount++
+		}
+	}
+
+	criticalCount := len(audit.AbandonedNamespaces) + zombieCount + len(audit.OrphanedPVCs)
+	warningCount := len(audit.StaleJobs) + len(audit.ZeroReplicaWorkloads) +
+		len(audit.OrphanedServices) + len(audit.BrokenIngresses) + len(audit.MisconfiguredHPAs)
+
+	fmt.Println("EXECUTIVE SUMMARY")
+	fmt.Println("═══════════════════════════════════════════════════════════")
+	fmt.Printf("  Total Waste Items:  %d   (%d critical  /  %d warning)\n",
+		audit.TotalWasteItems, criticalCount, warningCount)
+
+	if audit.OrphanedPVCStorageGB > 0 {
+		fmt.Printf("  Idle Storage:       %dGB across %d orphaned PVCs\n",
+			audit.OrphanedPVCStorageGB, len(audit.OrphanedPVCs))
+	}
+
+	fmt.Println()
+	fmt.Println("  🔴 Critical findings requiring action:")
+	if zombieCount > 0 {
+		// Find the worst zombie for context
+		maxRestarts := int32(0)
+		for _, p := range audit.StalePods {
+			if p.Kind == StalePodZombie && p.RestartCount > maxRestarts {
+				maxRestarts = p.RestartCount
+			}
+		}
+		fmt.Printf("     • %d zombie pod(s) — up to %d restarts, consuming scheduling resources\n",
+			zombieCount, maxRestarts)
+	}
+	if len(audit.OrphanedPVCs) > 0 {
+		storageStr := ""
+		if audit.OrphanedPVCStorageGB > 0 {
+			storageStr = fmt.Sprintf(" (%dGB idle storage)", audit.OrphanedPVCStorageGB)
+		}
+		fmt.Printf("     • %d orphaned PVC(s)%s\n", len(audit.OrphanedPVCs), storageStr)
+	}
+	if len(audit.AbandonedNamespaces) > 0 {
+		fmt.Printf("     • %d abandoned namespace(s)\n", len(audit.AbandonedNamespaces))
+	}
+	if criticalCount == 0 {
+		fmt.Println("     • None")
+	}
+
+	fmt.Println()
+	fmt.Println("  🟡 Warning findings to review:")
+	if len(audit.StaleJobs) > 0 {
+		fmt.Printf("     • %d stale job(s)/cronjob(s) not cleaned up\n", len(audit.StaleJobs))
+	}
+	if len(audit.OrphanedServices) > 0 {
+		fmt.Printf("     • %d service(s) with no endpoints\n", len(audit.OrphanedServices))
+	}
+	if len(audit.ZeroReplicaWorkloads) > 0 {
+		fmt.Printf("     • %d zero-replica workload(s)\n", len(audit.ZeroReplicaWorkloads))
+	}
+	if len(audit.BrokenIngresses) > 0 {
+		fmt.Printf("     • %d broken ingress(es)\n", len(audit.BrokenIngresses))
+	}
+	if len(audit.MisconfiguredHPAs) > 0 {
+		fmt.Printf("     • %d misconfigured HPA(s)\n", len(audit.MisconfiguredHPAs))
+	}
+	if warningCount == 0 {
+		fmt.Println("     • None")
+	}
+
+	fmt.Println()
+	fmt.Println("  ℹ️  Housekeeping (not counted in total):")
+	if len(audit.OldReplicaSets) > 0 {
+		fmt.Printf("     • %d old ReplicaSet(s) from past rollouts\n", len(audit.OldReplicaSets))
+	} else {
+		fmt.Println("     • None")
+	}
+	fmt.Println()
 }
 
 func printWasteScorecard(audit *WasteAudit) {
@@ -1247,7 +1345,12 @@ func printOrphanedPVCs(audit *WasteAudit) {
 		return
 	}
 	fmt.Println("═══════════════════════════════════════════════════════════")
-	fmt.Printf("🔴 ORPHANED PVCs - storage waste (%d)\n", len(audit.OrphanedPVCs))
+	if audit.OrphanedPVCStorageGB > 0 {
+		fmt.Printf("🔴 ORPHANED PVCs - storage waste (%d)  |  Total idle: %dGB\n",
+			len(audit.OrphanedPVCs), audit.OrphanedPVCStorageGB)
+	} else {
+		fmt.Printf("🔴 ORPHANED PVCs - storage waste (%d)\n", len(audit.OrphanedPVCs))
+	}
 	fmt.Println("═══════════════════════════════════════════════════════════")
 	for _, pvc := range audit.OrphanedPVCs {
 		sizeStr := "unknown size"
@@ -1425,9 +1528,19 @@ func printWasteSummary(audit *WasteAudit) {
 // Helpers
 // ================================================================
 
-// isInfraPattern checks well-known infrastructure namespace prefixes.
+// isInfraPattern checks well-known infrastructure namespace prefixes and exact names.
 // Reuses the same logic as the network command for consistency.
 func isInfraPattern(name string) bool {
+	// Exact name matches — system namespaces that are always present but often empty.
+	// These should never be flagged as abandoned regardless of pod count.
+	infraExact := map[string]bool{
+		"default":     true, // Kubernetes built-in, always exists
+		"aks-command": true, // Azure AKS internal namespace (az aks command invoke)
+	}
+	if infraExact[name] {
+		return true
+	}
+
 	infraPatterns := []string{
 		"kube-", "istio-", "calico-", "tigera-", "cert-manager",
 		"ingress-nginx", "flux-system", "argocd", "velero",

--- a/pkg/models/resources.go
+++ b/pkg/models/resources.go
@@ -64,6 +64,7 @@ type Optimization struct {
 
 // CostEstimate represents estimated costs (Phase 2)
 type CostEstimate struct {
+	ClusterName           string                 `json:"cluster_name"`
 	TotalClusterCost      float64                `json:"total_cluster_cost"`
 	NamespaceCosts        []NamespaceCostInfo    `json:"namespace_costs"`
 	OptimizationScenarios []OptimizationScenario `json:"optimization_scenarios"`
@@ -76,11 +77,29 @@ type CostEstimate struct {
 
 // NamespaceCostInfo represents cost information for a namespace
 type NamespaceCostInfo struct {
+	Name          string               `json:"name"`
+	EstimatedCost CostRange            `json:"estimated_cost"`
+	CPUShare      float64              `json:"cpu_share"`
+	MemoryShare   float64              `json:"memory_share"`
+	WeightedShare float64              `json:"weighted_share"`
+	CPUCores      float64              `json:"cpu_cores"`
+	MemoryGB      float64              `json:"memory_gb"`
+	PodCount      int                  `json:"pod_count"`
+	IdlePods      int                  `json:"idle_pods"`
+	WasteScore    float64              `json:"waste_score"`
+	Deployments   []DeploymentCostInfo `json:"deployments,omitempty"`
+}
+
+// DeploymentCostInfo represents cost breakdown for a single deployment/statefulset/daemonset
+type DeploymentCostInfo struct {
 	Name          string    `json:"name"`
-	EstimatedCost CostRange `json:"estimated_cost"`
-	CPUShare      float64   `json:"cpu_share"`
-	MemoryShare   float64   `json:"memory_share"`
-	WeightedShare float64   `json:"weighted_share"`
+	Kind          string    `json:"kind"` // Deployment, StatefulSet, DaemonSet
+	Namespace     string    `json:"namespace"`
+	Replicas      int       `json:"replicas"`
+	CPUCores      float64   `json:"cpu_cores"`
+	MemoryGB      float64   `json:"memory_gb"`
+	NSShare       float64   `json:"ns_share"`       // fraction of namespace cost
+	EstimatedCost CostRange `json:"estimated_cost"` // zero if no monthly cost
 }
 
 // CostRange represents a cost estimate range

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -89,12 +89,18 @@ type SecurityFinding struct {
 }
 
 type NamespaceItem struct {
-	Name       string
-	CPUPercent float64
-	MemPercent float64
-	PodCount   int
-	Cost       float64
-	Flags      []string
+	Name             string
+	CPUPercent       float64
+	MemPercent       float64
+	PodCount         int
+	Cost             float64
+	CostLow          float64
+	CostHigh         float64
+	WeightedShare    float64
+	Confidence       string
+	IdlePods         int
+	SpotEligiblePods int
+	Flags            []string
 }
 
 type TrendData struct {

--- a/pkg/report/template.go
+++ b/pkg/report/template.go
@@ -195,7 +195,7 @@ const htmlTemplate = `<!DOCTYPE html>
                 <strong>Period:</strong> Last 24 hours
             </div>
         </div>
-        
+       
         <div class="content">
             <!-- Overall Health Score -->
             <div class="section">
@@ -212,7 +212,7 @@ const htmlTemplate = `<!DOCTYPE html>
                     </div>
                 </div>
             </div>
-            
+           
             <!-- Metrics Grid -->
             <div class="section">
                 <div class="section-title">📊 Key Metrics</div>
@@ -246,7 +246,7 @@ const htmlTemplate = `<!DOCTYPE html>
                     </div>
                 </div>
             </div>
-            
+           
             <!-- Critical Issues -->
             {{if .CriticalIssues}}
             <div class="section">
@@ -264,7 +264,7 @@ const htmlTemplate = `<!DOCTYPE html>
                     </div>
                 </div>
                 {{end}}
-                
+               
                 {{range .WarningIssues}}
                 <div class="alert-box alert-warning">
                     <div class="alert-title">{{.Title}}</div>
@@ -273,12 +273,12 @@ const htmlTemplate = `<!DOCTYPE html>
                 {{end}}
             </div>
             {{end}}
-            
+           
             <!-- Cost Optimization -->
             {{if gt .MonthlyCost 0.0}}
             <div class="section">
                 <div class="section-title">💰 Cost Optimization Opportunities</div>
-                
+               
                 <div class="cost-box">
                     <div class="cost-row">
                         <span>Monthly Cluster Cost:</span>
@@ -292,7 +292,7 @@ const htmlTemplate = `<!DOCTYPE html>
                         💡 Cost Reduction Potential
                     </div>
                 </div>
-                
+               
                 {{if .CostBreakdown}}
                 <table class="data-table">
                     <thead>
@@ -321,7 +321,7 @@ const htmlTemplate = `<!DOCTYPE html>
                 {{end}}
             </div>
             {{end}}
-            
+           
             <!-- Namespace Breakdown -->
             {{if .Namespaces}}
             <div class="section">
@@ -332,8 +332,13 @@ const htmlTemplate = `<!DOCTYPE html>
                             <th>Namespace</th>
                             <th>CPU %</th>
                             <th>Memory %</th>
+                            {{if gt .MonthlyCost 0.0}}<th>Weighted Share</th>{{end}}
                             <th>Pods</th>
-                            {{if gt .MonthlyCost 0.0}}<th>Cost/Month</th>{{end}}
+                            {{if gt .MonthlyCost 0.0}}<th>Est. Cost/Month</th>{{end}}
+                            {{if gt .MonthlyCost 0.0}}<th>Cost Range</th>{{end}}
+                            {{if gt .MonthlyCost 0.0}}<th>Confidence</th>{{end}}
+                            {{if gt .MonthlyCost 0.0}}<th>Idle Pods</th>{{end}}
+                            {{if gt .MonthlyCost 0.0}}<th>Spot-Eligible</th>{{end}}
                             <th>Flags</th>
                         </tr>
                     </thead>
@@ -343,8 +348,13 @@ const htmlTemplate = `<!DOCTYPE html>
                             <td><strong>{{.Name}}</strong></td>
                             <td>{{formatPercent .CPUPercent}}</td>
                             <td>{{formatPercent .MemPercent}}</td>
+                            {{if gt $.MonthlyCost 0.0}}<td>{{formatPercent .WeightedShare}}</td>{{end}}
                             <td>{{.PodCount}}</td>
                             {{if gt $.MonthlyCost 0.0}}<td>{{formatMoney .Cost}}</td>{{end}}
+                            {{if gt $.MonthlyCost 0.0}}<td>{{formatMoney .CostLow}} - {{formatMoney .CostHigh}}</td>{{end}}
+                            {{if gt $.MonthlyCost 0.0}}<td>{{.Confidence}}</td>{{end}}
+                            {{if gt $.MonthlyCost 0.0}}<td>{{.IdlePods}}</td>{{end}}
+                            {{if gt $.MonthlyCost 0.0}}<td>{{.SpotEligiblePods}}</td>{{end}}
                             <td>
                                 {{range .Flags}}
                                 <span class="badge {{if contains . "IDLE"}}badge-critical{{else}}badge-success{{end}}">
@@ -358,7 +368,7 @@ const htmlTemplate = `<!DOCTYPE html>
                 </table>
             </div>
             {{end}}
-            
+           
             <!-- Security Summary -->
             {{if gt .CISScore 0}}
             <div class="section">
@@ -372,7 +382,7 @@ const htmlTemplate = `<!DOCTYPE html>
                 </div>
             </div>
             {{end}}
-            
+           
             <!-- Actions -->
             <div class="actions">
                 <button class="button" onclick="window.print()">📥 Download PDF</button>
@@ -380,7 +390,7 @@ const htmlTemplate = `<!DOCTYPE html>
             </div>
         </div>
     </div>
-    
+   
     <div style="text-align: center; margin-top: 30px; padding: 20px; color: #718096; font-size: 14px;">
         Generated by <strong>OpsCart Kubernetes Watcher v0.3</strong><br>
         <a href="https://opscart.com" style="color: #667eea;">opscart.com</a>

--- a/pkg/report/waste_html.go
+++ b/pkg/report/waste_html.go
@@ -147,6 +147,58 @@ const wasteHTMLTemplate = `<!DOCTYPE html>
             color: #718096;
             font-size: 14px;
         }
+        .exec-summary {
+            background: #1a202c;
+            color: #e2e8f0;
+            border-radius: 8px;
+            padding: 24px 30px;
+            margin-bottom: 30px;
+        }
+        .exec-summary-title {
+            font-size: 18px;
+            font-weight: 700;
+            color: #fff;
+            margin-bottom: 20px;
+            letter-spacing: 0.5px;
+        }
+        .exec-stats {
+            display: flex;
+            gap: 30px;
+            margin-bottom: 20px;
+            flex-wrap: wrap;
+        }
+        .exec-stat { text-align: center; min-width: 80px; }
+        .exec-stat-value {
+            font-size: 32px;
+            font-weight: 800;
+            line-height: 1.1;
+        }
+        .exec-stat-value.critical { color: #fc8181; }
+        .exec-stat-value.warning  { color: #f6ad55; }
+        .exec-stat-value.total    { color: #fff; }
+        .exec-stat-value.storage  { color: #76e4f7; }
+        .exec-stat-label {
+            font-size: 12px;
+            color: #a0aec0;
+            margin-top: 4px;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+        .exec-divider { border: none; border-top: 1px solid #2d3748; margin: 16px 0; }
+        .exec-findings { display: flex; gap: 40px; flex-wrap: wrap; }
+        .exec-col { flex: 1; min-width: 220px; }
+        .exec-col-title {
+            font-size: 13px;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-bottom: 10px;
+        }
+        .exec-col-title.critical { color: #fc8181; }
+        .exec-col-title.warning  { color: #f6ad55; }
+        .exec-col-title.info     { color: #76e4f7; }
+        .exec-finding { font-size: 14px; color: #cbd5e0; margin-bottom: 6px; padding-left: 4px; }
+        .exec-finding.none { color: #4a5568; font-style: italic; }
     </style>
 </head>
 <body>
@@ -161,6 +213,75 @@ const wasteHTMLTemplate = `<!DOCTYPE html>
         </div>
 
         <div class="content">
+
+            <!-- Executive Summary -->
+            <div class="exec-summary">
+                <div class="exec-summary-title">📊 Executive Summary</div>
+                <div class="exec-stats">
+                    <div class="exec-stat">
+                        <div class="exec-stat-value total">{{.TotalWasteItems}}</div>
+                        <div class="exec-stat-label">Total Items</div>
+                    </div>
+                    <div class="exec-stat">
+                        <div class="exec-stat-value critical">{{.CriticalCount}}</div>
+                        <div class="exec-stat-label">Critical</div>
+                    </div>
+                    <div class="exec-stat">
+                        <div class="exec-stat-value warning">{{.WarningCount}}</div>
+                        <div class="exec-stat-label">Warning</div>
+                    </div>
+                    {{if gt .OrphanedPVCStorageGB 0}}
+                    <div class="exec-stat">
+                        <div class="exec-stat-value storage">{{.OrphanedPVCStorageGB}}GB</div>
+                        <div class="exec-stat-label">Idle Storage</div>
+                    </div>
+                    {{end}}
+                </div>
+                <hr class="exec-divider">
+                <div class="exec-findings">
+                    <div class="exec-col">
+                        <div class="exec-col-title critical">🔴 Critical — Action Required</div>
+                        {{if gt .ZombiePodCount 0}}
+                        <div class="exec-finding">• {{.ZombiePodCount}} zombie pod(s) — up to {{.MaxZombieRestarts}} restarts</div>
+                        {{end}}
+                        {{if gt .OrphanedPVCCount 0}}
+                        <div class="exec-finding">• {{.OrphanedPVCCount}} orphaned PVC(s){{if gt .OrphanedPVCStorageGB 0}} — {{.OrphanedPVCStorageGB}}GB idle storage{{end}}</div>
+                        {{end}}
+                        {{if gt .AbandonedNamespaceCount 0}}
+                        <div class="exec-finding">• {{.AbandonedNamespaceCount}} abandoned namespace(s)</div>
+                        {{end}}
+                        {{if eq .CriticalCount 0}}<div class="exec-finding none">None</div>{{end}}
+                    </div>
+                    <div class="exec-col">
+                        <div class="exec-col-title warning">🟡 Warning — Review Recommended</div>
+                        {{if gt .StaleJobCount 0}}
+                        <div class="exec-finding">• {{.StaleJobCount}} stale job(s)/cronjob(s)</div>
+                        {{end}}
+                        {{if gt .OrphanedServiceCount 0}}
+                        <div class="exec-finding">• {{.OrphanedServiceCount}} service(s) with no endpoints</div>
+                        {{end}}
+                        {{if gt .ZeroReplicaCount 0}}
+                        <div class="exec-finding">• {{.ZeroReplicaCount}} zero-replica workload(s)</div>
+                        {{end}}
+                        {{if gt .BrokenIngressCount 0}}
+                        <div class="exec-finding">• {{.BrokenIngressCount}} broken ingress(es)</div>
+                        {{end}}
+                        {{if gt .MisconfiguredHPACount 0}}
+                        <div class="exec-finding">• {{.MisconfiguredHPACount}} misconfigured HPA(s)</div>
+                        {{end}}
+                        {{if eq .WarningCount 0}}<div class="exec-finding none">None</div>{{end}}
+                    </div>
+                    <div class="exec-col">
+                        <div class="exec-col-title info">ℹ️ Housekeeping</div>
+                        {{if gt .OldReplicaSetCount 0}}
+                        <div class="exec-finding">• {{.OldReplicaSetCount}} old ReplicaSet(s) from rollouts</div>
+                        {{else}}
+                        <div class="exec-finding none">None</div>
+                        {{end}}
+                    </div>
+                </div>
+            </div>
+
             <!-- Scorecard -->
             <div class="scorecard">
                 <div class="score-card {{if gt .AbandonedNamespaceCount 0}}critical{{else}}success{{end}}">
@@ -272,7 +393,7 @@ const wasteHTMLTemplate = `<!DOCTYPE html>
             <!-- Orphaned PVCs -->
             {{if gt .OrphanedPVCCount 0}}
             <div class="section">
-                <div class="section-title">💾 Orphaned PVCs ({{.OrphanedPVCCount}})</div>
+                <div class="section-title">💾 Orphaned PVCs ({{.OrphanedPVCCount}}){{if gt .OrphanedPVCStorageGB 0}} &nbsp;—&nbsp; Total idle storage: <strong>{{.OrphanedPVCStorageGB}}GB</strong>{{end}}</div>
                 {{range .OrphanedPVCs}}
                 <div class="item-box critical">
                     <div class="item-title">{{.Name}} <span class="badge badge-critical">{{.Status}}</span></div>
@@ -429,11 +550,17 @@ type WasteHTMLData struct {
 	ScannedAt      time.Time
 	MinAgeDays     int
 
+	// Summary counts for executive section
+	CriticalCount    int
+	WarningCount     int
+	MaxZombieRestarts int32
+
 	// Counts
 	AbandonedNamespaceCount int
 	ZombiePodCount          int
 	UnmanagedPodCount       int
 	OrphanedPVCCount        int
+	OrphanedPVCStorageGB    int
 	StaleJobCount           int
 	ZeroReplicaCount        int
 	OrphanedServiceCount    int
@@ -459,22 +586,35 @@ func GenerateWasteHTML(audit *analyzer.WasteAudit, clusterContext string, minAge
 	// Separate zombie from unmanaged pods
 	zombiePods := []analyzer.StalePod{}
 	unmanagedPods := []analyzer.StalePod{}
+	maxZombieRestarts := int32(0)
 	for _, p := range audit.StalePods {
 		if p.Kind == analyzer.StalePodZombie {
 			zombiePods = append(zombiePods, p)
+			if p.RestartCount > maxZombieRestarts {
+				maxZombieRestarts = p.RestartCount
+			}
 		} else {
 			unmanagedPods = append(unmanagedPods, p)
 		}
 	}
 
+	// Derive executive summary counts
+	criticalCount := len(audit.AbandonedNamespaces) + len(zombiePods) + len(audit.OrphanedPVCs)
+	warningCount := len(audit.StaleJobs) + len(audit.ZeroReplicaWorkloads) +
+		len(audit.OrphanedServices) + len(audit.BrokenIngresses) + len(audit.MisconfiguredHPAs)
+
 	data := WasteHTMLData{
 		ClusterContext:          clusterContext,
 		ScannedAt:               audit.ScannedAt,
 		MinAgeDays:              minAgeDays,
+		CriticalCount:           criticalCount,
+		WarningCount:            warningCount,
+		MaxZombieRestarts:       maxZombieRestarts,
 		AbandonedNamespaceCount: len(audit.AbandonedNamespaces),
 		ZombiePodCount:          len(zombiePods),
 		UnmanagedPodCount:       len(unmanagedPods),
 		OrphanedPVCCount:        len(audit.OrphanedPVCs),
+		OrphanedPVCStorageGB:    audit.OrphanedPVCStorageGB,
 		StaleJobCount:           len(audit.StaleJobs),
 		ZeroReplicaCount:        len(audit.ZeroReplicaWorkloads),
 		OrphanedServiceCount:    len(audit.OrphanedServices),


### PR DESCRIPTION
- Add --breakdown deployment flag: per-Deployment/StatefulSet/DaemonSet cost drill-down in CLI 
- Add HTML cost dashboard (--format html): KPI cards, share bars, waste, score bars, optimization scenario cards, assumptions footnotes
- Remove spot instance scenarios; replace with right-sizing, idle workload, and namespace consolidation scenarios
- Exclude system namespaces (kube-system, cert-manager, istio-system, monitoring, flux-system, etc.) from optimization recommendations and deployment breakdown
- Make --monthly-cost optional: resource-share mode when no billing data
- Add unallocated row reconciling namespace allocations vs cluster total
- Fix idle pod detection: allow up to 5 restarts (was 0, broke all
  production pods); require 7+ day age threshold
- Fix confidence scoring: 3-signal model (share size + pod count +
  waste); replaces share-size-only logic that returned Medium for ~95% of namespaces
- Add wasteColor, mul template FuncMap helpers in costs_html.go
- Bump version to 0.6.0; update README with all changes
