### PR TITLE
feat: Investigation page - Detection → Investigation → Resolution

### DIFF
--- a/cmd/opscart-dashboard/investigation.go
+++ b/cmd/opscart-dashboard/investigation.go
@@ -1,0 +1,339 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"html/template"
+	"log"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// ── Investigation page ────────────────────────────────────────────────────────
+
+type investigationEvent struct {
+	Type    string // Normal / Warning
+	Reason  string
+	Message string
+	Age     string
+	Count   int32
+}
+
+type investigationPageData struct {
+	// Sidebar fields
+	DashHref      string
+	WrHref        string
+	CostsHref     string
+	InfraHref     string
+	WasteHref     string
+	SecurityHref  string
+	IncidentsHref string
+	ActivePage    string
+	ClusterName   string
+	CriticalCount int
+	Clusters      []sidebarCluster
+
+	// Pod identity
+	PodName   string
+	Namespace string
+	IssueType string // crash_loop, image_pull, oom_killed, privileged
+	Severity  string
+	OwnerKind string // Deployment / StatefulSet / Job / (none)
+	OwnerName string
+
+	// Status
+	Phase       string
+	Restarts    int32
+	AgeDays     int
+	StateReason string // CrashLoopBackOff, ImagePullBackOff...
+	NotFound    bool   // pod deleted since scan
+
+	// Sections
+	Hints      []string             // possible causes
+	Commands   []string             // investigation kubectl commands
+	Events     []investigationEvent // last 10, this pod only
+	ConfigMaps []string
+	Secrets    []string
+	PVCs       []string
+
+	ScannedAtMs int64
+	BackURL     string
+}
+
+func investigationHints(issueType string, stateReason string, restarts int32) []string {
+	var hints []string
+	switch issueType {
+	case "crash_loop":
+		hints = append(hints,
+			"Check application logs with --previous flag — the container is exiting after start",
+			"Verify referenced ConfigMaps and Secrets exist and contain expected keys",
+			"Check liveness probe configuration — an aggressive probe can kill healthy containers",
+			"If restarts climb steadily, the failure is deterministic (config/code), not transient")
+		if restarts > 100 {
+			hints = append(hints,
+				"Restart count is very high — this workload has been failing unattended; check ownership")
+		}
+	case "image_pull":
+		hints = append(hints,
+			"Verify the image tag exists in the registry — typos and deleted tags are the most common cause",
+			"Check imagePullSecrets are present in the namespace and referenced by the pod spec",
+			"If the registry is private, confirm credentials have not expired",
+			"Run kubectl describe pod and read the Events section for the exact registry error")
+	case "oom_killed":
+		hints = append(hints,
+			"Memory limit is lower than actual usage — check resources.limits.memory",
+			"For JVM workloads, ensure heap settings respect the container limit",
+			"Compare requests vs limits — a large gap can hide steady memory growth",
+			"If OOM kills are periodic, look for a batch operation or cache growth pattern")
+	case "privileged":
+		hints = append(hints,
+			"Confirm this workload genuinely needs privileged mode — most do not",
+			"Consider replacing privileged: true with specific capabilities via securityContext.capabilities.add",
+			"If it is a CSI/CNI driver, privileged may be required — document the exception")
+	default:
+		hints = append(hints,
+			"Run kubectl describe on the resource and read the Events section",
+			"Check recent changes to this namespace — deployments, config updates, secret rotations")
+	}
+	return hints
+}
+
+// resolveOwner walks Pod → ReplicaSet → Deployment (or returns the direct owner).
+func resolveOwner(clientset *kubernetes.Clientset, pod *corev1.Pod) (kind, name string) {
+	if len(pod.OwnerReferences) == 0 {
+		return "", ""
+	}
+	ref := pod.OwnerReferences[0]
+	kind, name = ref.Kind, ref.Name
+
+	// If owned by a ReplicaSet, walk up to the Deployment
+	if ref.Kind == "ReplicaSet" {
+		rs, err := clientset.AppsV1().ReplicaSets(pod.Namespace).Get(
+			context.TODO(), ref.Name, metav1.GetOptions{})
+		if err == nil && len(rs.OwnerReferences) > 0 {
+			parent := rs.OwnerReferences[0]
+			kind, name = parent.Kind, parent.Name
+		}
+	}
+	return kind, name
+}
+
+// podEvents returns the last n events for a specific pod, newest first.
+func podEvents(clientset *kubernetes.Clientset, namespace, podName string, n int) []investigationEvent {
+	evList, err := clientset.CoreV1().Events(namespace).List(context.TODO(), metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=Pod", podName),
+	})
+	if err != nil {
+		log.Printf("investigation: listing events for %s/%s: %v", namespace, podName, err)
+		return nil
+	}
+
+	events := evList.Items
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].LastTimestamp.After(events[j].LastTimestamp.Time)
+	})
+	if len(events) > n {
+		events = events[:n]
+	}
+
+	var out []investigationEvent
+	for _, e := range events {
+		age := "unknown"
+		if !e.LastTimestamp.IsZero() {
+			age = humanAge(time.Since(e.LastTimestamp.Time))
+		}
+		out = append(out, investigationEvent{
+			Type:    e.Type,
+			Reason:  e.Reason,
+			Message: e.Message,
+			Age:     age,
+			Count:   e.Count,
+		})
+	}
+	return out
+}
+
+func humanAge(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}
+
+// referencedNames pulls ConfigMap/Secret/PVC names actually referenced by the pod spec.
+func referencedResources(pod *corev1.Pod) (cms, secrets, pvcs []string) {
+	seen := map[string]bool{}
+	add := func(list *[]string, name string) {
+		key := name
+		if !seen[key] && name != "" {
+			seen[key] = true
+			*list = append(*list, name)
+		}
+	}
+	for _, v := range pod.Spec.Volumes {
+		if v.ConfigMap != nil {
+			add(&cms, "cm:"+v.ConfigMap.Name)
+		}
+		if v.Secret != nil {
+			add(&secrets, "sec:"+v.Secret.SecretName)
+		}
+		if v.PersistentVolumeClaim != nil {
+			add(&pvcs, "pvc:"+v.PersistentVolumeClaim.ClaimName)
+		}
+	}
+	for _, c := range pod.Spec.Containers {
+		for _, ef := range c.EnvFrom {
+			if ef.ConfigMapRef != nil {
+				add(&cms, "cm:"+ef.ConfigMapRef.Name)
+			}
+			if ef.SecretRef != nil {
+				add(&secrets, "sec:"+ef.SecretRef.Name)
+			}
+		}
+		for _, e := range c.Env {
+			if e.ValueFrom != nil && e.ValueFrom.ConfigMapKeyRef != nil {
+				add(&cms, "cm:"+e.ValueFrom.ConfigMapKeyRef.Name)
+			}
+			if e.ValueFrom != nil && e.ValueFrom.SecretKeyRef != nil {
+				add(&secrets, "sec:"+e.ValueFrom.SecretKeyRef.Name)
+			}
+		}
+	}
+	// strip prefixes used for dedup
+	clean := func(list []string) []string {
+		out := make([]string, 0, len(list))
+		for _, s := range list {
+			out = append(out, s[strings.Index(s, ":")+1:])
+		}
+		return out
+	}
+	return clean(cms), clean(secrets), clean(pvcs)
+}
+
+func (srv *server) handleInvestigationPage(w http.ResponseWriter, r *http.Request) {
+	ctx := srv.activeCtx(r)
+	podName := r.URL.Query().Get("pod")
+	namespace := r.URL.Query().Get("ns")
+	issueType := r.URL.Query().Get("type")
+
+	if podName == "" || namespace == "" {
+		http.Error(w, "missing pod or ns query parameter", http.StatusBadRequest)
+		return
+	}
+
+	// Sidebar needs critical count from the cached scan
+	state := srv.getState(ctx)
+	state.mu.RLock()
+	scan := state.scan
+	state.mu.RUnlock()
+
+	q := "?cluster=" + url.QueryEscape(ctx)
+	data := investigationPageData{
+		DashHref:      "/" + q,
+		WrHref:        "/warroom" + q,
+		CostsHref:     "/costs" + q,
+		InfraHref:     "/infrastructure" + q,
+		WasteHref:     "/waste" + q,
+		SecurityHref:  "/security" + q,
+		IncidentsHref: "/incidents" + q,
+		ActivePage:    "incidents",
+		ClusterName:   displayName(ctx),
+		CriticalCount: countCriticalIssues(scan),
+		PodName:       podName,
+		Namespace:     namespace,
+		IssueType:     issueType,
+		BackURL:       "/warroom" + q,
+		ScannedAtMs:   time.Now().UnixMilli(),
+	}
+
+	// Live cluster data — fresh client, not scan cache
+	clientset, err := kubeClient(ctx)
+	if err != nil {
+		log.Printf("investigation: kube client: %v", err)
+		http.Error(w, "cluster connection failed", http.StatusBadGateway)
+		return
+	}
+
+	pod, err := clientset.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	if err != nil {
+		// Pod may have been deleted/recreated since the scan
+		data.NotFound = true
+		data.Hints = []string{
+			"This pod no longer exists — it may have been deleted or recreated with a new name",
+			"Check current pods in the namespace: kubectl get pods -n " + namespace,
+			"If owned by a Deployment, a replacement pod likely exists with a different suffix",
+		}
+		data.Commands = []string{
+			fmt.Sprintf("kubectl get pods -n %s", namespace),
+			fmt.Sprintf("kubectl get events -n %s --sort-by='.lastTimestamp'", namespace),
+		}
+		renderInvestigation(w, data)
+		return
+	}
+
+	// Status
+	data.Phase = string(pod.Status.Phase)
+	data.AgeDays = int(time.Since(pod.CreationTimestamp.Time).Hours() / 24)
+	data.Severity = "critical"
+	for _, cs := range pod.Status.ContainerStatuses {
+		data.Restarts += cs.RestartCount
+		if cs.State.Waiting != nil && data.StateReason == "" {
+			data.StateReason = cs.State.Waiting.Reason
+		}
+	}
+
+	// Owner, events, related resources, hints
+	data.OwnerKind, data.OwnerName = resolveOwner(clientset, pod)
+	data.Events = podEvents(clientset, namespace, podName, 10)
+	data.ConfigMaps, data.Secrets, data.PVCs = referencedResources(pod)
+	data.Hints = investigationHints(issueType, data.StateReason, data.Restarts)
+
+	// Investigation commands
+	data.Commands = []string{
+		fmt.Sprintf("kubectl logs %s -n %s --previous", podName, namespace),
+		fmt.Sprintf("kubectl describe pod %s -n %s", podName, namespace),
+		fmt.Sprintf("kubectl get events -n %s --field-selector involvedObject.name=%s", namespace, podName),
+	}
+	if data.OwnerKind == "Deployment" {
+		data.Commands = append(data.Commands,
+			fmt.Sprintf("kubectl rollout history deployment/%s -n %s", data.OwnerName, namespace))
+	}
+
+	renderInvestigation(w, data)
+}
+
+var getInvestigationTmpl = sync.OnceValue(func() *template.Template {
+	return template.Must(
+		template.New("investigation.html").
+			ParseFS(templateFS,
+				"templates/base.html",
+				"templates/sidebar.html",
+				"templates/investigation.html"),
+	)
+})
+
+func renderInvestigation(w http.ResponseWriter, data investigationPageData) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+	var buf strings.Builder
+	if err := getInvestigationTmpl().Execute(&buf, data); err != nil {
+		log.Printf("investigation template: %v", err)
+		http.Error(w, "template error", http.StatusInternalServerError)
+		return
+	}
+	w.Write([]byte(buf.String()))
+}

--- a/cmd/opscart-dashboard/main.go
+++ b/cmd/opscart-dashboard/main.go
@@ -282,6 +282,7 @@ func runDashboard(_ *cobra.Command, _ []string) error {
 	mux.HandleFunc("/namespaces", srv.handleNamespacesPage)
 	mux.HandleFunc("/optimizations", srv.handleOptimizationsPage)
 	mux.HandleFunc("/healthz", handleHealth)
+	mux.HandleFunc("/investigate", srv.handleInvestigationPage)
 	mux.HandleFunc("/incidents", srv.handleIncidentsPage)
 	mux.HandleFunc("/security", srv.handleSecurityPage)
 	mux.HandleFunc("/waste", srv.handleWastePage)
@@ -1572,6 +1573,16 @@ func renderWarRoomCard(issue warRoomIssue) string {
 	sb.WriteString(fmt.Sprintf(`<code>%s</code>`, issue.KubectlCmd))
 	sb.WriteString(`<button class="copy-btn" onclick="var b=this,c=this.previousElementSibling.textContent;navigator.clipboard.writeText(c).then(function(){b.textContent='✓';setTimeout(function(){b.textContent='Copy'},1500)})">Copy</button>`)
 	sb.WriteString(`</div>`)
+	// Investigate button — links to investigation page
+	if issue.Resource != "" && issue.Namespace != "" {
+		investigateURL := fmt.Sprintf("/investigate?pod=%s&ns=%s&type=%s",
+			url.QueryEscape(issue.Resource),
+			url.QueryEscape(issue.Namespace),
+			url.QueryEscape(issue.Type))
+		sb.WriteString(fmt.Sprintf(
+			`<a class="investigate-btn" href="%s">Investigate →</a>`,
+			investigateURL))
+	}
 	sb.WriteString(`</div>`)
 	return sb.String()
 }

--- a/cmd/opscart-dashboard/templates/investigation.html
+++ b/cmd/opscart-dashboard/templates/investigation.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>Investigation — {{.PodName}}</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+{{template "base" .}}
+<style>
+.inv-bar{display:flex;gap:1rem;margin-bottom:2rem;flex-wrap:wrap}
+.inv-chip{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);padding:0.75rem 1.25rem;display:flex;align-items:center;gap:0.75rem}
+.inv-chip.danger{border-color:rgba(239,68,68,0.35);background:rgba(239,68,68,0.025)}
+.inv-chip-label{font-size:0.72rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;line-height:1.3}
+.inv-chip-value{font-size:1.1rem;font-weight:700;color:var(--text);margin-top:0.1rem}
+.inv-badge{display:inline-flex;padding:2px 9px;border-radius:20px;font-size:0.7rem;font-weight:700;background:rgba(239,68,68,0.15);color:#f87171;text-transform:uppercase;letter-spacing:0.5px}
+.inv-state-reason{font-size:0.78rem;color:var(--text-muted);margin-top:0.25rem}
+.inv-section{margin-bottom:2.5rem}
+.inv-section-hdr{display:flex;align-items:center;gap:0.75rem;margin-bottom:1rem;padding-bottom:0.75rem;border-bottom:1px solid var(--border)}
+.inv-section-hdr h2{font-size:1rem;font-weight:700}
+.inv-hints{display:flex;flex-direction:column;gap:0.5rem}
+.inv-hint{display:flex;align-items:flex-start;gap:0.75rem;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);padding:0.85rem 1rem}
+.inv-hint-icon{color:var(--warning);flex-shrink:0;margin-top:2px}
+.inv-hint-text{font-size:0.85rem;color:var(--text);line-height:1.5}
+.inv-cmds{display:flex;flex-direction:column;gap:0.5rem}
+.inv-cmd{display:flex;align-items:center;gap:0.75rem;background:rgba(0,0,0,0.3);border:1px solid var(--border);border-radius:var(--radius-sm);padding:0.65rem 0.9rem}
+.inv-cmd code{font-family:'Consolas','Monaco',monospace;font-size:0.78rem;color:var(--primary-light);flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.wr-copy-btn{background:transparent;border:1px solid var(--border);border-radius:4px;color:var(--text-muted);cursor:pointer;font-size:0.64rem;padding:2px 8px;white-space:nowrap;transition:all 0.15s;flex-shrink:0;font-family:inherit}
+.wr-copy-btn:hover{background:var(--surface-hover);color:var(--text)}
+.inv-events-wrap{overflow-x:auto}
+.inv-events-tbl{width:100%;border-collapse:collapse;font-size:0.82rem}
+.inv-events-tbl th{text-align:left;padding:0.6rem 0.75rem;font-size:0.7rem;text-transform:uppercase;letter-spacing:0.5px;color:var(--text-muted);border-bottom:1px solid var(--border);font-weight:600}
+.inv-events-tbl td{padding:0.6rem 0.75rem;border-bottom:1px solid rgba(51,65,85,0.5);vertical-align:top;color:var(--text-secondary)}
+.inv-events-tbl tr:last-child td{border-bottom:none}
+.inv-events-tbl tr.evt-warning>td:first-child{border-left:3px solid var(--danger);padding-left:0.6rem}
+.inv-events-tbl tr.evt-normal>td:first-child{border-left:3px solid transparent;padding-left:0.6rem}
+.inv-evt-type-warning{color:#f87171;font-weight:600;font-size:0.75rem}
+.inv-evt-type-normal{color:var(--text-muted);font-size:0.75rem}
+.inv-evt-reason{font-weight:600;color:var(--text)}
+.inv-evt-count{font-variant-numeric:tabular-nums;text-align:center}
+.inv-evt-msg{color:var(--text-secondary);line-height:1.4;max-width:340px}
+.inv-empty{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);padding:2rem;text-align:center;color:var(--text-muted);font-size:0.85rem}
+.inv-resources{display:grid;grid-template-columns:repeat(3,1fr);gap:1rem}
+.inv-res-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);padding:1rem 1.25rem}
+.inv-res-title{font-size:0.7rem;text-transform:uppercase;letter-spacing:0.5px;color:var(--text-muted);margin-bottom:0.65rem;font-weight:600}
+.inv-res-list{display:flex;flex-direction:column;gap:0.3rem}
+.inv-res-item{font-size:0.8rem;color:var(--text-secondary);font-family:'Consolas','Monaco',monospace}
+.inv-res-none{font-size:0.8rem;color:var(--text-muted);font-style:italic}
+.inv-notice{background:rgba(245,158,11,0.06);border:1px solid rgba(245,158,11,0.3);border-radius:var(--radius);padding:1.5rem;display:flex;align-items:flex-start;gap:1rem;margin-bottom:2rem}
+.inv-notice-icon{color:var(--warning);flex-shrink:0;margin-top:2px}
+.inv-notice-text{font-size:0.9rem;color:var(--text);line-height:1.5}
+@media(max-width:768px){.inv-resources{grid-template-columns:1fr}.inv-bar{flex-direction:column}}
+</style>
+</head>
+<body>
+<div class="layout">
+{{template "sidebar.html" .}}
+<main class="main">
+  <div class="page-hdr">
+    <div>
+      <h1>Investigation</h1>
+      <p>{{.Namespace}} / {{.PodName}}</p>
+    </div>
+    <div class="page-meta">
+      <div>Last scanned: <strong id="inv-age">just now</strong></div>
+      <a class="back-link" href="{{.BackURL}}">← Back to War Room</a>
+    </div>
+  </div>
+
+  {{if .NotFound}}
+
+  <div class="inv-notice">
+    <div class="inv-notice-icon">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+    </div>
+    <div class="inv-notice-text">Pod not found — it may have been deleted or recreated</div>
+  </div>
+
+  {{if .Hints}}
+  <div class="inv-section">
+    <div class="inv-section-hdr">
+      <h2>Possible Causes</h2>
+    </div>
+    <div class="inv-hints">
+      {{range .Hints}}
+      <div class="inv-hint">
+        <div class="inv-hint-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg></div>
+        <div class="inv-hint-text">{{.}}</div>
+      </div>
+      {{end}}
+    </div>
+  </div>
+  {{end}}
+
+  {{if .Commands}}
+  <div class="inv-section">
+    <div class="inv-section-hdr">
+      <h2>Investigation Commands</h2>
+    </div>
+    <div class="inv-cmds">
+      {{range .Commands}}
+      <div class="inv-cmd"><code>{{.}}</code><button class="wr-copy-btn" onclick="navigator.clipboard.writeText('{{.}}')">Copy</button></div>
+      {{end}}
+    </div>
+  </div>
+  {{end}}
+
+  {{else}}
+
+  <div class="inv-bar">
+    <div class="inv-chip danger">
+      <div>
+        <div class="inv-badge">CRITICAL</div>
+        {{if .StateReason}}<div class="inv-state-reason">{{.StateReason}}</div>{{end}}
+      </div>
+    </div>
+    <div class="inv-chip">
+      <div>
+        <div class="inv-chip-label">Restarts</div>
+        <div class="inv-chip-value">{{.Restarts}}</div>
+      </div>
+    </div>
+    <div class="inv-chip">
+      <div>
+        <div class="inv-chip-label">Age</div>
+        <div class="inv-chip-value">{{.AgeDays}}d</div>
+      </div>
+    </div>
+    {{if .OwnerKind}}
+    <div class="inv-chip">
+      <div>
+        <div class="inv-chip-label">Owner</div>
+        <div class="inv-chip-value">{{.OwnerKind}}/{{.OwnerName}}</div>
+      </div>
+    </div>
+    {{end}}
+  </div>
+
+  {{if .Hints}}
+  <div class="inv-section">
+    <div class="inv-section-hdr">
+      <h2>Possible Causes</h2>
+    </div>
+    <div class="inv-hints">
+      {{range .Hints}}
+      <div class="inv-hint">
+        <div class="inv-hint-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg></div>
+        <div class="inv-hint-text">{{.}}</div>
+      </div>
+      {{end}}
+    </div>
+  </div>
+  {{end}}
+
+  {{if .Commands}}
+  <div class="inv-section">
+    <div class="inv-section-hdr">
+      <h2>Investigation Commands</h2>
+    </div>
+    <div class="inv-cmds">
+      {{range .Commands}}
+      <div class="inv-cmd"><code>{{.}}</code><button class="wr-copy-btn" onclick="navigator.clipboard.writeText('{{.}}')">Copy</button></div>
+      {{end}}
+    </div>
+  </div>
+  {{end}}
+
+  <div class="inv-section">
+    <div class="inv-section-hdr">
+      <h2>Recent Events</h2>
+    </div>
+    {{if .Events}}
+    <div class="inv-events-wrap">
+      <table class="inv-events-tbl">
+        <thead>
+          <tr>
+            <th>Type</th>
+            <th>Reason</th>
+            <th>Age</th>
+            <th>Count</th>
+            <th>Message</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{range .Events}}
+          <tr class="{{if eq .Type "Warning"}}evt-warning{{else}}evt-normal{{end}}">
+            <td><span class="{{if eq .Type "Warning"}}inv-evt-type-warning{{else}}inv-evt-type-normal{{end}}">{{.Type}}</span></td>
+            <td class="inv-evt-reason">{{.Reason}}</td>
+            <td>{{.Age}}</td>
+            <td class="inv-evt-count">{{.Count}}</td>
+            <td class="inv-evt-msg">{{.Message}}</td>
+          </tr>
+          {{end}}
+        </tbody>
+      </table>
+    </div>
+    {{else}}
+    <div class="inv-empty">No recent events recorded for this pod</div>
+    {{end}}
+  </div>
+
+  <div class="inv-section">
+    <div class="inv-section-hdr">
+      <h2>Related Resources</h2>
+    </div>
+    <div class="inv-resources">
+      <div class="inv-res-card">
+        <div class="inv-res-title">ConfigMaps</div>
+        <div class="inv-res-list">
+          {{if .ConfigMaps}}{{range .ConfigMaps}}<div class="inv-res-item">{{.}}</div>{{end}}{{else}}<div class="inv-res-none">None referenced</div>{{end}}
+        </div>
+      </div>
+      <div class="inv-res-card">
+        <div class="inv-res-title">Secrets</div>
+        <div class="inv-res-list">
+          {{if .Secrets}}{{range .Secrets}}<div class="inv-res-item">{{.}}</div>{{end}}{{else}}<div class="inv-res-none">None referenced</div>{{end}}
+        </div>
+      </div>
+      <div class="inv-res-card">
+        <div class="inv-res-title">PVCs</div>
+        <div class="inv-res-list">
+          {{if .PVCs}}{{range .PVCs}}<div class="inv-res-item">{{.}}</div>{{end}}{{else}}<div class="inv-res-none">None referenced</div>{{end}}
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {{end}}
+
+  <div class="footer">OpsCart FinOps Engine &middot; Investigation &middot; {{.Namespace}} / {{.PodName}}</div>
+</main>
+</div>
+<script>
+(function(){
+  var TS={{.ScannedAtMs}},el=document.getElementById('inv-age');
+  function upd(){
+    var s=Math.floor((Date.now()-TS)/1000);
+    var t=s<5?'just now':s<60?s+'s ago':Math.floor(s/60)+'m ago';
+    if(el)el.textContent=t;
+  }
+  setInterval(upd,1000);upd();
+})();
+</script>
+</body>
+</html>

--- a/cmd/opscart-dashboard/templates/overview.html
+++ b/cmd/opscart-dashboard/templates/overview.html
@@ -121,7 +121,7 @@
 <div class="page-hdr">
   <div>
     <h1>Overview</h1>
-    <p>Your cluster at a glance</p>
+    <p>Find what deserves attention first</p>
   </div>
 </div>
 

--- a/cmd/opscart-dashboard/templates/warroom.html
+++ b/cmd/opscart-dashboard/templates/warroom.html
@@ -39,6 +39,8 @@
 .wr-reason{font-size:0.78rem;color:var(--text-secondary);line-height:1.55;display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden}
 .wr-cmd{display:flex;align-items:center;gap:0.5rem;background:rgba(0,0,0,0.3);border:1px solid var(--border);border-radius:var(--radius-xs);padding:0.5rem 0.75rem;margin-top:auto}
 .wr-cmd code{font-family:'Consolas','Monaco',monospace;font-size:0.7rem;color:var(--primary-light);flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.investigate-btn{display:inline-flex;align-items:center;margin-top:0.75rem;padding:0.4rem 1rem;background:var(--primary-bg);color:var(--primary-light);border-radius:var(--radius-sm);font-size:0.78rem;font-weight:600;text-decoration:none;transition:background .15s}
+.investigate-btn:hover{background:rgba(99,102,241,0.2)}
 .copy-btn{background:transparent;border:1px solid var(--border);border-radius:4px;color:var(--text-muted);cursor:pointer;font-size:0.64rem;padding:2px 7px;white-space:nowrap;transition:all 0.15s;flex-shrink:0}
 .copy-btn:hover{background:var(--surface-hover);color:var(--text)}
 .all-clear-box{background:var(--surface);border:1px solid rgba(16,185,129,0.25);border-radius:var(--radius);padding:2.5rem;text-align:center;color:var(--text-muted)}

--- a/demo-broken-workloads.yaml
+++ b/demo-broken-workloads.yaml
@@ -1,0 +1,664 @@
+# OpsCart Watcher — Demo Environment
+# Realistic failure scenarios for screenshots and demos
+# Deploy: kubectl apply -f demo-broken-workloads.yaml
+# Teardown: kubectl delete -f demo-broken-workloads.yaml
+#
+# Covers: CrashLoopBackOff, ImagePullBackOff, OOMKilled,
+#         Privileged containers, Missing NetworkPolicy,
+#         Orphaned PVCs, Zero-replica workloads
+
+---
+# ── Namespaces ────────────────────────────────────────────────────
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: payments
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: inventory
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: auth
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: notifications
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: data-pipeline
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: api-gateway
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: platform-ops
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: reporting
+
+---
+# ── PAYMENTS namespace ────────────────────────────────────────────
+# 2 CrashLoopBackOff pods
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-processor
+  namespace: payments
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: payment-processor
+  template:
+    metadata:
+      labels:
+        app: payment-processor
+    spec:
+      containers:
+      - name: app
+        image: busybox:latest
+        command: ["sh", "-c", "echo 'starting payment-processor'; sleep 5; exit 1"]
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "50m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fraud-detection
+  namespace: payments
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fraud-detection
+  template:
+    metadata:
+      labels:
+        app: fraud-detection
+    spec:
+      containers:
+      - name: app
+        image: busybox:latest
+        command: ["sh", "-c", "echo 'starting fraud-detection'; sleep 3; exit 1"]
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "50m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+---
+# Healthy pods in payments (makes it look real)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-api
+  namespace: payments
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: payment-api
+  template:
+    metadata:
+      labels:
+        app: payment-api
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "50m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+
+---
+# ── INVENTORY namespace ───────────────────────────────────────────
+# 1 CrashLoopBackOff + 1 ImagePullBackOff
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inventory-sync
+  namespace: inventory
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: inventory-sync
+  template:
+    metadata:
+      labels:
+        app: inventory-sync
+    spec:
+      containers:
+      - name: app
+        image: busybox:latest
+        command: ["sh", "-c", "echo 'starting inventory-sync'; sleep 4; exit 1"]
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "50m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: catalog-indexer
+  namespace: inventory
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: catalog-indexer
+  template:
+    metadata:
+      labels:
+        app: catalog-indexer
+    spec:
+      containers:
+      - name: app
+        image: company-registry.internal/catalog-indexer:v2.1.4
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "50m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+---
+# Healthy pods in inventory
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inventory-api
+  namespace: inventory
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: inventory-api
+  template:
+    metadata:
+      labels:
+        app: inventory-api
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "50m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+
+---
+# ── AUTH namespace ────────────────────────────────────────────────
+# 1 CrashLoopBackOff + 1 privileged container
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: token-service
+  namespace: auth
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: token-service
+  template:
+    metadata:
+      labels:
+        app: token-service
+    spec:
+      containers:
+      - name: app
+        image: busybox:latest
+        command: ["sh", "-c", "echo 'starting token-service'; sleep 6; exit 1"]
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "50m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: secrets-manager
+  namespace: auth
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: secrets-manager
+  template:
+    metadata:
+      labels:
+        app: secrets-manager
+    spec:
+      containers:
+      - name: app
+        image: nginx:alpine
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "50m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+---
+# Healthy pods in auth
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: auth-api
+  namespace: auth
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: auth-api
+  template:
+    metadata:
+      labels:
+        app: auth-api
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "50m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+
+---
+# ── NOTIFICATIONS namespace ───────────────────────────────────────
+# 1 ImagePullBackOff + healthy pods
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: email-dispatcher
+  namespace: notifications
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: email-dispatcher
+  template:
+    metadata:
+      labels:
+        app: email-dispatcher
+    spec:
+      containers:
+      - name: app
+        image: company-registry.internal/email-dispatcher:v1.8.2
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "50m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: push-service
+  namespace: notifications
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: push-service
+  template:
+    metadata:
+      labels:
+        app: push-service
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "50m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+
+---
+# ── DATA-PIPELINE namespace ───────────────────────────────────────
+# 1 OOMKilled (stress container with low memory limit)
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stream-processor
+  namespace: data-pipeline
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: stream-processor
+  template:
+    metadata:
+      labels:
+        app: stream-processor
+    spec:
+      containers:
+      - name: stress
+        image: polinux/stress
+        command: ["stress"]
+        args: ["--vm", "1", "--vm-bytes", "150M", "--vm-hang", "1"]
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "50m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: batch-importer
+  namespace: data-pipeline
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: batch-importer
+  template:
+    metadata:
+      labels:
+        app: batch-importer
+    spec:
+      containers:
+      - name: app
+        image: company-registry.internal/batch-importer:v3.0.1
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "50m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+---
+# Healthy pods in data-pipeline
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pipeline-api
+  namespace: data-pipeline
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: pipeline-api
+  template:
+    metadata:
+      labels:
+        app: pipeline-api
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "50m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+
+---
+# ── API-GATEWAY namespace ─────────────────────────────────────────
+# Healthy pods, no NetworkPolicy (intentional gap)
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway
+  namespace: api-gateway
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: gateway
+  template:
+    metadata:
+      labels:
+        app: gateway
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "50m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rate-limiter
+  namespace: api-gateway
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: rate-limiter
+  template:
+    metadata:
+      labels:
+        app: rate-limiter
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "50m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+
+---
+# ── PLATFORM-OPS namespace ────────────────────────────────────────
+# Zero-replica workloads (scaled down, forgotten)
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: log-aggregator
+  namespace: platform-ops
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: log-aggregator
+  template:
+    metadata:
+      labels:
+        app: log-aggregator
+    spec:
+      containers:
+      - name: app
+        image: nginx:alpine
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-exporter
+  namespace: platform-ops
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: metrics-exporter
+    spec:
+      containers:
+      - name: app
+        image: nginx:alpine
+---
+# One healthy pod in platform-ops
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ops-dashboard
+  namespace: platform-ops
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ops-dashboard
+  template:
+    metadata:
+      labels:
+        app: ops-dashboard
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "50m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+
+---
+# ── REPORTING namespace ───────────────────────────────────────────
+# Healthy pods, no NetworkPolicy (intentional gap)
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: report-generator
+  namespace: reporting
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: report-generator
+  template:
+    metadata:
+      labels:
+        app: report-generator
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "50m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: export-service
+  namespace: reporting
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: export-service
+  template:
+    metadata:
+      labels:
+        app: export-service
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "50m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+
+---
+# ── Orphaned PVCs ─────────────────────────────────────────────────
+# 3 PVCs with no consuming pods
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-backup
+  namespace: payments
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 50Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: elastic-search-data
+  namespace: inventory
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: archive-storage
+  namespace: data-pipeline
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 10Gi


### PR DESCRIPTION
- New /investigate route with live K8s API calls (not scan cache)
- Pod status: restarts, age, state reason, owner (Deployment/RS traversal)
- Possible Causes: rules-based heuristics per issue type
- Investigation Commands: copy-paste kubectl with rollout history for Deployments
- Recent Events: last 10 events filtered to specific pod, Warning rows highlighted
- Related Resources: ConfigMaps, Secrets, PVCs referenced by pod spec
- NotFound branch: graceful handling when pod deleted/recreated
- Investigate → button wired on all War Room and Incidents cards
- investigation.go: new file pattern (handler logic out of main.go)