### PR TITLE
Feature/enhance investigation page

### DIFF
--- a/cmd/opscart-dashboard/investigation.go
+++ b/cmd/opscart-dashboard/investigation.go
@@ -57,7 +57,12 @@ type investigationPageData struct {
 	StateReason   string // CrashLoopBackOff, ImagePullBackOff...
 	NotFound      bool   // pod deleted since scan
 	FirstDetected string
-
+	// Blast radius
+	BlastSiblings   []blastRadiusPod     // sibling pods under same owner
+	BlastServices   []blastRadiusService // services routing to this deployment
+	BlastSharedConf []blastSharedDep     // other deployments sharing same CMs/Secrets
+	BlastHealthy    int                  // count of healthy siblings
+	BlastTotal      int                  // total replicas
 	// Sections
 	Hints              []investigationHint  // possible causes
 	Commands           []string             // investigation kubectl commands
@@ -76,6 +81,24 @@ type investigationHint struct {
 	Title      string
 	Reason     string
 	Command    string // optional — if this hint has a specific command
+}
+
+type blastRadiusPod struct {
+	Name    string
+	Phase   string
+	Healthy bool
+}
+
+type blastRadiusService struct {
+	Name      string
+	Namespace string
+	Type      string // ClusterIP / LoadBalancer / NodePort
+	Ports     string // "80/TCP, 443/TCP"
+}
+
+type blastSharedDep struct {
+	DeploymentName string
+	SharedItems    []string // names of the shared CMs/Secrets
 }
 
 func investigationHints(issueType string, stateReason string, restarts int32, pod *corev1.Pod) []investigationHint {
@@ -292,6 +315,185 @@ func referencedResources(pod *corev1.Pod) (cms, secrets, pvcs []string) {
 	return clean(cms), clean(secrets), clean(pvcs)
 }
 
+// blastRadiusSiblings returns all pods owned by the same workload.
+func blastRadiusSiblings(clientset *kubernetes.Clientset, namespace, ownerKind, ownerName string) (pods []blastRadiusPod, healthy, total int) {
+	if ownerName == "" {
+		return
+	}
+	list, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return
+	}
+	for _, p := range list.Items {
+		kind, name := resolveOwner(clientset, &p)
+		if kind != ownerKind || name != ownerName {
+			continue
+		}
+		// Derive kubectl-style status from container state
+		status := string(p.Status.Phase)
+		for _, cs := range p.Status.ContainerStatuses {
+			if cs.State.Waiting != nil && cs.State.Waiting.Reason != "" {
+				status = cs.State.Waiting.Reason
+				break
+			}
+			if cs.State.Terminated != nil && cs.State.Terminated.Reason != "" {
+				status = cs.State.Terminated.Reason
+				break
+			}
+		}
+		isHealthy := p.Status.Phase == corev1.PodRunning && func() bool {
+			for _, cs := range p.Status.ContainerStatuses {
+				if cs.State.Waiting != nil || !cs.Ready {
+					return false
+				}
+			}
+			return true
+		}()
+		pods = append(pods, blastRadiusPod{
+			Name:    p.Name,
+			Phase:   status,
+			Healthy: isHealthy,
+		})
+		total++
+		if isHealthy {
+			healthy++
+		}
+	}
+	return
+}
+
+// blastRadiusServices returns services whose selector matches the pod's labels.
+func blastRadiusServices(clientset *kubernetes.Clientset, namespace string, podLabels map[string]string) []blastRadiusService {
+	list, err := clientset.CoreV1().Services(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil
+	}
+	var results []blastRadiusService
+	for _, svc := range list.Items {
+		if len(svc.Spec.Selector) == 0 {
+			continue
+		}
+		if labelsMatch(svc.Spec.Selector, podLabels) {
+			ports := formatPorts(svc.Spec.Ports)
+			results = append(results, blastRadiusService{
+				Name:      svc.Name,
+				Namespace: svc.Namespace,
+				Type:      string(svc.Spec.Type),
+				Ports:     ports,
+			})
+		}
+	}
+	return results
+}
+
+// blastRadiusSharedConfig finds other Deployments in the namespace sharing CMs or Secrets with this pod.
+func blastRadiusSharedConfig(clientset *kubernetes.Clientset, namespace, selfName string, cms, secrets []string) []blastSharedDep {
+	if len(cms) == 0 && len(secrets) == 0 {
+		return nil
+	}
+	deps, err := clientset.AppsV1().Deployments(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil
+	}
+	var results []blastSharedDep
+	for _, dep := range deps.Items {
+		if dep.Name == selfName {
+			continue
+		}
+		depCMs, depSecrets, _ := referencedResourcesFromSpec(&dep.Spec.Template.Spec)
+		var shared []string
+		for _, cm := range cms {
+			if contains(depCMs, cm) {
+				shared = append(shared, "cm:"+cm)
+			}
+		}
+		for _, sec := range secrets {
+			if contains(depSecrets, sec) {
+				shared = append(shared, "secret:"+sec)
+			}
+		}
+		if len(shared) > 0 {
+			results = append(results, blastSharedDep{
+				DeploymentName: dep.Name,
+				SharedItems:    shared,
+			})
+		}
+	}
+	return results
+}
+
+// labelsMatch reports whether all selector keys/values exist in target.
+func labelsMatch(selector, target map[string]string) bool {
+	for k, v := range selector {
+		if target[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// formatPorts formats a slice of ServicePort into "80/TCP, 443/TCP".
+func formatPorts(ports []corev1.ServicePort) string {
+	var parts []string
+	for _, p := range ports {
+		parts = append(parts, fmt.Sprintf("%d/%s", p.Port, p.Protocol))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// contains reports whether slice s contains item.
+func contains(s []string, item string) bool {
+	for _, v := range s {
+		if v == item {
+			return true
+		}
+	}
+	return false
+}
+
+// referencedResourcesFromSpec extracts CM/Secret/PVC names from a PodSpec directly.
+func referencedResourcesFromSpec(spec *corev1.PodSpec) (cms, secrets, pvcs []string) {
+	seen := map[string]bool{}
+	add := func(slice *[]string, name string) {
+		if name != "" && !seen[name] {
+			seen[name] = true
+			*slice = append(*slice, name)
+		}
+	}
+	for _, v := range spec.Volumes {
+		if v.ConfigMap != nil {
+			add(&cms, v.ConfigMap.Name)
+		}
+		if v.Secret != nil {
+			add(&secrets, v.Secret.SecretName)
+		}
+		if v.PersistentVolumeClaim != nil {
+			add(&pvcs, v.PersistentVolumeClaim.ClaimName)
+		}
+	}
+	for _, c := range append(spec.InitContainers, spec.Containers...) {
+		for _, e := range c.EnvFrom {
+			if e.ConfigMapRef != nil {
+				add(&cms, e.ConfigMapRef.Name)
+			}
+			if e.SecretRef != nil {
+				add(&secrets, e.SecretRef.Name)
+			}
+		}
+		for _, e := range c.Env {
+			if e.ValueFrom != nil {
+				if e.ValueFrom.ConfigMapKeyRef != nil {
+					add(&cms, e.ValueFrom.ConfigMapKeyRef.Name)
+				}
+				if e.ValueFrom.SecretKeyRef != nil {
+					add(&secrets, e.ValueFrom.SecretKeyRef.Name)
+				}
+			}
+		}
+	}
+	return
+}
+
 func (srv *server) handleInvestigationPage(w http.ResponseWriter, r *http.Request) {
 	ctx := srv.activeCtx(r)
 	podName := r.URL.Query().Get("pod")
@@ -369,6 +571,11 @@ func (srv *server) handleInvestigationPage(w http.ResponseWriter, r *http.Reques
 	data.Events = podEvents(clientset, namespace, podName, 10)
 	data.ConfigMaps, data.Secrets, data.PVCs = referencedResources(pod)
 	data.Hints = investigationHints(issueType, data.StateReason, data.Restarts, pod)
+
+	// Blast radius
+	data.BlastSiblings, data.BlastHealthy, data.BlastTotal = blastRadiusSiblings(clientset, namespace, data.OwnerKind, data.OwnerName)
+	data.BlastServices = blastRadiusServices(clientset, namespace, pod.Labels)
+	data.BlastSharedConf = blastRadiusSharedConfig(clientset, namespace, data.OwnerName, data.ConfigMaps, data.Secrets)
 
 	// ── NEW: First detected (from incidents table) ────────────────────────────
 	ownerNameForFP := data.OwnerName

--- a/cmd/opscart-dashboard/investigation.go
+++ b/cmd/opscart-dashboard/investigation.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/opscart/opscart-k8s-watcher/pkg/store"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -50,11 +51,12 @@ type investigationPageData struct {
 	OwnerName string
 
 	// Status
-	Phase       string
-	Restarts    int32
-	AgeDays     int
-	StateReason string // CrashLoopBackOff, ImagePullBackOff...
-	NotFound    bool   // pod deleted since scan
+	Phase         string
+	Restarts      int32
+	AgeDays       int
+	StateReason   string // CrashLoopBackOff, ImagePullBackOff...
+	NotFound      bool   // pod deleted since scan
+	FirstDetected string
 
 	// Sections
 	Hints              []investigationHint  // possible causes
@@ -368,6 +370,17 @@ func (srv *server) handleInvestigationPage(w http.ResponseWriter, r *http.Reques
 	data.ConfigMaps, data.Secrets, data.PVCs = referencedResources(pod)
 	data.Hints = investigationHints(issueType, data.StateReason, data.Restarts, pod)
 
+	// ── NEW: First detected (from incidents table) ────────────────────────────
+	ownerNameForFP := data.OwnerName
+	if ownerNameForFP == "" {
+		ownerNameForFP = store.OwnerNameFromPod(podName)
+	}
+	fp := store.Fingerprint(namespace, "Workload", ownerNameForFP, issueType)
+	if rec, err := srv.db.GetIncidentHistory(ctx, fp); err == nil && rec != nil {
+		data.FirstDetected = firstDetectedLabel(rec.FirstSeen)
+	}
+	// ── END NEW
+
 	// Investigation commands
 	data.OperationalSummary = buildOperationalSummary(&data)
 	if data.OwnerKind == "Deployment" {
@@ -456,4 +469,21 @@ func max(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// firstDetectedLabel converts a first_seen timestamp to a human label.
+// Returns "today", "1 day ago", "N days ago", or "" for zero time.
+func firstDetectedLabel(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	days := int(time.Since(t).Hours() / 24)
+	switch days {
+	case 0:
+		return "today"
+	case 1:
+		return "1 day ago"
+	default:
+		return fmt.Sprintf("%d days ago", days)
+	}
 }

--- a/cmd/opscart-dashboard/templates/investigation.html
+++ b/cmd/opscart-dashboard/templates/investigation.html
@@ -205,6 +205,66 @@
       </div>
     </div>
   </div>
+{{if or .BlastSiblings .BlastServices .BlastSharedConf}}
+<div class="inv-section">
+  <div class="inv-section-hdr">
+    <h2>Blast Radius</h2>
+    {{if .BlastTotal}}
+    <span style="font-size:0.8rem;color:var(--text-muted);margin-left:auto">
+      {{.BlastHealthy}}/{{.BlastTotal}} replicas healthy
+    </span>
+    {{end}}
+  </div>
+
+  {{if .BlastSiblings}}
+  <div style="margin-bottom:1.25rem">
+    <div class="inv-evidence-label" style="margin-bottom:0.6rem">Sibling Pods</div>
+    <div style="display:flex;flex-wrap:wrap;gap:0.5rem">
+      {{range .BlastSiblings}}
+      <span style="font-size:0.75rem;font-family:monospace;padding:3px 10px;border-radius:20px;
+        background:{{if .Healthy}}rgba(34,197,94,0.1){{else}}rgba(239,68,68,0.1){{end}};
+        color:{{if .Healthy}}#4ade80{{else}}#f87171{{end}};
+        border:1px solid {{if .Healthy}}rgba(34,197,94,0.25){{else}}rgba(239,68,68,0.25){{end}}">
+        {{.Name}} <span style="opacity:0.6">({{.Phase}})</span>
+      </span>
+      {{end}}
+    </div>
+  </div>
+  {{end}}
+
+  {{if .BlastServices}}
+  <div style="margin-bottom:1.25rem">
+    <div class="inv-evidence-label" style="margin-bottom:0.6rem">Services routing to this workload</div>
+    <div style="display:flex;flex-wrap:wrap;gap:0.5rem">
+      {{range .BlastServices}}
+      <div class="inv-evidence-chip">
+        <div class="inv-evidence-label">{{.Type}}</div>
+        <div class="inv-evidence-value" style="font-size:0.85rem">{{.Name}}</div>
+        {{if .Ports}}<div style="font-size:0.72rem;color:var(--text-muted);margin-top:0.2rem">{{.Ports}}</div>{{end}}
+      </div>
+      {{end}}
+    </div>
+  </div>
+  {{end}}
+
+  {{if .BlastSharedConf}}
+  <div>
+    <div class="inv-evidence-label" style="margin-bottom:0.6rem">Deployments sharing same config</div>
+    <div style="display:flex;flex-direction:column;gap:0.4rem">
+      {{range .BlastSharedConf}}
+      <div class="inv-hint" style="padding:0.65rem 1rem">
+        <span style="font-size:0.82rem;font-weight:600;color:var(--text)">{{.DeploymentName}}</span>
+        <span style="font-size:0.75rem;color:var(--text-muted);margin-left:0.75rem">
+          shares: {{range $i,$v := .SharedItems}}{{if $i}}, {{end}}{{$v}}{{end}}
+        </span>
+      </div>
+      {{end}}
+    </div>
+  </div>
+  {{end}}
+
+</div>
+{{end}}
 
   {{if .Hints}}
   <div class="inv-section">

--- a/cmd/opscart-dashboard/templates/investigation.html
+++ b/cmd/opscart-dashboard/templates/investigation.html
@@ -151,6 +151,14 @@
         <div class="inv-chip-value">{{.AgeDays}}d</div>
       </div>
     </div>
+    {{if .FirstDetected}}
+    <div class="inv-chip">
+      <div>
+        <div class="inv-chip-label">First detected</div>
+        <div class="inv-chip-value">{{.FirstDetected}}</div>
+      </div>
+    </div>
+    {{end}}
     {{if .OwnerKind}}
     <div class="inv-chip">
       <div>
@@ -172,7 +180,13 @@
     <div class="inv-section-hdr">
       <h2>Evidence</h2>
     </div>
-    <div class="inv-evidence">
+<div class="inv-evidence">
+      {{if .FirstDetected}}
+      <div class="inv-evidence-chip">
+        <div class="inv-evidence-label">First detected</div>
+        <div class="inv-evidence-value">{{.FirstDetected}}</div>
+      </div>
+      {{end}}
       <div class="inv-evidence-chip">
         <div class="inv-evidence-label">Restarts</div>
         <div class="inv-evidence-value">{{.Restarts}}</div>


### PR DESCRIPTION
Surface impact scope on the Investigation page with three subsections:
- Sibling pods: all pods under the same owner with kubectl-accurate
  status (CrashLoopBackOff/ImagePullBackOff, not just Phase)
- Services routing to this workload via label selector match
- Deployments in the same namespace sharing ConfigMaps or Secrets