### PR TITLE
feat: Replace emojis with Lucide SVG icons

### DIFF
--- a/cmd/opscart-dashboard/templates/base.html
+++ b/cmd/opscart-dashboard/templates/base.html
@@ -22,6 +22,8 @@ body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--t
 .nav-item{display:flex;align-items:center;gap:0.75rem;padding:0.7rem 0.75rem;border-radius:var(--radius-sm);color:var(--text-secondary);font-size:0.9rem;cursor:pointer;transition:all 0.15s;text-decoration:none}
 .nav-item:hover{background:var(--surface-hover);color:var(--text)}
 .nav-item.active{background:var(--primary-bg);color:var(--primary-light);font-weight:600}
+.nav-icon{width:18px;height:18px;display:inline-flex;align-items:center;justify-content:center;flex-shrink:0}
+.kpi-icon-svg{width:20px;height:20px;display:inline-flex;align-items:center;justify-content:center}
 .nav-badge{display:inline-flex;align-items:center;justify-content:center;min-width:18px;height:18px;padding:0 5px;border-radius:99px;font-size:0.65rem;font-weight:700;background:var(--danger);color:#fff;margin-left:auto}
 .nav-badge-critical{background:var(--danger);color:#fff}
 .nav-divider{border:none;border-top:1px solid var(--border);margin:1rem 0}

--- a/cmd/opscart-dashboard/templates/cost.html
+++ b/cmd/opscart-dashboard/templates/cost.html
@@ -107,27 +107,27 @@ tbody tr{transition:background 0.1s}
 <div class="layout">
 <aside class="sidebar">
 <div class="logo">
-<div class="logo-icon">⚡</div>
+<div class="logo-icon"><span class="nav-icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg></span></div>
 <div><div class="logo-text">OpsCart</div><div class="logo-sub">K8s Operational Intelligence</div></div>
 </div>
 
 <div class="nav-section">
 <div class="nav-label">Overview</div>
-<a class="nav-item{{if eq .ActivePage "dashboard"}} active{{end}}" href="{{.DashURL}}">📊 Overview</a>
-<a class="nav-item{{if eq .ActivePage "warroom"}} active{{end}}" href="{{.WrURL}}">🚨 War Room{{if .CriticalCount}} <span class="nav-badge nav-badge-critical">{{.CriticalCount}}</span>{{end}}</a>
+<a class="nav-item{{if eq .ActivePage "dashboard"}} active{{end}}" href="{{.DashURL}}"><span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg></span> Overview</a>
+<a class="nav-item{{if eq .ActivePage "warroom"}} active{{end}}" href="{{.WrURL}}"><span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><polygon points="7.86 2 16.14 2 22 7.86 22 16.14 16.14 22 7.86 22 2 16.14 2 7.86 7.86 2"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg></span> War Room{{if .CriticalCount}} <span class="nav-badge nav-badge-critical">{{.CriticalCount}}</span>{{end}}</a>
 </div>
 
 <div class="nav-section">
 <div class="nav-label">Investigate</div>
-<a class="nav-item{{if eq .ActivePage "incidents"}} active{{end}}" href="{{.IncidentsURL}}">🔍 Incidents</a>
-<a class="nav-item{{if eq .ActivePage "infrastructure"}} active{{end}}" href="{{.InfraURL}}">🖥️ Infrastructure</a>
+<a class="nav-item{{if eq .ActivePage "incidents"}} active{{end}}" href="{{.IncidentsURL}}"><span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg></span> Incidents</a>
+<a class="nav-item{{if eq .ActivePage "infrastructure"}} active{{end}}" href="{{.InfraURL}}"><span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span> Infrastructure</a>
 </div>
 
 <div class="nav-section">
 <div class="nav-label">Analyze</div>
-<a class="nav-item active" href="{{.CostsURL}}">💰 Cost Intelligence</a>
-<a class="nav-item{{if eq .ActivePage "security"}} active{{end}}" href="{{.SecurityURL}}">🔒 Security Posture</a>
-<a class="nav-item{{if eq .ActivePage "waste"}} active{{end}}" href="{{.WasteURL}}">🗑️ Waste & Drift</a>
+<a class="nav-item active" href="{{.CostsURL}}"><span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="2" x2="12" y2="22"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg></span> Cost Intelligence</a>
+<a class="nav-item{{if eq .ActivePage "security"}} active{{end}}" href="{{.SecurityURL}}"><span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg></span> Security Posture</a>
+<a class="nav-item{{if eq .ActivePage "waste"}} active{{end}}" href="{{.WasteURL}}"><span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/></svg></span> Waste &amp; Drift</a>
 </div>
 
 <div class="nav-footer">
@@ -143,17 +143,17 @@ tbody tr{transition:background 0.1s}
 {{end}}
 </div>
 <div class="nav-divider"></div>
-<a class="nav-item{{if eq .ActivePage "settings"}} active{{end}}" href="/settings">⚙️ Settings</a>
+<a class="nav-item{{if eq .ActivePage "settings"}} active{{end}}" href="/settings"><span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14M4.93 4.93a10 10 0 0 0 0 14.14"/></svg></span> Settings</a>
 </div>
 </aside>
 <main class="main">
 <div class="oc-kpi-row">
-<div class="kpi"><div class="kpi-top"><div class="kpi-icon {{if .CriticalCount}}red{{else}}green{{end}}">🚨</div></div><h3 class="money {{if .CriticalCount}}red{{else}}green{{end}}">{{.CriticalCount}}</h3><p>{{if .CriticalCount}}Critical Issues{{else}}All Clear{{end}}</p></div>
+<div class="kpi-icon {{if .CriticalCount}}red{{else}}green{{end}}"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><polygon points="7.86 2 16.14 2 22 7.86 22 16.14 16.14 22 7.86 22 2 16.14 2 7.86 7.86 2"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg></div>
 <div class="kpi"><div class="kpi-top"><div class="kpi-icon green">💡</div><span class="kpi-trend down">↓ Save</span></div><h3 class="money green">${{money .SavingsPotential}}</h3><p>Potential Savings</p></div>
 <div class="kpi"><div class="kpi-top"><div class="kpi-icon {{.SecurityColor}}">🔐</div></div><h3>{{.SecurityDisplay}}</h3><p>Security Score</p></div>
-<div class="kpi"><div class="kpi-top"><div class="kpi-icon {{.WasteColor}}">🗑️</div></div><h3>{{.WasteDisplay}}</h3><p>Waste Resources</p></div>
-<div class="kpi"><div class="kpi-top"><div class="kpi-icon red">💰</div></div><h3 class="money red">${{money .MonthlyCost}}</h3><p>Monthly Cost</p></div>
-<div class="kpi"><div class="kpi-top"><div class="kpi-icon cyan">☸️</div></div><h3>{{.ClusterCount}}</h3><p>Clusters</p></div>
+<div class="kpi-icon {{.WasteColor}}"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/></svg></div>
+<div class="kpi-icon red"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="2" x2="12" y2="22"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg></div>
+<div class="kpi"><div class="kpi-top"><div class="kpi-icon cyan"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="3"/><line x1="12" y1="2" x2="12" y2="5"/><line x1="12" y1="19" x2="12" y2="22"/><line x1="2" y1="12" x2="5" y2="12"/><line x1="19" y1="12" x2="22" y2="12"/></svg></div></div><h3>{{.ClusterCount}}</h3><p>Clusters</p></div>
 </div>
 <div style="display:grid;grid-template-columns:1fr 340px;gap:1.5rem;align-items:start">
 <div>
@@ -162,7 +162,7 @@ tbody tr{transition:background 0.1s}
 <p style="color:var(--text-muted);font-size:0.9rem">Kubernetes infrastructure cost breakdown &bull; {{.Timestamp.Format "Monday, January 2, 2006"}}</p>
 </div>
 <div class="section">
-<div class="section-hdr"><div class="section-title">🎯 Pricing Confidence</div></div>
+<div class="section-hdr"><div class="section-title">Pricing Confidence</div></div>
 <div class="confidence-card">
 <div class="conf-ring">
 <svg width="80" height="80" viewBox="0 0 80 80">
@@ -184,7 +184,7 @@ tbody tr{transition:background 0.1s}
 </div>
 </div>
 <div class="section">
-<div class="section-hdr"><div class="section-title">🖥️ Node Pool Infrastructure</div></div>
+<div class="section-hdr"><div class="section-title">Node Pool Infrastructure</div></div>
 <div class="table-wrap"><table>
 <thead><tr><th>Pool Name</th><th>VM Size</th><th>Nodes</th><th>Type</th><th>CPU Utilization</th><th>Memory Utilization</th><th>$/Node/Mo</th><th>Pool Total</th><th>RI Savings</th></tr></thead>
 <tbody>
@@ -250,7 +250,7 @@ tbody tr{transition:background 0.1s}
 </div>
 {{if .Scenarios}}
 <div class="section">
-<div class="section-hdr"><div class="section-title">🎯 Optimization Opportunities</div></div>
+<div class="section-hdr"><div class="section-title">Optimization Opportunities</div></div>
 <div class="scenarios-grid">
 {{range .Scenarios}}
 <div class="scenario-card">
@@ -275,7 +275,7 @@ tbody tr{transition:background 0.1s}
 <div style="position:sticky;top:2rem">
 <div class="section" style="border-color:rgba(239,68,68,0.4)">
 <div class="section-hdr">
-<div class="section-title">🚨 War Room</div>
+<div class="section-title">War Room</div>
 {{if .WRIssues}}<span style="background:rgba(239,68,68,0.12);color:#ef4444;padding:3px 10px;border-radius:20px;font-size:0.72rem;font-weight:700">{{len .WRIssues}} issues</span>
 {{else}}<span style="background:rgba(16,185,129,0.12);color:#10b981;padding:3px 10px;border-radius:20px;font-size:0.72rem;font-weight:700">All clear</span>
 {{end}}

--- a/cmd/opscart-dashboard/templates/infrastructure.html
+++ b/cmd/opscart-dashboard/templates/infrastructure.html
@@ -56,7 +56,7 @@
 <main class="main">
   <div class="page-hdr">
     <div>
-      <h1>🖥️ Infrastructure</h1>
+      <h1>Infrastructure</h1>
       <p>{{.ClusterName}} &mdash; {{.PoolCount}} node pool(s), {{.TotalNodes}} node(s)</p>
     </div>
     <div class="page-meta">

--- a/cmd/opscart-dashboard/templates/optimizations.html
+++ b/cmd/opscart-dashboard/templates/optimizations.html
@@ -54,7 +54,7 @@
   <!-- RI Opportunities -->
   <div class="section">
     <div class="section-hdr">
-      <div class="section-title">💰 Reserved Instance Opportunities</div>
+      <div class="section-title">Reserved Instance Opportunities</div>
       <div class="section-sub">Savings vs. Pay-As-You-Go for On-Demand pools</div>
     </div>
     {{if not .HasRI}}
@@ -86,7 +86,7 @@
   <!-- Waste by Category -->
   <div class="section">
     <div class="section-hdr">
-      <div class="section-title">🗑️ Waste Items by Category</div>
+      <div class="section-title">Waste Items by Category</div>
       <div class="section-sub">Resources consuming cost or capacity without business value</div>
     </div>
     <div class="opt-wrap"><table class="opt-table">

--- a/cmd/opscart-dashboard/templates/overview.html
+++ b/cmd/opscart-dashboard/templates/overview.html
@@ -129,35 +129,35 @@
 <div class="kpi-row">
 
   <div class="kpi-card kpi-card-score{{if eq .IncidentScoreColor "red"}} critical{{end}}">
-    <div class="kpi-icon {{.IncidentScoreColor}}">🎯</div>
+    <div class="kpi-icon {{.IncidentScoreColor}}"><span class="kpi-icon-svg"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg></span></div>
     <div class="kpi-label">Incident Score</div>
     <div class="kpi-value {{.IncidentScoreColor}}">{{.IncidentScore}}<span style="font-size:0.9rem;font-weight:600;color:var(--text-muted)">/100</span></div>
     <div class="kpi-sub {{.IncidentScoreColor}}">{{.IncidentScoreLabel}}</div>
   </div>
 
   <div class="kpi-card{{if .CriticalCount}} critical{{end}}">
-    <div class="kpi-icon red">⚠️</div>
+    <div class="kpi-icon red"><span class="kpi-icon-svg"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg></span></div>
     <div class="kpi-label">Critical Issues</div>
     <div class="kpi-value{{if .CriticalCount}} red{{else}} green{{end}}">{{.CriticalCount}}</div>
     <div class="kpi-sub{{if .CriticalCount}} red{{end}}">{{if .CriticalCount}}Needs immediate attention{{else}}All clear{{end}}</div>
   </div>
 
   <div class="kpi-card">
-    <div class="kpi-icon purple">🛡️</div>
+    <div class="kpi-icon purple"><span class="kpi-icon-svg"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg></span></div>
     <div class="kpi-label">Security Score</div>
     <div class="kpi-value">{{.SecurityScore}}<span style="font-size:0.7rem;color:var(--text-muted);font-weight:600">/100</span></div>
     <div class="kpi-sub">{{if lt .SecurityScore 40}}High Risk{{else if lt .SecurityScore 70}}Medium Risk{{else}}Good{{end}}</div>
   </div>
 
   <div class="kpi-card">
-    <div class="kpi-icon orange">🗑️</div>
+    <div class="kpi-icon orange"><span class="kpi-icon-svg"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/></svg></span></div>
     <div class="kpi-label">Waste Resources</div>
     <div class="kpi-value orange">{{.WasteCount}}</div>
     <div class="kpi-sub">Resources found</div>
   </div>
 
   <div class="kpi-card">
-    <div class="kpi-icon gold">$</div>
+    <div class="kpi-icon gold"><span class="kpi-icon-svg"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="2" x2="12" y2="22"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg></span></div>
     <div class="kpi-label">Monthly Cost</div>
     <div class="kpi-value">${{.MonthlyCost | printf "%.0f"}}</div>
     <div class="kpi-sub">Estimated</div>
@@ -220,7 +220,7 @@
           <div class="summary-sub">Pods</div>
         </div>
         <div class="summary-card">
-          <div class="summary-icon">⚡</div>
+          <div class="summary-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg></div>
           <div class="summary-lbl">CPU Utilization</div>
           <div class="summary-num">{{.CPUUtilization}}%</div>
           <div class="summary-sub">Average</div>
@@ -247,7 +247,7 @@
 
       <!-- Sticky header -->
       <div class="wr-featured-hdr">
-        <div class="wr-featured-title">🚨 War Room
+        <div class="wr-featured-title">War Room
           {{if .HasFeatured}}<span class="wr-featured-count">{{.CriticalCount}} {{if eq .CriticalCount 1}}Critical{{else}}Issues{{end}}</span>{{end}}
         </div>
         <a class="view-all-link" href="{{.WrURL}}" style="margin-top:0">View all →</a>

--- a/cmd/opscart-dashboard/templates/security.html
+++ b/cmd/opscart-dashboard/templates/security.html
@@ -48,7 +48,7 @@
 <main class="main">
   <div class="page-hdr">
     <div>
-      <h1>🔒 Security Posture</h1>
+      <h1>Security Posture</h1>
       <p>{{.ClusterName}} &mdash; CIS Kubernetes Benchmark v1.8</p>
     </div>
     <div class="page-meta">
@@ -109,7 +109,7 @@
 
   <div class="sec-section">
     <div class="sec-section-hdr">
-      <h2>⚠️ Risk Breakdown</h2>
+      <h2>Risk Breakdown</h2>
     </div>
     {{$r := .Risks}}
     {{if .HasRisks}}
@@ -217,7 +217,7 @@
   {{if .PriorityActions}}
   <div class="sec-section">
     <div class="sec-section-hdr">
-      <h2>🎯 Priority Actions</h2>
+      <h2>Priority Actions</h2>
     </div>
     <div class="actions-list">
       {{range $i, $a := .PriorityActions}}

--- a/cmd/opscart-dashboard/templates/sidebar.html
+++ b/cmd/opscart-dashboard/templates/sidebar.html
@@ -1,6 +1,6 @@
 <aside class="sidebar">
 <div class="logo">
-  <div class="logo-icon">⚡</div>
+  <div class="logo-icon"><span class="nav-icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg></span></div>
   <div>
     <div class="logo-text">OpsCart</div>
     <div class="logo-sub">K8s Operational Intelligence</div>
@@ -9,21 +9,21 @@
 
 <div class="nav-section">
   <div class="nav-label">Overview</div>
-  <a class="nav-item{{if eq .ActivePage "dashboard"}} active{{end}}" href="{{.DashHref}}">📊 Overview</a>
-  <a class="nav-item{{if eq .ActivePage "warroom"}} active{{end}}" href="{{.WrHref}}">🚨 War Room{{if .CriticalCount}} <span class="nav-badge nav-badge-critical">{{.CriticalCount}}</span>{{end}}</a>
+  <a class="nav-item{{if eq .ActivePage "dashboard"}} active{{end}}" href="{{.DashHref}}"><span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg></span> Overview</a>
+  <a class="nav-item{{if eq .ActivePage "warroom"}} active{{end}}" href="{{.WrHref}}"><span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><polygon points="7.86 2 16.14 2 22 7.86 22 16.14 16.14 22 7.86 22 2 16.14 2 7.86 7.86 2"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg></span> War Room{{if .CriticalCount}} <span class="nav-badge nav-badge-critical">{{.CriticalCount}}</span>{{end}}</a>
 </div>
 
 <div class="nav-section">
   <div class="nav-label">Investigate</div>
-  <a class="nav-item{{if eq .ActivePage "incidents"}} active{{end}}" href="{{.IncidentsHref}}">🔍 Incidents</a>
-  <a class="nav-item{{if eq .ActivePage "infrastructure"}} active{{end}}" href="{{.InfraHref}}">🖥️ Infrastructure</a>
+  <a class="nav-item{{if eq .ActivePage "incidents"}} active{{end}}" href="{{.IncidentsHref}}"><span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg></span> Incidents</a>
+  <a class="nav-item{{if eq .ActivePage "infrastructure"}} active{{end}}" href="{{.InfraHref}}"><span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg></span> Infrastructure</a>
 </div>
 
 <div class="nav-section">
   <div class="nav-label">Analyze</div>
-  <a class="nav-item{{if eq .ActivePage "costs"}} active{{end}}" href="{{.CostsHref}}">💰 Cost Intelligence</a>
-  <a class="nav-item{{if eq .ActivePage "security"}} active{{end}}" href="{{.SecurityHref}}">🔒 Security Posture</a>
-  <a class="nav-item{{if eq .ActivePage "waste"}} active{{end}}" href="{{.WasteHref}}">🗑️ Waste & Drift</a>
+  <a class="nav-item{{if eq .ActivePage "costs"}} active{{end}}" href="{{.CostsHref}}"><span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="2" x2="12" y2="22"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg></span> Cost Intelligence</a>
+  <a class="nav-item{{if eq .ActivePage "security"}} active{{end}}" href="{{.SecurityHref}}"><span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg></span> Security Posture</a>
+  <a class="nav-item{{if eq .ActivePage "waste"}} active{{end}}" href="{{.WasteHref}}"><span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/></svg></span> Waste &amp; Drift</a>
 </div>
 
 <div class="nav-footer">
@@ -40,6 +40,6 @@
     {{end}}
   </div>
   <div class="nav-divider"></div>
-  <a class="nav-item{{if eq .ActivePage "settings"}} active{{end}}" href="/settings">⚙️ Settings</a>
+  <a class="nav-item{{if eq .ActivePage "settings"}} active{{end}}" href="/settings"><span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14M4.93 4.93a10 10 0 0 0 0 14.14"/></svg></span> Settings</a>
 </div>
 </aside>

--- a/cmd/opscart-dashboard/templates/stub.html
+++ b/cmd/opscart-dashboard/templates/stub.html
@@ -11,7 +11,7 @@
 {{template "sidebar.html" .}}
 <main class="main">
 <div class="empty-state" style="height:70vh;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:1rem">
-  <div style="font-size:2.5rem">🚧</div>
+  <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="color:var(--warning)"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg>
   <h2 style="font-size:1.5rem;font-weight:700;margin:0">{{.Title}}</h2>
   <p style="color:var(--text-muted);margin:0">Coming in v1.1</p>
   <a href="{{.DashHref}}" class="back-link">← Back to Overview</a>

--- a/cmd/opscart-dashboard/templates/warroom.html
+++ b/cmd/opscart-dashboard/templates/warroom.html
@@ -53,7 +53,7 @@
 <main class="main">
   <div class="page-hdr">
     <div>
-      <h1>🚨 War Room</h1>
+      <h1>War Room</h1>
       <p>{{.ClusterName}} &mdash; {{.StatusDesc}}</p>
     </div>
     <div class="page-meta">

--- a/cmd/opscart-dashboard/templates/waste.html
+++ b/cmd/opscart-dashboard/templates/waste.html
@@ -58,7 +58,7 @@
 <main class="main">
   <div class="page-hdr">
     <div>
-      <h1>🗑️ Waste &amp; Drift</h1>
+      <h1>Waste &amp; Drift</h1>
       <p>Unused and forgotten resources</p>
     </div>
     <div class="page-meta">


### PR DESCRIPTION
- Sidebar: overview, warroom, incidents, infrastructure, cost, security, waste, settings all using SVG
- KPI cards: alert-triangle, alert-circle, shield, trash, dollar
- Page titles: removed emojis from all section headers
- Clusters KPI: Kubernetes wheel SVG
- Empty states: kept decorative emojis (not navigation)