### PR TITLE
Waste & Drift page - zombie pods, orphaned PVCs, zero-replica

### DIFF
--- a/cmd/opscart-dashboard/main.go
+++ b/cmd/opscart-dashboard/main.go
@@ -282,7 +282,7 @@ func runDashboard(_ *cobra.Command, _ []string) error {
 	mux.HandleFunc("/namespaces", srv.handleNamespacesPage)
 	mux.HandleFunc("/optimizations", srv.handleOptimizationsPage)
 	mux.HandleFunc("/healthz", handleHealth)
-	mux.HandleFunc("/incidents", srv.handleStubPage("incidents", "Incidents"))
+	mux.HandleFunc("/incidents", srv.handleIncidentsPage)
 	mux.HandleFunc("/security", srv.handleStubPage("security", "Security Posture"))
 	mux.HandleFunc("/waste", srv.handleStubPage("waste", "Waste & Drift"))
 	mux.HandleFunc("/settings", srv.handleStubPage("settings", "Settings"))
@@ -1575,6 +1575,144 @@ func renderWarRoomCard(issue warRoomIssue) string {
 	sb.WriteString(`</div>`)
 	return sb.String()
 }
+
+// ── Incidents page ───────────────────────────────────────────────────────────
+
+type incidentsPageData struct {
+	// Sidebar fields (used by {{template "sidebar.html" .}})
+	DashHref      string
+	WrHref        string
+	CostsHref     string
+	InfraHref     string
+	WasteHref     string
+	SecurityHref  string
+	IncidentsHref string
+	ActivePage    string
+	ClusterName   string
+	Clusters      []sidebarCluster
+	CriticalCount int
+	// Page content
+	StatusDesc    string
+	DashURL       string
+	CritChipClass string
+	WarnChipClass string
+	Critical      []warRoomIssue
+	Warnings      []warRoomIssue
+	ScannedAtMs   int64
+}
+
+func (srv *server) handleIncidentsPage(w http.ResponseWriter, r *http.Request) {
+	ctx := srv.activeCtx(r)
+	state := srv.getState(ctx)
+
+	state.mu.RLock()
+	scan := state.scan
+	state.mu.RUnlock()
+
+	if scan == nil {
+		if err := state.refresh(srv.clusterList); err != nil {
+			http.Error(w, "scan failed: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		state.mu.RLock()
+		scan = state.scan
+		state.mu.RUnlock()
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprint(w, renderIncidentsPage(scan, ctx, srv.clusterList))
+}
+
+func renderIncidentsPage(scan *clusterScan, activeCtx string, clusterList []string) string {
+	allIssues := collectWarRoomIssues(scan, 0)
+	var critical, warnings []warRoomIssue
+	for _, issue := range allIssues {
+		if issue.Severity == "critical" {
+			critical = append(critical, issue)
+		} else {
+			warnings = append(warnings, issue)
+		}
+	}
+
+	scannedAt := time.Now()
+	clusterName := displayName(activeCtx)
+	if scan != nil && scan.report != nil {
+		scannedAt = scan.report.Timestamp
+		clusterName = scan.report.ClusterName
+	}
+
+	q := ""
+	if activeCtx != "" {
+		q = "?cluster=" + url.QueryEscape(activeCtx)
+	}
+
+	var clusters []sidebarCluster
+	if len(clusterList) > 1 {
+		for _, ctx := range clusterList {
+			label := displayName(ctx)
+			if len(label) > 22 {
+				label = label[:21] + "…"
+			}
+			clusters = append(clusters, sidebarCluster{
+				Href:     "/incidents?" + url.Values{"cluster": {ctx}}.Encode(),
+				Label:    label,
+				IsActive: ctx == activeCtx,
+			})
+		}
+	}
+
+	critChipClass := "ok"
+	if len(critical) > 0 {
+		critChipClass = "c"
+	}
+	warnChipClass := "ok"
+	if len(warnings) > 0 {
+		warnChipClass = "w"
+	}
+
+	data := incidentsPageData{
+		DashHref:      "/" + q,
+		WrHref:        "/warroom" + q,
+		CostsHref:     "/costs" + q,
+		InfraHref:     "/infrastructure" + q,
+		WasteHref:     "/waste" + q,
+		SecurityHref:  "/security" + q,
+		IncidentsHref: "/incidents" + q,
+		ActivePage:    "incidents",
+		ClusterName:   clusterName,
+		Clusters:      clusters,
+		CriticalCount: len(critical),
+		StatusDesc:    fmt.Sprintf("%d issue(s) detected", len(critical)+len(warnings)),
+		DashURL:       "/" + q,
+		CritChipClass: critChipClass,
+		WarnChipClass: warnChipClass,
+		Critical:      critical,
+		Warnings:      warnings,
+		ScannedAtMs:   scannedAt.UnixMilli(),
+	}
+
+	var buf strings.Builder
+	if err := getIncidentsTmpl().Execute(&buf, data); err != nil {
+		log.Printf("incidents template: %v", err)
+		return ""
+	}
+	return buf.String()
+}
+
+var getIncidentsTmpl = sync.OnceValue(func() *template.Template {
+	return template.Must(
+		template.New("incidents.html").
+			Funcs(template.FuncMap{
+				"renderCard": func(issue warRoomIssue) template.HTML {
+					return template.HTML(renderWarRoomCard(issue))
+				},
+			}).
+			ParseFS(templateFS,
+				"templates/base.html",
+				"templates/sidebar.html",
+				"templates/incidents.html"),
+	)
+})
 
 // ── HTML rendering pipeline ───────────────────────────────────────────────────
 

--- a/cmd/opscart-dashboard/main.go
+++ b/cmd/opscart-dashboard/main.go
@@ -283,7 +283,7 @@ func runDashboard(_ *cobra.Command, _ []string) error {
 	mux.HandleFunc("/optimizations", srv.handleOptimizationsPage)
 	mux.HandleFunc("/healthz", handleHealth)
 	mux.HandleFunc("/incidents", srv.handleIncidentsPage)
-	mux.HandleFunc("/security", srv.handleStubPage("security", "Security Posture"))
+	mux.HandleFunc("/security", srv.handleSecurityPage)
 	mux.HandleFunc("/waste", srv.handleStubPage("waste", "Waste & Drift"))
 	mux.HandleFunc("/settings", srv.handleStubPage("settings", "Settings"))
 	addr := ":" + port
@@ -1574,6 +1574,140 @@ func renderWarRoomCard(issue warRoomIssue) string {
 	sb.WriteString(`</div>`)
 	sb.WriteString(`</div>`)
 	return sb.String()
+}
+
+// ── Security Posture page ─────────────────────────────────────────────────────
+
+type securityPageData struct {
+	DashHref      string
+	WrHref        string
+	CostsHref     string
+	InfraHref     string
+	WasteHref     string
+	SecurityHref  string
+	IncidentsHref string
+	ActivePage    string
+	ClusterName   string
+	CriticalCount int
+	Clusters      []sidebarCluster
+
+	CISScore      int
+	CISScoreColor string
+	TotalChecks   int
+	PassedChecks  int
+	FailedChecks  int
+	Controls      []analyzer.CISControl
+	Risks         models.SecurityRisks
+	HasRisks      bool
+	TotalPods     int
+	PriorityActions []string
+	ScannedAtMs   int64
+}
+
+var getSecurityTmpl = sync.OnceValue(func() *template.Template {
+	return template.Must(
+		template.New("security.html").
+			Funcs(template.FuncMap{
+				"add": func(a, b int) int { return a + b },
+			}).
+			ParseFS(templateFS,
+				"templates/base.html",
+				"templates/sidebar.html",
+				"templates/security.html"),
+	)
+})
+
+func (srv *server) handleSecurityPage(w http.ResponseWriter, r *http.Request) {
+	ctx := srv.activeCtx(r)
+	state := srv.getState(ctx)
+	state.mu.RLock()
+	scan := state.scan
+	state.mu.RUnlock()
+
+	if scan == nil {
+		if err := state.refresh(srv.clusterList); err != nil {
+			http.Error(w, "scan failed: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		state.mu.RLock()
+		scan = state.scan
+		state.mu.RUnlock()
+	}
+
+	q := "?cluster=" + url.QueryEscape(ctx)
+
+	var clusters []sidebarCluster
+	if len(srv.clusterList) > 1 {
+		for _, c := range srv.clusterList {
+			label := displayName(c)
+			if len(label) > 22 {
+				label = label[:21] + "…"
+			}
+			clusters = append(clusters, sidebarCluster{
+				Href:     "/security?" + url.Values{"cluster": {c}}.Encode(),
+				Label:    label,
+				IsActive: c == ctx,
+			})
+		}
+	}
+
+	data := securityPageData{
+		DashHref:      "/" + q,
+		WrHref:        "/warroom" + q,
+		CostsHref:     "/costs" + q,
+		InfraHref:     "/infrastructure" + q,
+		WasteHref:     "/waste" + q,
+		SecurityHref:  "/security" + q,
+		IncidentsHref: "/incidents" + q,
+		ActivePage:    "security",
+		ClusterName:   displayName(ctx),
+		CriticalCount: countCriticalIssues(scan),
+		Clusters:      clusters,
+		ScannedAtMs:   time.Now().UnixMilli(),
+	}
+
+	if scan.cisResult != nil {
+		data.CISScore = scan.cisResult.Score
+		data.TotalChecks = scan.cisResult.TotalChecks
+		data.PassedChecks = scan.cisResult.PassedChecks
+		data.FailedChecks = scan.cisResult.FailedChecks
+		data.Controls = make([]analyzer.CISControl, len(scan.cisResult.Controls))
+		copy(data.Controls, scan.cisResult.Controls)
+		sort.SliceStable(data.Controls, func(i, j int) bool {
+			return !data.Controls[i].Passed && data.Controls[j].Passed
+		})
+	}
+	if scan.secAudit != nil {
+		data.Risks = scan.secAudit.Risks
+		data.TotalPods = scan.secAudit.TotalPodsAudited
+		data.PriorityActions = scan.secAudit.PriorityActions
+		r := scan.secAudit.Risks
+		data.HasRisks = r.RunningAsRoot > 0 || r.PrivilegedContainers > 0 ||
+			r.HostNetwork > 0 || r.HostPID > 0 || r.HostIPC > 0 ||
+			r.HostPathVolumes > 0 || r.DefaultServiceAccount > 0 ||
+			r.MissingResourceLimits > 0 || r.MissingProbes > 0 ||
+			r.AddedCapabilities > 0 || r.PrivilegeEscalation > 0 ||
+			r.WritableFilesystem > 0 || r.MissingNetworkPolicies > 0
+	}
+
+	switch {
+	case data.CISScore >= 70:
+		data.CISScoreColor = "green"
+	case data.CISScore >= 40:
+		data.CISScoreColor = "orange"
+	default:
+		data.CISScoreColor = "red"
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+	var buf strings.Builder
+	if err := getSecurityTmpl().Execute(&buf, data); err != nil {
+		log.Printf("security template: %v", err)
+		http.Error(w, "template error", http.StatusInternalServerError)
+		return
+	}
+	w.Write([]byte(buf.String()))
 }
 
 // ── Incidents page ───────────────────────────────────────────────────────────

--- a/cmd/opscart-dashboard/main.go
+++ b/cmd/opscart-dashboard/main.go
@@ -284,7 +284,7 @@ func runDashboard(_ *cobra.Command, _ []string) error {
 	mux.HandleFunc("/healthz", handleHealth)
 	mux.HandleFunc("/incidents", srv.handleIncidentsPage)
 	mux.HandleFunc("/security", srv.handleSecurityPage)
-	mux.HandleFunc("/waste", srv.handleStubPage("waste", "Waste & Drift"))
+	mux.HandleFunc("/waste", srv.handleWastePage)
 	mux.HandleFunc("/settings", srv.handleStubPage("settings", "Settings"))
 	addr := ":" + port
 	log.Printf("Dashboard ready at http://localhost%s", addr)
@@ -1847,6 +1847,121 @@ var getIncidentsTmpl = sync.OnceValue(func() *template.Template {
 				"templates/incidents.html"),
 	)
 })
+
+// ── Waste & Drift page ────────────────────────────────────────────────────────
+
+type wastePageData struct {
+	DashHref      string
+	WrHref        string
+	CostsHref     string
+	InfraHref     string
+	WasteHref     string
+	SecurityHref  string
+	IncidentsHref string
+	ActivePage    string
+	ClusterName   string
+	CriticalCount int
+	Clusters      []sidebarCluster
+
+	TotalWasteItems      int
+	OrphanedPVCStorageGB int
+	EstimatedMonthly     float64
+	ZombieCount          int
+	StalePods            []analyzer.StalePod
+	OrphanedPVCs         []analyzer.OrphanedPVC
+	ZeroReplicaWorkloads []analyzer.ZeroReplicaWorkload
+	AbandonedNamespaces  []analyzer.AbandonedNamespace
+	StaleJobs            []analyzer.StaleJob
+	ScannedAtMs          int64
+}
+
+var getWasteTmpl = sync.OnceValue(func() *template.Template {
+	return template.Must(
+		template.New("waste.html").
+			ParseFS(templateFS,
+				"templates/base.html",
+				"templates/sidebar.html",
+				"templates/waste.html"),
+	)
+})
+
+func (srv *server) handleWastePage(w http.ResponseWriter, r *http.Request) {
+	ctx := srv.activeCtx(r)
+	state := srv.getState(ctx)
+	state.mu.RLock()
+	scan := state.scan
+	state.mu.RUnlock()
+
+	if scan == nil {
+		if err := state.refresh(srv.clusterList); err != nil {
+			http.Error(w, "scan failed: "+err.Error(), 500)
+			return
+		}
+		state.mu.RLock()
+		scan = state.scan
+		state.mu.RUnlock()
+	}
+
+	q := "?cluster=" + url.QueryEscape(ctx)
+
+	var clusters []sidebarCluster
+	if len(srv.clusterList) > 1 {
+		for _, c := range srv.clusterList {
+			label := displayName(c)
+			if len(label) > 22 {
+				label = label[:21] + "…"
+			}
+			clusters = append(clusters, sidebarCluster{
+				Href:     "/waste?" + url.Values{"cluster": {c}}.Encode(),
+				Label:    label,
+				IsActive: c == ctx,
+			})
+		}
+	}
+
+	data := wastePageData{
+		DashHref:      "/" + q,
+		WrHref:        "/warroom" + q,
+		CostsHref:     "/costs" + q,
+		InfraHref:     "/infrastructure" + q,
+		WasteHref:     "/waste" + q,
+		SecurityHref:  "/security" + q,
+		IncidentsHref: "/incidents" + q,
+		ActivePage:    "waste",
+		ClusterName:   displayName(ctx),
+		CriticalCount: countCriticalIssues(scan),
+		Clusters:      clusters,
+		ScannedAtMs:   time.Now().UnixMilli(),
+	}
+
+	if scan.wasteAudit != nil {
+		wa := scan.wasteAudit
+		data.TotalWasteItems = wa.TotalWasteItems
+		data.OrphanedPVCStorageGB = wa.OrphanedPVCStorageGB
+		data.EstimatedMonthly = wa.EstimatedMonthlyWaste
+		data.OrphanedPVCs = wa.OrphanedPVCs
+		data.ZeroReplicaWorkloads = wa.ZeroReplicaWorkloads
+		data.AbandonedNamespaces = wa.AbandonedNamespaces
+		data.StaleJobs = wa.StaleJobs
+
+		for _, p := range wa.StalePods {
+			if p.Kind == analyzer.StalePodZombie {
+				data.StalePods = append(data.StalePods, p)
+				data.ZombieCount++
+			}
+		}
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+	var buf strings.Builder
+	if err := getWasteTmpl().Execute(&buf, data); err != nil {
+		log.Printf("waste template: %v", err)
+		http.Error(w, "template error", 500)
+		return
+	}
+	w.Write([]byte(buf.String()))
+}
 
 // ── HTML rendering pipeline ───────────────────────────────────────────────────
 

--- a/cmd/opscart-dashboard/templates/incidents.html
+++ b/cmd/opscart-dashboard/templates/incidents.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>Incidents — {{.ClusterName}}</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+{{template "base" .}}
+<style>
+.summary-bar{display:flex;gap:1rem;margin-bottom:2rem;flex-wrap:wrap}
+.summary-chip{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);padding:0.75rem 1.25rem;display:flex;align-items:center;gap:0.75rem;min-width:160px}
+.summary-chip.c{border-color:rgba(239,68,68,0.35)}
+.summary-chip.w{border-color:rgba(245,158,11,0.35)}
+.summary-chip.ok{border-color:rgba(16,185,129,0.35)}
+.summary-num{font-size:1.6rem;font-weight:800;line-height:1}
+.c .summary-num{color:var(--danger)}
+.w .summary-num{color:var(--warning)}
+.ok .summary-num{color:var(--success)}
+.summary-lbl{font-size:0.72rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;line-height:1.3}
+.wr-section{margin-bottom:2.5rem}
+.wr-section-hdr{display:flex;align-items:center;gap:0.75rem;margin-bottom:1rem;padding-bottom:0.75rem;border-bottom:1px solid var(--border)}
+.wr-section-hdr h2{font-size:1rem;font-weight:700}
+.cnt-chip{padding:3px 10px;border-radius:20px;font-size:0.7rem;font-weight:700}
+.cnt-chip.c{background:rgba(239,68,68,0.15);color:#f87171}
+.cnt-chip.w{background:rgba(245,158,11,0.15);color:#fbbf24}
+.wr-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(340px,1fr));gap:1rem}
+.wr-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:1.25rem;display:flex;flex-direction:column;gap:0.55rem;transition:border-color 0.2s;animation:fadeIn 0.3s ease both}
+.wr-card.c{border-color:rgba(239,68,68,0.3);background:rgba(239,68,68,0.025)}
+.wr-card.w{border-color:rgba(245,158,11,0.25);background:rgba(245,158,11,0.02)}
+.wr-card:hover{border-color:var(--primary)}
+.wr-top{display:flex;align-items:center;gap:0.5rem;flex-wrap:wrap}
+.badge{padding:2px 8px;border-radius:20px;font-size:0.64rem;font-weight:700;letter-spacing:0.5px}
+.badge.c{background:rgba(239,68,68,0.15);color:#f87171}
+.badge.w{background:rgba(245,158,11,0.15);color:#fbbf24}
+.type-lbl{font-size:0.72rem;color:var(--text-muted)}
+.age-lbl{margin-left:auto;font-size:0.7rem;color:var(--text-muted);white-space:nowrap;background:rgba(255,255,255,0.05);padding:1px 7px;border-radius:4px}
+.wr-name{font-size:0.93rem;font-weight:700;color:var(--text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.wr-ns{font-size:0.73rem;color:var(--text-muted)}
+.wr-reason{font-size:0.78rem;color:var(--text-secondary);line-height:1.55;display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden}
+.wr-cmd{display:flex;align-items:center;gap:0.5rem;background:rgba(0,0,0,0.3);border:1px solid var(--border);border-radius:var(--radius-xs);padding:0.5rem 0.75rem;margin-top:auto}
+.wr-cmd code{font-family:'Consolas','Monaco',monospace;font-size:0.7rem;color:var(--primary-light);flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.copy-btn{background:transparent;border:1px solid var(--border);border-radius:4px;color:var(--text-muted);cursor:pointer;font-size:0.64rem;padding:2px 7px;white-space:nowrap;transition:all 0.15s;flex-shrink:0}
+.copy-btn:hover{background:var(--surface-hover);color:var(--text)}
+.all-clear-box{background:var(--surface);border:1px solid rgba(16,185,129,0.25);border-radius:var(--radius);padding:2.5rem;text-align:center;color:var(--text-muted)}
+.all-clear-box .icon{font-size:2.5rem;margin-bottom:0.5rem}
+.footer{text-align:center;padding:1.5rem 0;color:var(--text-muted);font-size:0.75rem;border-top:1px solid var(--border);margin-top:1rem}
+@media(max-width:640px){.wr-grid{grid-template-columns:1fr}.summary-bar{flex-direction:column}}
+</style>
+</head>
+<body>
+<div class="layout">
+{{template "sidebar.html" .}}
+<main class="main">
+  <div class="page-hdr">
+    <div>
+      <h1>🔍 Incidents</h1>
+      <p>{{.ClusterName}} &mdash; {{.StatusDesc}}</p>
+    </div>
+    <div class="page-meta">
+      <div>Last scanned: <strong id="inc-age">just now</strong></div>
+      <a class="back-link" href="{{.DashURL}}">← Back to Dashboard</a>
+    </div>
+  </div>
+
+  <div class="summary-bar">
+    <div class="summary-chip {{.CritChipClass}}">
+      <div class="summary-num">{{len .Critical}}</div>
+      <div class="summary-lbl">Critical<br>Issues</div>
+    </div>
+    <div class="summary-chip {{.WarnChipClass}}">
+      <div class="summary-num">{{len .Warnings}}</div>
+      <div class="summary-lbl">High<br>Severity</div>
+    </div>
+  </div>
+
+  <div class="wr-section">
+    <div class="wr-section-hdr">
+      <h2>🔴 Critical Issues</h2>
+      <span class="cnt-chip c">{{len .Critical}}</span>
+    </div>
+    {{if eq (len .Critical) 0}}
+    <div class="all-clear-box">
+      <div class="icon">✅</div>
+      <div>No crash-looping, OOMKilled, or ImagePullBackOff pods detected</div>
+    </div>
+    {{else}}
+    <div class="wr-grid">
+      {{range .Critical}}{{renderCard .}}{{end}}
+    </div>
+    {{end}}
+  </div>
+
+  <div class="wr-section">
+    <div class="wr-section-hdr">
+      <h2>🟡 High Severity</h2>
+      <span class="cnt-chip w">{{len .Warnings}}</span>
+    </div>
+    {{if eq (len .Warnings) 0}}
+    <div class="all-clear-box">
+      <div class="icon">✅</div>
+      <div>No unprotected namespaces, orphaned PVCs, or zero-replica workloads detected</div>
+    </div>
+    {{else}}
+    <div class="wr-grid">
+      {{range .Warnings}}{{renderCard .}}{{end}}
+    </div>
+    {{end}}
+  </div>
+
+  <div class="footer">OpsCart FinOps Engine &middot; Incidents &middot; All active issues &mdash; verify with owners before acting</div>
+</main>
+</div>
+<script>
+(function(){
+  var TS={{.ScannedAtMs}},el=document.getElementById('inc-age');
+  function upd(){
+    var s=Math.floor((Date.now()-TS)/1000);
+    var t=s<5?'just now':s<60?s+'s ago':Math.floor(s/60)+'m ago';
+    if(el)el.textContent=t;
+  }
+  setInterval(upd,1000);upd();
+})();
+</script>
+</body>
+</html>

--- a/cmd/opscart-dashboard/templates/security.html
+++ b/cmd/opscart-dashboard/templates/security.html
@@ -1,0 +1,248 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>Security Posture — {{.ClusterName}}</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+{{template "base" .}}
+<style>
+.summary-bar{display:flex;gap:1rem;margin-bottom:2rem;flex-wrap:wrap}
+.summary-chip{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);padding:0.75rem 1.25rem;display:flex;align-items:center;gap:0.75rem;min-width:160px}
+.summary-chip.green{border-color:rgba(16,185,129,0.35)}
+.summary-chip.orange{border-color:rgba(245,158,11,0.35)}
+.summary-chip.red{border-color:rgba(239,68,68,0.35)}
+.summary-num{font-size:1.6rem;font-weight:800;line-height:1}
+.green .summary-num{color:var(--success)}
+.orange .summary-num{color:var(--warning)}
+.red .summary-num{color:var(--danger)}
+.summary-lbl{font-size:0.72rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;line-height:1.3}
+.sec-section{margin-bottom:2.5rem}
+.sec-section-hdr{display:flex;align-items:center;gap:0.75rem;margin-bottom:1rem;padding-bottom:0.75rem;border-bottom:1px solid var(--border)}
+.sec-section-hdr h2{font-size:1rem;font-weight:700}
+.control-list{display:flex;flex-direction:column;gap:0.5rem}
+.control-row{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);padding:0.85rem 1rem;display:grid;grid-template-columns:auto auto 1fr auto;align-items:start;gap:0.75rem}
+.control-row.failed{border-color:rgba(239,68,68,0.3);background:rgba(239,68,68,0.025)}
+.control-row.passed{opacity:0.75}
+.control-icon{font-size:1rem;line-height:1}
+.control-id{font-size:0.72rem;font-weight:700;color:var(--primary-light);white-space:nowrap;padding-top:1px}
+.control-desc{font-size:0.85rem;color:var(--text)}
+.control-finding{font-size:0.75rem;color:var(--danger);margin-top:0.2rem;line-height:1.4}
+.risk-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:0.75rem}
+.risk-card{background:var(--surface);border:1px solid rgba(239,68,68,0.3);border-radius:var(--radius-sm);padding:0.85rem 1rem;background:rgba(239,68,68,0.025)}
+.risk-count{font-size:1.4rem;font-weight:800;color:var(--danger);line-height:1}
+.risk-name{font-size:0.8rem;font-weight:600;color:var(--text);margin-top:0.15rem}
+.risk-hint{font-size:0.7rem;color:var(--text-muted);margin-top:0.35rem;line-height:1.4}
+.actions-list{display:flex;flex-direction:column;gap:0.5rem;counter-reset:actions}
+.action-item{display:flex;align-items:flex-start;gap:0.85rem;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);padding:0.85rem 1rem}
+.action-num{background:var(--primary-bg);color:var(--primary-light);border-radius:50%;width:24px;height:24px;min-width:24px;display:flex;align-items:center;justify-content:center;font-size:0.7rem;font-weight:700;margin-top:1px}
+.action-text{font-size:0.85rem;color:var(--text);line-height:1.5}
+.no-risks{background:var(--surface);border:1px solid rgba(16,185,129,0.25);border-radius:var(--radius);padding:2rem;text-align:center;color:var(--text-muted)}
+.footer{text-align:center;padding:1.5rem 0;color:var(--text-muted);font-size:0.75rem;border-top:1px solid var(--border);margin-top:1rem}
+@media(max-width:640px){.risk-grid{grid-template-columns:1fr}.summary-bar{flex-direction:column}.control-row{grid-template-columns:auto 1fr}}
+</style>
+</head>
+<body>
+<div class="layout">
+{{template "sidebar.html" .}}
+<main class="main">
+  <div class="page-hdr">
+    <div>
+      <h1>🔒 Security Posture</h1>
+      <p>{{.ClusterName}} &mdash; CIS Kubernetes Benchmark v1.8</p>
+    </div>
+    <div class="page-meta">
+      <div>Last scanned: <strong id="sec-age">just now</strong></div>
+      <a class="back-link" href="{{.DashHref}}">← Back to Dashboard</a>
+    </div>
+  </div>
+
+  <div class="summary-bar">
+    <div class="summary-chip {{.CISScoreColor}}">
+      <div class="summary-num">{{.CISScore}}<span style="font-size:0.9rem;font-weight:500">/100</span></div>
+      <div class="summary-lbl">CIS<br>Score</div>
+    </div>
+    <div class="summary-chip{{if gt .PassedChecks 0}} green{{end}}">
+      <div class="summary-num">{{.PassedChecks}}<span style="font-size:0.9rem;font-weight:500">/{{.TotalChecks}}</span></div>
+      <div class="summary-lbl">Controls<br>Passed</div>
+    </div>
+    <div class="summary-chip">
+      <div class="summary-num">{{.TotalPods}}</div>
+      <div class="summary-lbl">Pods<br>Audited</div>
+    </div>
+  </div>
+
+  {{if .Controls}}
+  <div class="sec-section">
+    <div class="sec-section-hdr">
+      <h2>🛡️ CIS Controls</h2>
+      <span style="font-size:0.75rem;color:var(--text-muted)">{{.FailedChecks}} failed &middot; {{.PassedChecks}} passed</span>
+    </div>
+    <div class="control-list">
+      {{range .Controls}}
+      {{if .Passed}}
+      <div class="control-row passed">
+        <div class="control-icon">✅</div>
+        <div class="control-id">{{.ID}}</div>
+        <div>
+          <div class="control-desc">{{.Description}}</div>
+        </div>
+        <div style="font-size:0.7rem;color:var(--text-muted);white-space:nowrap">w: {{printf "%.1f" .Weight}}</div>
+      </div>
+      {{else}}
+      <div class="control-row failed">
+        <div class="control-icon">❌</div>
+        <div class="control-id">{{.ID}}</div>
+        <div>
+          <div class="control-desc">{{.Description}}</div>
+          {{if .Finding}}
+          <div class="control-finding">{{.Finding}}</div>
+          {{end}}
+        </div>
+        <div style="font-size:0.7rem;color:var(--text-muted);white-space:nowrap">w: {{printf "%.1f" .Weight}}</div>
+      </div>
+      {{end}}
+      {{end}}
+    </div>
+  </div>
+  {{end}}
+
+  <div class="sec-section">
+    <div class="sec-section-hdr">
+      <h2>⚠️ Risk Breakdown</h2>
+    </div>
+    {{$r := .Risks}}
+    {{if .HasRisks}}
+    <div class="risk-grid">
+      {{if gt $r.RunningAsRoot 0}}
+      <div class="risk-card">
+        <div class="risk-count">{{$r.RunningAsRoot}}</div>
+        <div class="risk-name">Running as Root</div>
+        <div class="risk-hint">Set securityContext.runAsNonRoot: true</div>
+      </div>
+      {{end}}
+      {{if gt $r.PrivilegedContainers 0}}
+      <div class="risk-card">
+        <div class="risk-count">{{$r.PrivilegedContainers}}</div>
+        <div class="risk-name">Privileged Containers</div>
+        <div class="risk-hint">Remove privileged: true from securityContext</div>
+      </div>
+      {{end}}
+      {{if gt $r.HostNetwork 0}}
+      <div class="risk-card">
+        <div class="risk-count">{{$r.HostNetwork}}</div>
+        <div class="risk-name">Host Network</div>
+        <div class="risk-hint">Avoid hostNetwork: true unless required</div>
+      </div>
+      {{end}}
+      {{if gt $r.HostPID 0}}
+      <div class="risk-card">
+        <div class="risk-count">{{$r.HostPID}}</div>
+        <div class="risk-name">Host PID</div>
+        <div class="risk-hint">Avoid hostPID: true — exposes host process tree</div>
+      </div>
+      {{end}}
+      {{if gt $r.HostIPC 0}}
+      <div class="risk-card">
+        <div class="risk-count">{{$r.HostIPC}}</div>
+        <div class="risk-name">Host IPC</div>
+        <div class="risk-hint">Avoid hostIPC: true — exposes host IPC namespace</div>
+      </div>
+      {{end}}
+      {{if gt $r.HostPathVolumes 0}}
+      <div class="risk-card">
+        <div class="risk-count">{{$r.HostPathVolumes}}</div>
+        <div class="risk-name">Host Path Volumes</div>
+        <div class="risk-hint">Replace hostPath mounts with PVCs where possible</div>
+      </div>
+      {{end}}
+      {{if gt $r.DefaultServiceAccount 0}}
+      <div class="risk-card">
+        <div class="risk-count">{{$r.DefaultServiceAccount}}</div>
+        <div class="risk-name">Default Service Account</div>
+        <div class="risk-hint">Create dedicated service accounts per workload</div>
+      </div>
+      {{end}}
+      {{if gt $r.MissingResourceLimits 0}}
+      <div class="risk-card">
+        <div class="risk-count">{{$r.MissingResourceLimits}}</div>
+        <div class="risk-name">Missing Resource Limits</div>
+        <div class="risk-hint">Set resources.limits.cpu and memory on all containers</div>
+      </div>
+      {{end}}
+      {{if gt $r.MissingProbes 0}}
+      <div class="risk-card">
+        <div class="risk-count">{{$r.MissingProbes}}</div>
+        <div class="risk-name">Missing Probes</div>
+        <div class="risk-hint">Add livenessProbe and readinessProbe to containers</div>
+      </div>
+      {{end}}
+      {{if gt $r.AddedCapabilities 0}}
+      <div class="risk-card">
+        <div class="risk-count">{{$r.AddedCapabilities}}</div>
+        <div class="risk-name">Added Capabilities</div>
+        <div class="risk-hint">Drop all capabilities and add only what's required</div>
+      </div>
+      {{end}}
+      {{if gt $r.PrivilegeEscalation 0}}
+      <div class="risk-card">
+        <div class="risk-count">{{$r.PrivilegeEscalation}}</div>
+        <div class="risk-name">Privilege Escalation</div>
+        <div class="risk-hint">Set allowPrivilegeEscalation: false in securityContext</div>
+      </div>
+      {{end}}
+      {{if gt $r.WritableFilesystem 0}}
+      <div class="risk-card">
+        <div class="risk-count">{{$r.WritableFilesystem}}</div>
+        <div class="risk-name">Writable Filesystem</div>
+        <div class="risk-hint">Set readOnlyRootFilesystem: true in securityContext</div>
+      </div>
+      {{end}}
+      {{if gt $r.MissingNetworkPolicies 0}}
+      <div class="risk-card">
+        <div class="risk-count">{{$r.MissingNetworkPolicies}}</div>
+        <div class="risk-name">Missing Network Policies</div>
+        <div class="risk-hint">Apply default-deny NetworkPolicy to each namespace</div>
+      </div>
+      {{end}}
+    </div>
+    {{else}}
+    <div class="no-risks">
+      <div style="font-size:2rem;margin-bottom:0.5rem">✅</div>
+      <div>No active risks detected</div>
+    </div>
+    {{end}}
+  </div>
+
+  {{if .PriorityActions}}
+  <div class="sec-section">
+    <div class="sec-section-hdr">
+      <h2>🎯 Priority Actions</h2>
+    </div>
+    <div class="actions-list">
+      {{range $i, $a := .PriorityActions}}
+      <div class="action-item">
+        <div class="action-num">{{add $i 1}}</div>
+        <div class="action-text">{{$a}}</div>
+      </div>
+      {{end}}
+    </div>
+  </div>
+  {{end}}
+
+  <div class="footer">OpsCart FinOps Engine &middot; Security Posture &middot; CIS Kubernetes Benchmark v1.8</div>
+</main>
+</div>
+<script>
+(function(){
+  var TS={{.ScannedAtMs}},el=document.getElementById('sec-age');
+  function upd(){
+    var s=Math.floor((Date.now()-TS)/1000);
+    var t=s<5?'just now':s<60?s+'s ago':Math.floor(s/60)+'m ago';
+    if(el)el.textContent=t;
+  }
+  setInterval(upd,1000);upd();
+})();
+</script>
+</body>
+</html>

--- a/cmd/opscart-dashboard/templates/waste.html
+++ b/cmd/opscart-dashboard/templates/waste.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>Waste &amp; Drift — {{.ClusterName}}</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+{{template "base" .}}
+<style>
+.summary-chip{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);padding:0.75rem 1.25rem;display:flex;align-items:center;gap:0.75rem;min-width:160px}
+.summary-chip.red{border-color:rgba(239,68,68,0.35)}
+.summary-chip.orange{border-color:rgba(245,158,11,0.35)}
+.summary-chip.green{border-color:rgba(16,185,129,0.35)}
+.summary-num{font-size:1.6rem;font-weight:800;line-height:1}
+.red .summary-num{color:var(--danger)}
+.orange .summary-num{color:var(--warning)}
+.green .summary-num{color:var(--success)}
+.summary-lbl{font-size:0.72rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;line-height:1.3}
+.waste-section{margin-bottom:2.5rem}
+.waste-section-hdr{display:flex;align-items:center;gap:0.75rem;margin-bottom:1rem;padding-bottom:0.75rem;border-bottom:1px solid var(--border)}
+.waste-section-hdr h2{font-size:1rem;font-weight:700}
+.cnt-chip{padding:3px 10px;border-radius:20px;font-size:0.7rem;font-weight:700}
+.cnt-chip.red{background:rgba(239,68,68,0.15);color:#f87171}
+.cnt-chip.orange{background:rgba(245,158,11,0.15);color:#fbbf24}
+.cnt-chip.gray{background:rgba(100,116,139,0.15);color:#94a3b8}
+.cnt-chip.yellow{background:rgba(234,179,8,0.15);color:#facc15}
+.waste-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:1rem}
+.waste-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:1.25rem;display:flex;flex-direction:column;gap:0.55rem;animation:fadeIn 0.3s ease both}
+.waste-card:hover{border-color:var(--primary)}
+.waste-card.red{border-color:rgba(239,68,68,0.3);background:rgba(239,68,68,0.025)}
+.waste-card.orange{border-color:rgba(245,158,11,0.25);background:rgba(245,158,11,0.02)}
+.waste-card.yellow{border-color:rgba(234,179,8,0.2);background:rgba(234,179,8,0.015)}
+.waste-card.gray{border-color:rgba(100,116,139,0.25);background:rgba(100,116,139,0.015)}
+.waste-top{display:flex;align-items:center;gap:0.5rem;flex-wrap:wrap}
+.waste-badge{padding:2px 8px;border-radius:20px;font-size:0.64rem;font-weight:700;letter-spacing:0.5px}
+.waste-badge.red{background:rgba(239,68,68,0.15);color:#f87171}
+.waste-badge.orange{background:rgba(245,158,11,0.15);color:#fbbf24}
+.waste-badge.yellow{background:rgba(234,179,8,0.12);color:#facc15}
+.waste-badge.gray{background:rgba(100,116,139,0.15);color:#94a3b8}
+.waste-name{font-size:0.93rem;font-weight:700;color:var(--text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.waste-ns{font-size:0.73rem;color:var(--text-muted)}
+.waste-meta{display:flex;gap:1.25rem;flex-wrap:wrap;margin-top:0.1rem}
+.waste-meta-item{font-size:0.78rem;color:var(--text-secondary)}
+.waste-meta-item span{color:var(--text-muted);font-size:0.7rem}
+.waste-reason{font-size:0.76rem;color:var(--text-muted);line-height:1.5;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;margin-top:0.15rem}
+.empty-state-box{background:var(--surface);border:1px solid rgba(16,185,129,0.25);border-radius:var(--radius);padding:2.5rem;text-align:center;color:var(--text-muted)}
+.empty-state-box .icon{font-size:2.5rem;margin-bottom:0.5rem}
+.all-clean{background:var(--surface);border:1px solid rgba(16,185,129,0.3);border-radius:var(--radius);padding:3.5rem 2rem;text-align:center}
+.all-clean .big-icon{font-size:3.5rem;margin-bottom:1rem}
+.all-clean h2{font-size:1.25rem;font-weight:700;color:var(--success);margin-bottom:0.5rem}
+.all-clean p{font-size:0.85rem;color:var(--text-muted)}
+@media(max-width:640px){.waste-grid{grid-template-columns:1fr}.summary-bar{flex-direction:column}}
+</style>
+</head>
+<body>
+<div class="layout">
+{{template "sidebar.html" .}}
+<main class="main">
+  <div class="page-hdr">
+    <div>
+      <h1>🗑️ Waste &amp; Drift</h1>
+      <p>Unused and forgotten resources</p>
+    </div>
+    <div class="page-meta">
+      <div>Last scanned: <strong id="waste-age">just now</strong></div>
+      <a class="back-link" href="{{.DashHref}}">← Back to Dashboard</a>
+    </div>
+  </div>
+
+  <div class="summary-bar">
+    <div class="summary-chip{{if gt .TotalWasteItems 0}} orange{{end}}">
+      <div class="summary-num">{{.TotalWasteItems}}</div>
+      <div class="summary-lbl">Total Waste<br>Items</div>
+    </div>
+    <div class="summary-chip{{if gt .OrphanedPVCStorageGB 0}} orange{{end}}">
+      <div class="summary-num">{{.OrphanedPVCStorageGB}}<span style="font-size:0.9rem;font-weight:500"> GB</span></div>
+      <div class="summary-lbl">Orphaned<br>Storage</div>
+    </div>
+    <div class="summary-chip{{if gt .EstimatedMonthly 0.0}} red{{end}}">
+      <div class="summary-num">{{if gt .EstimatedMonthly 0.0}}${{printf "%.0f" .EstimatedMonthly}}{{else}}—{{end}}</div>
+      <div class="summary-lbl">Est. Monthly<br>Waste</div>
+    </div>
+    <div class="summary-chip{{if gt .ZombieCount 0}} red{{end}}">
+      <div class="summary-num">{{.ZombieCount}}</div>
+      <div class="summary-lbl">Zombie<br>Pods</div>
+    </div>
+  </div>
+
+  {{if eq .TotalWasteItems 0}}
+  <div class="all-clean">
+    <div class="big-icon">✅</div>
+    <h2>No waste detected</h2>
+    <p>Your cluster looks clean — no abandoned, stale, or orphaned resources found.</p>
+  </div>
+  {{else}}
+
+  {{if .StalePods}}
+  <div class="waste-section">
+    <div class="waste-section-hdr">
+      <h2>💀 Zombie Pods</h2>
+      <span class="cnt-chip red">{{len .StalePods}}</span>
+    </div>
+    <div class="waste-grid">
+      {{range .StalePods}}
+      <div class="waste-card red">
+        <div class="waste-top">
+          <span class="waste-badge red">ZOMBIE</span>
+        </div>
+        <div class="waste-name">{{.Name}}</div>
+        <div class="waste-ns">ns: {{.Namespace}}</div>
+        <div class="waste-meta">
+          <div class="waste-meta-item"><span>Status</span> {{.Status}}</div>
+          <div class="waste-meta-item"><span>Restarts</span> {{.RestartCount}}</div>
+          <div class="waste-meta-item"><span>Age</span> {{.AgeDays}}d</div>
+        </div>
+        {{if .Reason}}<div class="waste-reason">{{.Reason}}</div>{{end}}
+      </div>
+      {{end}}
+    </div>
+  </div>
+  {{end}}
+
+  {{if .OrphanedPVCs}}
+  <div class="waste-section">
+    <div class="waste-section-hdr">
+      <h2>💾 Orphaned PVCs</h2>
+      <span class="cnt-chip orange">{{len .OrphanedPVCs}}</span>
+    </div>
+    <div class="waste-grid">
+      {{range .OrphanedPVCs}}
+      <div class="waste-card orange">
+        <div class="waste-top">
+          <span class="waste-badge orange">PVC</span>
+        </div>
+        <div class="waste-name">{{.Name}}</div>
+        <div class="waste-ns">ns: {{.Namespace}}</div>
+        <div class="waste-meta">
+          <div class="waste-meta-item"><span>Size</span> {{.SizeGB}} GB</div>
+          <div class="waste-meta-item"><span>Status</span> {{.Status}}</div>
+          <div class="waste-meta-item"><span>Age</span> {{.AgeDays}}d</div>
+        </div>
+        {{if .Reason}}<div class="waste-reason">{{.Reason}}</div>{{end}}
+      </div>
+      {{end}}
+    </div>
+  </div>
+  {{end}}
+
+  {{if .ZeroReplicaWorkloads}}
+  <div class="waste-section">
+    <div class="waste-section-hdr">
+      <h2>⏸️ Zero-Replica Workloads</h2>
+      <span class="cnt-chip yellow">{{len .ZeroReplicaWorkloads}}</span>
+    </div>
+    <div class="waste-grid">
+      {{range .ZeroReplicaWorkloads}}
+      <div class="waste-card yellow">
+        <div class="waste-top">
+          <span class="waste-badge yellow">SCALED TO ZERO</span>
+        </div>
+        <div class="waste-name">{{.Name}}</div>
+        <div class="waste-ns">ns: {{.Namespace}}</div>
+        <div class="waste-meta">
+          <div class="waste-meta-item"><span>Kind</span> {{.Kind}}</div>
+          <div class="waste-meta-item"><span>Age</span> {{.AgeDays}}d</div>
+        </div>
+        {{if .Reason}}<div class="waste-reason">{{.Reason}}</div>{{end}}
+      </div>
+      {{end}}
+    </div>
+  </div>
+  {{end}}
+
+  {{if .AbandonedNamespaces}}
+  <div class="waste-section">
+    <div class="waste-section-hdr">
+      <h2>📁 Abandoned Namespaces</h2>
+      <span class="cnt-chip gray">{{len .AbandonedNamespaces}}</span>
+    </div>
+    <div class="waste-grid">
+      {{range .AbandonedNamespaces}}
+      <div class="waste-card gray">
+        <div class="waste-top">
+          <span class="waste-badge gray">ABANDONED</span>
+        </div>
+        <div class="waste-name">{{.Name}}</div>
+        <div class="waste-meta">
+          <div class="waste-meta-item"><span>Age</span> {{.AgeDays}}d</div>
+          <div class="waste-meta-item"><span>Pods</span> {{.PodCount}}</div>
+        </div>
+        {{if .Reason}}<div class="waste-reason">{{.Reason}}</div>{{end}}
+      </div>
+      {{end}}
+    </div>
+  </div>
+  {{end}}
+
+  {{if .StaleJobs}}
+  <div class="waste-section">
+    <div class="waste-section-hdr">
+      <h2>⏰ Stale Jobs</h2>
+      <span class="cnt-chip gray">{{len .StaleJobs}}</span>
+    </div>
+    <div class="waste-grid">
+      {{range .StaleJobs}}
+      <div class="waste-card gray">
+        <div class="waste-top">
+          <span class="waste-badge gray">STALE JOB</span>
+          {{if .IsCronJob}}<span class="waste-badge gray">CRONJOB</span>{{end}}
+        </div>
+        <div class="waste-name">{{.Name}}</div>
+        <div class="waste-ns">ns: {{.Namespace}}</div>
+        <div class="waste-meta">
+          <div class="waste-meta-item"><span>Status</span> {{.JobStatus}}</div>
+          <div class="waste-meta-item"><span>Age</span> {{.AgeDays}}d</div>
+        </div>
+        {{if .Reason}}<div class="waste-reason">{{.Reason}}</div>{{end}}
+      </div>
+      {{end}}
+    </div>
+  </div>
+  {{end}}
+
+  {{end}}
+
+  <div class="footer">OpsCart FinOps Engine &middot; Waste &amp; Drift &middot; Suggestions only — verify with owners before removing resources</div>
+</main>
+</div>
+<script>
+(function(){
+  var TS={{.ScannedAtMs}},el=document.getElementById('waste-age');
+  function upd(){
+    var s=Math.floor((Date.now()-TS)/1000);
+    var t=s<5?'just now':s<60?s+'s ago':Math.floor(s/60)+'m ago';
+    if(el)el.textContent=t;
+  }
+  setInterval(upd,1000);upd();
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
- Summary bar: total items, storage GB, monthly waste, zombie count
- Zombie Pods grid with CrashLoop/ImagePullBackOff cards
- Orphaned PVCs with size and status
- Zero-replica workloads, abandoned namespaces, stale jobs sections
- Empty state when no waste detected
- Replaces stub at /waste"