### PR TITLE
Feature/pvc persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ kubectl port-forward -n opscart-system svc/opscart-watcher 8080:80
 open http://localhost:8080
 ```
 
+Incident history persists on a PVC by default — see the [chart README](helm/opscart-watcher/README.md) for storage options and minikube-specific notes. The raw manifest below is a quickstart; the Helm chart is canonical.
+
 ### kubectl
 
 ```bash
@@ -81,8 +83,10 @@ go build -o opscart-dashboard ./cmd/opscart-dashboard
 
 **Investigation** — One click from detection to investigation. Every incident includes:
 - OpsCart Assessment: what the pattern means and estimated investigation time
-- Evidence: restart count, state, age, owner
-- Recommended Investigation: High / Medium / Low confidence hints with specific kubectl commands
+- Incident Timeline: an operational journal — first detected, restart milestones, severity changes, resolved/reoccurred — persisted across pod restarts
+- Evidence: severity, first detected, restart count, state, age, owner
+- Blast Radius: replicas down, sibling pod health, services routing to the workload, ingress exposure, namespace-wide health, and a customer-impact heuristic (internal vs. possible external traffic)
+- Recommended Investigation: numbered steps with High / Medium / Low confidence and specific kubectl commands
 - Recent Events: last 10 events filtered to this pod
 - Related Resources: ConfigMaps, Secrets, PVCs referenced by the pod spec
 
@@ -98,9 +102,9 @@ go build -o opscart-dashboard ./cmd/opscart-dashboard
 
 ### Platform
 
-**Operational Memory** — OpsCart remembers what happened. A lightweight local database tracks cluster snapshots, incident history (first seen, last seen, active/resolved), and scan metadata. Powers trend arrows, sparklines, and incident age on the Investigation page. Backed by SQLite (~5MB), stored at `/data/opscart.db`.
+**Operational Memory** — OpsCart remembers what happened. A lightweight local database tracks cluster snapshots, incident lifecycle (detected → milestones → resolved → reopened) as an append-only event journal, and scan metadata. Powers trend arrows, sparklines, incident age, and the per-incident timeline. Backed by SQLite, persisted on a PVC that survives pod restarts and `helm uninstall`.
 
-**Helm Chart** — Full Helm chart with configurable values, read-only RBAC, non-root security context, and EmptyDir volume for persistence.
+**Helm Chart** — Full Helm chart with configurable values, PVC-backed persistence, read-only RBAC, and non-root security context. See the [chart README](helm/opscart-watcher/README.md) for persistence options, minikube notes, and all values.
 
 **Agentless** — Runs as a single container. No sidecars, no DaemonSets, no node access, no cloud credentials.
 
@@ -142,14 +146,9 @@ OpsCart is not a replacement for these tools. It is the triage layer that tells 
 
 ## Helm Configuration
 
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `image.repository` | `ghcr.io/opscart/opscart-dashboard` | Image repository |
-| `image.tag` | `latest` | Image tag |
-| `namespace.name` | `opscart-system` | Target namespace |
-| `service.type` | `ClusterIP` | Service type |
-| `resources.requests.memory` | `64Mi` | Memory request |
-| `resources.limits.memory` | `256Mi` | Memory limit |
+See [helm/opscart-watcher/README.md](helm/opscart-watcher/README.md)
+for the full values reference, persistence configuration, and
+environment-specific notes (minikube, multi-node, local images).
 
 ---
 
@@ -170,11 +169,10 @@ go build -o opscart-scan ./cmd/opscart-scan
 
 ## Coming Next
 
-- Persistent incident history (PVC-backed SQLite)
-- Blast radius analysis (services and ingresses affected per incident)
-- Change detection ("new since yesterday" / "resolved since yesterday")
+- Restart acceleration in assessments ("22% increase since yesterday")
+- Root cause confidence scoring (deterministic, evidence-based)
+- Related incidents (cross-incident correlation within a namespace)
 - Slack and Teams notifications
-
 ---
 
 ## Disclaimer

--- a/cmd/opscart-dashboard/main.go
+++ b/cmd/opscart-dashboard/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/rand"
 	"embed"
 	"encoding/hex"
@@ -11,10 +12,12 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/signal"
 	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/opscart/opscart-k8s-watcher/pkg/analyzer"
@@ -333,9 +336,9 @@ func runDashboard(_ *cobra.Command, _ []string) error {
 		db = &store.NullStore{}
 	} else {
 		db = sqlDB
-		defer sqlDB.Close()
 		log.Printf("store: operational memory at %s", dbPath)
 	}
+	defer db.Close()
 	srv := newServer(cl, db)
 
 	log.Printf("Scanning cluster %q ...", displayName(cl[0]))
@@ -364,8 +367,34 @@ func runDashboard(_ *cobra.Command, _ []string) error {
 	mux.HandleFunc("/waste", srv.handleWastePage)
 	mux.HandleFunc("/settings", srv.handleStubPage("settings", "Settings"))
 	addr := ":" + port
-	log.Printf("Dashboard ready at http://localhost%s", addr)
-	return http.ListenAndServe(addr, mux)
+	httpServer := &http.Server{Addr: addr, Handler: mux}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	serveErr := make(chan error, 1)
+	go func() {
+		log.Printf("Dashboard ready at http://localhost%s", addr)
+		serveErr <- httpServer.ListenAndServe()
+	}()
+
+	select {
+	case err := <-serveErr:
+		if err != nil && err != http.ErrServerClosed {
+			return err
+		}
+	case <-ctx.Done():
+		stop()
+		log.Printf("shutting down: flushing operational memory")
+
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := httpServer.Shutdown(shutdownCtx); err != nil {
+			log.Printf("http server shutdown: %v", err)
+		}
+	}
+
+	return nil
 }
 
 // ── Stub pages ────────────────────────────────────────────────────────────────

--- a/deploy/dashboard.yaml
+++ b/deploy/dashboard.yaml
@@ -63,6 +63,25 @@ subjects:
     namespace: opscart-system
 
 ---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: opscart-data
+  namespace: opscart-system
+spec:
+  accessModes:
+    - ReadWriteOnce
+  # storageClassName is intentionally omitted so the cluster's default
+  # StorageClass is used (e.g. minikube's "standard", or a cloud
+  # provider's default such as "gp2" / "managed-csi"). If your cluster
+  # has no default StorageClass, or you need a specific one, set it
+  # explicitly here, e.g.:
+  #   storageClassName: standard
+  resources:
+    requests:
+      storage: 1Gi
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -72,6 +91,14 @@ metadata:
     app: opscart-watcher
 spec:
   replicas: 1
+  # opscart-data is ReadWriteOnce, so it can only be mounted by one pod
+  # at a time. A RollingUpdate would start the new pod (and try to mount
+  # the volume) before terminating the old one, and the new pod would
+  # hang waiting for a mount the old pod still holds. Recreate tears down
+  # the old pod first, freeing the volume before the replacement starts.
+  # Only correct for single-replica deployments backed by RWO storage.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: opscart-watcher
@@ -126,7 +153,8 @@ spec:
             failureThreshold: 3
       volumes:
         - name: opscart-data
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: opscart-data
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534   # nobody — matches USER in Dockerfile

--- a/deploy/dashboard.yaml
+++ b/deploy/dashboard.yaml
@@ -115,7 +115,7 @@ spec:
 
       containers:
         - name: dashboard
-          image: ghcr.io/opscart/opscart-dashboard:v1.3.0
+          image: ghcr.io/opscart/opscart-dashboard:v1.7.0
           imagePullPolicy: Always
           args:
             - "--port=8080"

--- a/helm/opscart-watcher/Chart.yaml
+++ b/helm/opscart-watcher/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: opscart-watcher
 description: Read-only Kubernetes operational triage dashboard
 type: application
-version: 0.1.0
-appVersion: "v1.2.0"
+version: 0.2.0
+appVersion: "v1.7.0"
 home: https://opscart.com
 sources:
   - https://github.com/opscart/opscart-k8s-watcher

--- a/helm/opscart-watcher/README.md
+++ b/helm/opscart-watcher/README.md
@@ -1,32 +1,107 @@
 # OpsCart Watcher — Helm Chart
 
-Read-only Kubernetes operational triage dashboard.
+Read-only Kubernetes operational triage dashboard with persistent
+operational memory (incident history, timelines).
 
 ## Prerequisites
 
 - Kubernetes 1.24+
 - Helm 3.0+
+- A default StorageClass (for persistence; see [Persistence](#persistence))
 
 ## Install
 
 ```bash
-# From local chart
 helm install opscart-watcher ./helm/opscart-watcher \
   --namespace opscart-system \
   --create-namespace
 
 # Access the dashboard
-kubectl port-forward -n opscart-system \
-  svc/opscart-watcher 8080:80
+kubectl port-forward -n opscart-system svc/opscart-watcher 8080:80
 ```
 
 Open http://localhost:8080
+
+> The chart does not create the namespace itself — always pass
+> `--create-namespace` on first install.
 
 ## Uninstall
 
 ```bash
 helm uninstall opscart-watcher -n opscart-system
-kubectl delete namespace opscart-system
+```
+
+The PVC holding incident history is **intentionally kept** on uninstall
+(`helm.sh/resource-policy: keep`). To discard all operational memory:
+
+```bash
+kubectl delete pvc opscart-watcher -n opscart-system
+kubectl delete namespace opscart-system   # if no longer needed
+```
+
+## Persistence
+
+Incident history and timelines are stored in SQLite on a PVC (default
+1Gi, ReadWriteOnce). Enabled by default.
+
+| Scenario | Setting |
+|----------|---------|
+| Use a specific StorageClass | `--set persistence.storageClassName=<name>` |
+| Use a pre-created PVC | `--set persistence.existingClaim=<name>` |
+| Disable (ephemeral, history lost on restart) | `--set persistence.enabled=false` |
+
+When persistence is enabled the Deployment uses `strategy: Recreate` —
+an RWO volume cannot be mounted by the old and new pod simultaneously,
+so upgrades incur brief downtime. This is expected.
+
+If the store cannot open its database the dashboard **falls back to
+in-memory mode and keeps running** — the symptom is
+`store: persistence disabled` in the pod logs and incident history that
+resets on every restart. If you see that, check the sections below.
+
+### Volume permissions (hostPath provisioners, minikube default)
+
+The pod runs as non-root (UID 65534). Some provisioners — including
+minikube's default `hostpath-provisioner` — do not honor `fsGroup`, so
+the volume is created root-owned and unwritable. Fix with the bundled
+init container:
+
+```bash
+helm upgrade opscart-watcher ./helm/opscart-watcher -n opscart-system \
+  --set volumePermissions.enabled=true
+```
+
+This runs a root `busybox` init container that chowns `/data` before the
+dashboard starts. Not needed on CSI drivers that honor fsGroup
+(EBS, Azure Disk, GKE PD, etc.).
+
+### Multi-node minikube
+
+minikube's default hostPath PVs have **no node affinity** — if the pod
+is rescheduled to a different node it mounts an empty directory and
+history appears to reset (incidents re-detected with new timestamps).
+Options:
+
+```bash
+# Workaround: pin the pod to the node holding the volume
+helm upgrade ... --set nodeSelector."kubernetes\.io/hostname"=<node>
+
+# Preferred: use the CSI hostpath driver (real node affinity)
+minikube addons enable volumesnapshots
+minikube addons enable csi-hostpath-driver
+helm upgrade ... --set persistence.storageClassName=csi-hostpath-sc
+```
+
+## Local development images
+
+With `image.pullPolicy=Never`, kubelet requires the image to be loaded
+under the **exact** `repository:tag` the chart renders — there is no
+fuzzy matching:
+
+```bash
+docker build -t ghcr.io/opscart/opscart-dashboard:dev .
+minikube image load ghcr.io/opscart/opscart-dashboard:dev
+helm upgrade ... --set image.tag=dev --set image.pullPolicy=Never
 ```
 
 ## Configuration
@@ -34,10 +109,14 @@ kubectl delete namespace opscart-system
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `image.repository` | `ghcr.io/opscart/opscart-dashboard` | Image repository |
-| `image.tag` | `v1.2.0` | Image tag |
+| `image.tag` | `v1.7.0` | Image tag |
 | `image.pullPolicy` | `Always` | Pull policy |
-| `namespace.create` | `true` | Create namespace |
-| `namespace.name` | `opscart-system` | Target namespace |
+| `persistence.enabled` | `true` | Persist incident history on a PVC |
+| `persistence.size` | `1Gi` | PVC size |
+| `persistence.storageClassName` | `""` | StorageClass (empty = cluster default) |
+| `persistence.existingClaim` | `""` | Use a pre-created PVC |
+| `volumePermissions.enabled` | `false` | Root init container to chown the data volume |
+| `nodeSelector` | `{}` | Pod node selector |
 | `service.type` | `ClusterIP` | Service type |
 | `resources.requests.cpu` | `100m` | CPU request |
 | `resources.requests.memory` | `64Mi` | Memory request |
@@ -51,3 +130,5 @@ kubectl delete namespace opscart-system
 - No cloud credentials required
 - No agents, no mutations
 - Image built FROM scratch
+- The optional `volumePermissions` init container runs as root by
+  design (one-shot chown); disabled by default

--- a/helm/opscart-watcher/templates/NOTES.txt
+++ b/helm/opscart-watcher/templates/NOTES.txt
@@ -1,0 +1,17 @@
+{{ .Chart.Name }} {{ .Chart.AppVersion }} deployed.
+
+  Install into a fresh cluster with:
+    helm install {{ .Release.Name }} ./helm/opscart-watcher -n {{ .Release.Namespace }} --create-namespace
+
+  Access the dashboard:
+    kubectl port-forward -n {{ .Release.Namespace }} deploy/{{ include "opscart-watcher.fullname" . }} 8080:8080
+    open http://localhost:8080
+
+{{- if .Values.persistence.enabled }}
+  Operational memory (incident history, timelines) is persisted on PVC
+  "{{ .Values.persistence.existingClaim | default (include "opscart-watcher.fullname" .) }}".
+  This PVC is kept on `helm uninstall` — delete it manually to discard history.
+{{- else }}
+  WARNING: persistence.enabled=false — incident history and timelines
+  will be LOST on every pod restart.
+{{- end }}

--- a/helm/opscart-watcher/templates/_helpers.tpl
+++ b/helm/opscart-watcher/templates/_helpers.tpl
@@ -39,7 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Namespace
 */}}
 {{- define "opscart-watcher.namespace" -}}
-{{- .Values.namespace.name }}
+{{- .Release.Namespace }}
 {{- end }}
 
 {{/*
@@ -47,4 +47,15 @@ ServiceAccount name
 */}}
 {{- define "opscart-watcher.serviceAccountName" -}}
 {{- .Values.serviceAccount.name }}
+{{- end }}
+
+{{/*
+PVC claim name — the templated PVC's name, or the user-supplied existingClaim.
+*/}}
+{{- define "opscart-watcher.pvcName" -}}
+{{- if .Values.persistence.existingClaim }}
+{{- .Values.persistence.existingClaim }}
+{{- else }}
+{{- include "opscart-watcher.fullname" . }}
+{{- end }}
 {{- end }}

--- a/helm/opscart-watcher/templates/deployment.yaml
+++ b/helm/opscart-watcher/templates/deployment.yaml
@@ -7,6 +7,16 @@ metadata:
     {{- include "opscart-watcher.labels" . | nindent 4 }}
 spec:
   replicas: 1
+  {{- if .Values.persistence.enabled }}
+  # opscart-data is ReadWriteOnce, so it can only be mounted by one pod at a
+  # time. A RollingUpdate would start the new pod (and try to mount the
+  # volume) before terminating the old one, and the new pod would hang
+  # waiting for a mount the old pod still holds. Recreate tears down the old
+  # pod first, freeing the volume before the replacement starts. Only
+  # correct for single-replica deployments backed by RWO storage.
+  strategy:
+    type: Recreate
+  {{- end }}
   selector:
     matchLabels:
       {{- include "opscart-watcher.selectorLabels" . | nindent 6 }}
@@ -18,18 +28,36 @@ spec:
       serviceAccountName: {{ include "opscart-watcher.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.volumePermissions.enabled }}
+      initContainers:
+        - name: volume-permissions
+          image: busybox:1.36
+          command: ["sh", "-c", "chown -R 65534:65534 /data"]
+          securityContext:
+            runAsUser: 0
+            runAsNonRoot: false
+          volumeMounts:
+            - name: opscart-data
+              mountPath: /data
+      {{- end }}
       containers:
         - name: dashboard
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             {{- toYaml .Values.args | nindent 12 }}
+          env:
+            - name: OPSCART_DB_PATH
+              value: /data/opscart.db
           ports:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: opscart-data
+              mountPath: /data
           readinessProbe:
             httpGet:
               path: {{ .Values.probes.readiness.path }}
@@ -44,3 +72,15 @@ spec:
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
             failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: opscart-data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "opscart-watcher.pvcName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}

--- a/helm/opscart-watcher/templates/namespace.yaml
+++ b/helm/opscart-watcher/templates/namespace.yaml
@@ -1,8 +1,0 @@
-{{- if .Values.namespace.create }}
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ include "opscart-watcher.namespace" . }}
-  labels:
-    {{- include "opscart-watcher.labels" . | nindent 4 }}
-{{- end }}

--- a/helm/opscart-watcher/templates/pvc.yaml
+++ b/helm/opscart-watcher/templates/pvc.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "opscart-watcher.fullname" . }}
+  namespace: {{ include "opscart-watcher.namespace" . }}
+  labels:
+    {{- include "opscart-watcher.labels" . | nindent 4 }}
+  annotations:
+    # Survive `helm uninstall` — this PVC holds the operational memory
+    # (incident history, timelines). Delete manually if truly unwanted:
+    #   kubectl delete pvc {{ include "opscart-watcher.fullname" . }} -n <ns>
+    "helm.sh/resource-policy": keep
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.persistence.storageClassName }}
+  storageClassName: {{ .Values.persistence.storageClassName | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/helm/opscart-watcher/values.yaml
+++ b/helm/opscart-watcher/values.yaml
@@ -2,15 +2,17 @@
 
 image:
   repository: ghcr.io/opscart/opscart-dashboard
-  tag: "v1.3.0"
+  tag: "v1.7.0"
+  # For local development with a locally-built image (e.g. minikube):
+  # the image must be loaded under the EXACT repository:tag rendered by
+  # this chart — kubelet does no fuzzy matching with pullPolicy Never.
+  #   docker build -t ghcr.io/opscart/opscart-dashboard:dev .
+  #   minikube image load ghcr.io/opscart/opscart-dashboard:dev
+  #   helm upgrade ... --set image.tag=dev --set image.pullPolicy=Never
   pullPolicy: Always
 
 nameOverride: ""
 fullnameOverride: ""
-
-namespace:
-  create: true
-  name: opscart-system
 
 serviceAccount:
   create: true
@@ -20,6 +22,12 @@ service:
   type: ClusterIP
   port: 80
   targetPort: 8080
+
+persistence:
+  enabled: true
+  size: 1Gi
+  storageClassName: ""   # empty = cluster default
+  existingClaim: ""      # use a pre-created PVC instead of templating one
 
 resources:
   requests:
@@ -37,8 +45,17 @@ podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65534
   runAsGroup: 65534
+  fsGroup: 65534   
   seccompProfile:
     type: RuntimeDefault
+
+volumePermissions:
+  # Enable when the storage provisioner doesn't honor fsGroup
+  # (e.g. minikube hostpath-provisioner, some NFS provisioners).
+  # Runs a root init container to chown the data volume.
+  enabled: false
+
+nodeSelector: {}
 
 probes:
   readiness:

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -107,6 +107,14 @@ func OpenSQLite(path string) (*SQLiteStore, error) {
 		db.Close()
 		return nil, err
 	}
+	// NORMAL syncs the WAL on checkpoint rather than every transaction.
+	// Paired with WAL mode and a clean Close() on SIGTERM, this is safe
+	// against kubelet-initiated pod restarts while avoiding FULL's
+	// per-commit fsync cost.
+	if _, err := db.Exec("PRAGMA synchronous=NORMAL"); err != nil {
+		db.Close()
+		return nil, err
+	}
 
 	var version int
 	if err := db.QueryRow("PRAGMA user_version").Scan(&version); err != nil {

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -50,6 +50,46 @@ func TestOpenAndMigrate(t *testing.T) {
 	}
 }
 
+func TestWALModeActive(t *testing.T) {
+	s := openTestStore(t)
+
+	var mode string
+	if err := s.db.QueryRow("PRAGMA journal_mode").Scan(&mode); err != nil {
+		t.Fatalf("PRAGMA journal_mode: %v", err)
+	}
+	if mode != "wal" {
+		t.Fatalf("expected journal_mode=wal, got %q", mode)
+	}
+}
+
+func TestClose_SubsequentOpsFailCleanly(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "close.db")
+	s, err := OpenSQLite(path)
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if err := s.WriteSnapshot("test-cluster", "scan-1", SnapshotData{}); err == nil {
+		t.Fatalf("expected WriteSnapshot to fail on a closed store")
+	}
+	if err := s.UpsertIncidents("test-cluster", "scan-1", []IncidentData{{Fingerprint: "fp"}}); err == nil {
+		t.Fatalf("expected UpsertIncidents to fail on a closed store")
+	}
+	if _, err := s.GetIncidentTimeline("test-cluster", "fp"); err == nil {
+		t.Fatalf("expected GetIncidentTimeline to fail on a closed store")
+	}
+
+	// Close is safe to call again (mirrors main.go's single deferred Close
+	// alongside any explicit shutdown-path close).
+	if err := s.Close(); err != nil {
+		t.Fatalf("second Close should not error, got: %v", err)
+	}
+}
+
 func TestSnapshotRoundTrip(t *testing.T) {
 	s := openTestStore(t)
 


### PR DESCRIPTION
- Persistence: templated PVC (persistence.enabled/size/storageClassName/
  existingClaim), annotated helm.sh/resource-policy: keep so operational
  memory survives helm uninstall; strategy Recreate when enabled (RWO)
- Namespace: remove templated namespace (use --create-namespace);
  namespace helper resolves .Release.Namespace so -n is honored
- Volume ownership: fsGroup 65534; values-toggled volumePermissions
  init container for provisioners that ignore fsGroup on hostPath
  (minikube default) — symptom was silent NullStore fallback
- nodeSelector support — required on multi-node minikube where hostPath
  PVs have no node affinity (rescheduled pod mounts empty dir)
- NOTES.txt, chart README (persistence, minikube gotchas, local image
  workflow, full values table), root README refreshed (timeline, blast
  radius, operational memory; chart declared canonical)
- Chart 0.1.0 → 0.2.0, appVersion → v1.7.0; dashboard.yaml image bumped