### PR TITLE
feat(incidents): SQLite-backed registry with search, filters, pagination

### DIFF
--- a/cmd/opscart-dashboard/incident.go
+++ b/cmd/opscart-dashboard/incident.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"fmt"
+	"html/template"
+	"math"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/opscart/opscart-k8s-watcher/pkg/store"
+)
+
+type incidentsPageData struct {
+	// Sidebar
+	DashHref      string
+	WrHref        string
+	CostsHref     string
+	InfraHref     string
+	WasteHref     string
+	SecurityHref  string
+	IncidentsHref string
+	ActivePage    string
+	ClusterName   string
+	CriticalCount int
+	Clusters      []sidebarCluster
+
+	// Filter state
+	Filter store.IncidentFilter
+
+	// Results
+	Incidents  []store.IncidentSummary
+	Total      int
+	Page       int
+	PerPage    int
+	TotalPages int
+	Namespaces []string // distinct namespaces for filter dropdown
+
+	// Summary counts (across all matching, not just this page)
+	ActiveCount   int
+	ReopenedCount int
+	ResolvedCount int
+}
+
+func (srv *server) handleIncidentsPage(w http.ResponseWriter, r *http.Request) {
+	ctx := srv.activeCtx(r)
+	q := r.URL.Query()
+
+	page, _ := strconv.Atoi(q.Get("page"))
+	if page < 1 {
+		page = 1
+	}
+
+	status := q.Get("status")
+	if status == "" && q.Get("page") == "" && q.Get("q") == "" &&
+		q.Get("ns") == "" && q.Get("type") == "" && q.Get("severity") == "" {
+		status = "active" // default: active only on first load
+	}
+
+	sortBy := q.Get("sort")
+	if sortBy == "" {
+		sortBy = "severity"
+	}
+
+	f := store.IncidentFilter{
+		Cluster:   ctx,
+		Text:      q.Get("q"),
+		Namespace: q.Get("ns"),
+		IssueType: q.Get("type"),
+		Severity:  q.Get("severity"),
+		Status:    status,
+		SortBy:    sortBy,
+		SortDesc:  true,
+		Page:      page,
+		PerPage:   50,
+	}
+
+	state := srv.getState(ctx)
+	state.mu.RLock()
+	scan := state.scan
+	state.mu.RUnlock()
+
+	clusterQ := "?cluster=" + url.QueryEscape(ctx)
+	data := incidentsPageData{
+		DashHref:      "/" + clusterQ,
+		WrHref:        "/warroom" + clusterQ,
+		CostsHref:     "/costs" + clusterQ,
+		InfraHref:     "/infrastructure" + clusterQ,
+		WasteHref:     "/waste" + clusterQ,
+		SecurityHref:  "/security" + clusterQ,
+		IncidentsHref: "/incidents" + clusterQ,
+		ActivePage:    "incidents",
+		ClusterName:   displayName(ctx),
+		CriticalCount: countCriticalIssues(scan),
+		Filter:        f,
+		Page:          page,
+		PerPage:       50,
+	}
+
+	// Query store
+	items, total, err := srv.db.QueryIncidents(f)
+	if err == nil {
+		data.Incidents = items
+		data.Total = total
+		data.TotalPages = int(math.Ceil(float64(total) / 50))
+	}
+
+	// Summary counts — query with status overrides for the strip
+	if ac, _, e := srv.db.QueryIncidents(store.IncidentFilter{Cluster: ctx, Status: "active", PerPage: 1}); e == nil {
+		_ = ac
+	}
+	// Simpler: get counts from a summary query
+	if all, allTotal, e := srv.db.QueryIncidents(store.IncidentFilter{
+		Cluster: ctx, Text: f.Text, Namespace: f.Namespace,
+		IssueType: f.IssueType, Severity: f.Severity,
+		Status: "", PerPage: 200,
+	}); e == nil {
+		for _, inc := range all {
+			switch {
+			case inc.Status == "resolved":
+				data.ResolvedCount++
+			case inc.ReopenCount > 0:
+				data.ReopenedCount++
+			default:
+				data.ActiveCount++
+			}
+		}
+		_ = allTotal
+	}
+
+	// Distinct namespaces for dropdown
+	if ns, _, e := srv.db.QueryIncidents(store.IncidentFilter{
+		Cluster: ctx, Status: "", PerPage: 200,
+	}); e == nil {
+		seen := map[string]bool{}
+		for _, inc := range ns {
+			if !seen[inc.Namespace] {
+				seen[inc.Namespace] = true
+				data.Namespaces = append(data.Namespaces, inc.Namespace)
+			}
+		}
+	}
+
+	renderIncidents(w, data)
+}
+
+var getIncidentsTmpl = sync.OnceValue(func() *template.Template {
+	humanAge := func(t time.Time) string {
+		if t.IsZero() {
+			return "—"
+		}
+		d := time.Since(t)
+		switch {
+		case d < time.Minute:
+			return "just now"
+		case d < time.Hour:
+			return fmt.Sprintf("%dm ago", int(d.Minutes()))
+		case d < 24*time.Hour:
+			return fmt.Sprintf("%dh ago", int(d.Hours()))
+		case d < 48*time.Hour:
+			return "yesterday"
+		default:
+			days := int(d.Hours() / 24)
+			return fmt.Sprintf("%d days ago", days)
+		}
+	}
+	recoveredIn := func(first, last time.Time) string {
+		if first.IsZero() || last.IsZero() {
+			return "—"
+		}
+		d := last.Sub(first)
+		days := int(d.Hours() / 24)
+		if days < 1 {
+			return fmt.Sprintf("%dh", int(d.Hours()))
+		}
+		return fmt.Sprintf("%dd", days)
+	}
+	pageStart := func(page, perPage int) int {
+		return (page-1)*perPage + 1
+	}
+	pageEnd := func(page, perPage, total int) int {
+		end := page * perPage
+		if end > total {
+			return total
+		}
+		return end
+	}
+	prevPage := func(page int) int {
+		if page > 1 {
+			return page - 1
+		}
+		return 1
+	}
+	nextPage := func(page, total int) int {
+		if page < total {
+			return page + 1
+		}
+		return total
+	}
+	pageRange := func(page, totalPages int) []int {
+		var pages []int
+		start := page - 2
+		if start < 1 {
+			start = 1
+		}
+		end := start + 4
+		if end > totalPages {
+			end = totalPages
+		}
+		for i := start; i <= end; i++ {
+			pages = append(pages, i)
+		}
+		return pages
+	}
+
+	return template.Must(
+		template.New("incidents.html").
+			Funcs(template.FuncMap{
+				"firstDetected": humanAge,
+				"lastSeen":      humanAge,
+				"recoveredIn":   recoveredIn,
+				"pageStart":     pageStart,
+				"pageEnd":       pageEnd,
+				"prevPage":      prevPage,
+				"nextPage":      nextPage,
+				"pageRange":     pageRange,
+			}).
+			ParseFS(templateFS,
+				"templates/base.html",
+				"templates/sidebar.html",
+				"templates/incidents.html"),
+	)
+})
+
+func renderIncidents(w http.ResponseWriter, data incidentsPageData) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+	if err := getIncidentsTmpl().Execute(w, data); err != nil {
+		http.Error(w, "template error", http.StatusInternalServerError)
+	}
+}

--- a/cmd/opscart-dashboard/main.go
+++ b/cmd/opscart-dashboard/main.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/signal"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -138,12 +139,13 @@ func (s *clusterScan) securityScore() int {
 // ── Per-cluster state ─────────────────────────────────────────────────────────
 
 type dashboardState struct {
-	ctx      string
-	mu       sync.RWMutex
-	scan     *clusterScan
-	htmlPage string
-	scanning atomic.Bool
-	db       store.Store
+	ctx           string
+	mu            sync.RWMutex
+	scan          *clusterScan
+	htmlPage      string
+	scanning      atomic.Bool
+	db            store.Store
+	retentionDays int
 }
 
 func (s *dashboardState) refresh(clusterList []string) error {
@@ -215,6 +217,13 @@ func (s *dashboardState) refresh(clusterList []string) error {
 		if resolved, err := s.db.ResolveMissing(s.ctx, scanID); err == nil && resolved > 0 {
 			log.Printf("[%s] %d incident(s) resolved", displayName(s.ctx), resolved)
 		}
+		if cutoff, ok := store.RetentionCutoff(s.retentionDays, time.Now()); ok {
+			if pruned, err := s.db.PruneOlderThan(s.ctx, cutoff); err != nil {
+				log.Printf("[%s] store prune: %v", displayName(s.ctx), err)
+			} else if pruned > 0 {
+				log.Printf("[%s] retention: pruned %d incident(s) older than %d day(s)", displayName(s.ctx), pruned, s.retentionDays)
+			}
+		}
 		_ = s.db.WriteScanHistory(s.ctx, scanID, store.ScanMeta{
 			DurationMS: time.Since(start).Milliseconds(),
 			Success:    true,
@@ -229,14 +238,15 @@ func (s *dashboardState) refresh(clusterList []string) error {
 // ── Server ────────────────────────────────────────────────────────────────────
 
 type server struct {
-	clusterList []string
-	mu          sync.RWMutex
-	states      map[string]*dashboardState
-	db          store.Store
+	clusterList   []string
+	mu            sync.RWMutex
+	states        map[string]*dashboardState
+	db            store.Store
+	retentionDays int
 }
 
-func newServer(clusterList []string, db store.Store) *server {
-	return &server{clusterList: clusterList, states: make(map[string]*dashboardState), db: db}
+func newServer(clusterList []string, db store.Store, retentionDays int) *server {
+	return &server{clusterList: clusterList, states: make(map[string]*dashboardState), db: db, retentionDays: retentionDays}
 }
 
 func (srv *server) getState(ctx string) *dashboardState {
@@ -251,7 +261,7 @@ func (srv *server) getState(ctx string) *dashboardState {
 	if s = srv.states[ctx]; s != nil {
 		return s
 	}
-	s = &dashboardState{ctx: ctx, db: srv.db}
+	s = &dashboardState{ctx: ctx, db: srv.db, retentionDays: srv.retentionDays}
 	srv.states[ctx] = s
 	return s
 }
@@ -330,6 +340,14 @@ func runDashboard(_ *cobra.Command, _ []string) error {
 	if dbPath == "" {
 		dbPath = "./opscart.db"
 	}
+	retentionDays := 90
+	if v := os.Getenv("OPSCART_RETENTION_DAYS"); v != "" {
+		if parsed, err := strconv.Atoi(v); err != nil {
+			log.Printf("store: invalid OPSCART_RETENTION_DAYS=%q, using default of %d days", v, retentionDays)
+		} else {
+			retentionDays = parsed
+		}
+	}
 	var db store.Store
 	if sqlDB, err := store.OpenSQLite(dbPath); err != nil {
 		log.Printf("store: persistence disabled (%v)", err)
@@ -339,7 +357,7 @@ func runDashboard(_ *cobra.Command, _ []string) error {
 		log.Printf("store: operational memory at %s", dbPath)
 	}
 	defer db.Close()
-	srv := newServer(cl, db)
+	srv := newServer(cl, db, retentionDays)
 
 	log.Printf("Scanning cluster %q ...", displayName(cl[0]))
 	if err := srv.getState(cl[0]).refresh(cl); err != nil {
@@ -1827,144 +1845,6 @@ func (srv *server) handleSecurityPage(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Write([]byte(buf.String()))
 }
-
-// ── Incidents page ───────────────────────────────────────────────────────────
-
-type incidentsPageData struct {
-	// Sidebar fields (used by {{template "sidebar.html" .}})
-	DashHref      string
-	WrHref        string
-	CostsHref     string
-	InfraHref     string
-	WasteHref     string
-	SecurityHref  string
-	IncidentsHref string
-	ActivePage    string
-	ClusterName   string
-	Clusters      []sidebarCluster
-	CriticalCount int
-	// Page content
-	StatusDesc    string
-	DashURL       string
-	CritChipClass string
-	WarnChipClass string
-	Critical      []warRoomIssue
-	Warnings      []warRoomIssue
-	ScannedAtMs   int64
-}
-
-func (srv *server) handleIncidentsPage(w http.ResponseWriter, r *http.Request) {
-	ctx := srv.activeCtx(r)
-	state := srv.getState(ctx)
-
-	state.mu.RLock()
-	scan := state.scan
-	state.mu.RUnlock()
-
-	if scan == nil {
-		if err := state.refresh(srv.clusterList); err != nil {
-			http.Error(w, "scan failed: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
-		state.mu.RLock()
-		scan = state.scan
-		state.mu.RUnlock()
-	}
-
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	fmt.Fprint(w, renderIncidentsPage(scan, ctx, srv.clusterList))
-}
-
-func renderIncidentsPage(scan *clusterScan, activeCtx string, clusterList []string) string {
-	allIssues := collectWarRoomIssues(scan, 0)
-	var critical, warnings []warRoomIssue
-	for _, issue := range allIssues {
-		if issue.Severity == "critical" {
-			critical = append(critical, issue)
-		} else {
-			warnings = append(warnings, issue)
-		}
-	}
-
-	scannedAt := time.Now()
-	clusterName := displayName(activeCtx)
-	if scan != nil && scan.report != nil {
-		scannedAt = scan.report.Timestamp
-		clusterName = scan.report.ClusterName
-	}
-
-	q := ""
-	if activeCtx != "" {
-		q = "?cluster=" + url.QueryEscape(activeCtx)
-	}
-
-	var clusters []sidebarCluster
-	if len(clusterList) > 1 {
-		for _, ctx := range clusterList {
-			label := displayName(ctx)
-			if len(label) > 22 {
-				label = label[:21] + "…"
-			}
-			clusters = append(clusters, sidebarCluster{
-				Href:     "/incidents?" + url.Values{"cluster": {ctx}}.Encode(),
-				Label:    label,
-				IsActive: ctx == activeCtx,
-			})
-		}
-	}
-
-	critChipClass := "ok"
-	if len(critical) > 0 {
-		critChipClass = "c"
-	}
-	warnChipClass := "ok"
-	if len(warnings) > 0 {
-		warnChipClass = "w"
-	}
-
-	data := incidentsPageData{
-		DashHref:      "/" + q,
-		WrHref:        "/warroom" + q,
-		CostsHref:     "/costs" + q,
-		InfraHref:     "/infrastructure" + q,
-		WasteHref:     "/waste" + q,
-		SecurityHref:  "/security" + q,
-		IncidentsHref: "/incidents" + q,
-		ActivePage:    "incidents",
-		ClusterName:   clusterName,
-		Clusters:      clusters,
-		CriticalCount: len(critical),
-		StatusDesc:    fmt.Sprintf("%d issue(s) detected", len(critical)+len(warnings)),
-		DashURL:       "/" + q,
-		CritChipClass: critChipClass,
-		WarnChipClass: warnChipClass,
-		Critical:      critical,
-		Warnings:      warnings,
-		ScannedAtMs:   scannedAt.UnixMilli(),
-	}
-
-	var buf strings.Builder
-	if err := getIncidentsTmpl().Execute(&buf, data); err != nil {
-		log.Printf("incidents template: %v", err)
-		return ""
-	}
-	return buf.String()
-}
-
-var getIncidentsTmpl = sync.OnceValue(func() *template.Template {
-	return template.Must(
-		template.New("incidents.html").
-			Funcs(template.FuncMap{
-				"renderCard": func(issue warRoomIssue) template.HTML {
-					return template.HTML(renderWarRoomCard(issue))
-				},
-			}).
-			ParseFS(templateFS,
-				"templates/base.html",
-				"templates/sidebar.html",
-				"templates/incidents.html"),
-	)
-})
 
 // ── Waste & Drift page ────────────────────────────────────────────────────────
 

--- a/cmd/opscart-dashboard/templates/incidents.html
+++ b/cmd/opscart-dashboard/templates/incidents.html
@@ -7,151 +7,315 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 {{template "base" .}}
 <style>
-.summary-bar{display:flex;gap:1rem;margin-bottom:2rem;flex-wrap:wrap}
-.summary-chip{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);padding:0.75rem 1.25rem;display:flex;align-items:center;gap:0.75rem;min-width:160px}
-.summary-chip.c{border-color:rgba(239,68,68,0.35)}
-.summary-chip.w{border-color:rgba(245,158,11,0.35)}
-.summary-chip.ok{border-color:rgba(16,185,129,0.35)}
-.summary-num{font-size:1.6rem;font-weight:800;line-height:1}
-.c .summary-num{color:var(--danger)}
-.w .summary-num{color:var(--warning)}
-.ok .summary-num{color:var(--success)}
-.summary-lbl{font-size:0.72rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;line-height:1.3}
-.wr-section{margin-bottom:2.5rem}
-.wr-section-hdr{display:flex;align-items:center;gap:0.75rem;margin-bottom:1rem;padding-bottom:0.75rem;border-bottom:1px solid var(--border)}
-.wr-section-hdr h2{font-size:1rem;font-weight:700}
-.cnt-chip{padding:3px 10px;border-radius:20px;font-size:0.7rem;font-weight:700}
-.cnt-chip.c{background:rgba(239,68,68,0.15);color:#f87171}
-.cnt-chip.w{background:rgba(245,158,11,0.15);color:#fbbf24}
-.wr-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(340px,1fr));gap:1rem}
-.wr-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:1.25rem;display:flex;flex-direction:column;gap:0.55rem;transition:border-color 0.2s;animation:fadeIn 0.3s ease both}
-.wr-card.c{border-color:rgba(239,68,68,0.3);background:rgba(239,68,68,0.025)}
-.wr-card.w{border-color:rgba(245,158,11,0.25);background:rgba(245,158,11,0.02)}
-.wr-card:hover{border-color:var(--primary)}
-.wr-type-crash-loop{border-left:3px solid rgba(239,68,68,0.6)}
-.wr-type-oomkilled{border-left:3px solid rgba(249,115,22,0.6)}
-.wr-type-image-pull-backoff{border-left:3px solid rgba(234,179,8,0.6)}
-.wr-type-privileged-container{border-left:3px solid rgba(139,92,246,0.6)}
-.wr-type-unprotected-namespace{border-left:3px solid rgba(59,130,246,0.6)}
-.wr-type-orphaned-pvc{border-left:3px solid rgba(100,116,139,0.5)}
-.wr-type-zero-replica{border-left:3px solid rgba(100,116,139,0.4)}
-.wr-type-icon{display:inline-flex;align-items:center;justify-content:center;
-  width:16px;height:16px;margin-right:2px;vertical-align:middle;flex-shrink:0}
-.wri-crash::before{content:"";display:block;width:14px;height:14px;
-  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%23f87171' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='23 4 23 10 17 10'/%3E%3Cpolyline points='1 20 1 14 7 14'/%3E%3Cpath d='M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15'/%3E%3C/svg%3E");
-  background-repeat:no-repeat;background-size:contain}
-.wri-oom::before{content:"";display:block;width:14px;height:14px;
-  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%23fb923c' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='4' y='4' width='16' height='16' rx='2'/%3E%3Crect x='9' y='9' width='6' height='6'/%3E%3Cline x1='9' y1='1' x2='9' y2='4'/%3E%3Cline x1='15' y1='1' x2='15' y2='4'/%3E%3Cline x1='9' y1='20' x2='9' y2='23'/%3E%3Cline x1='15' y1='20' x2='15' y2='23'/%3E%3Cline x1='20' y1='9' x2='23' y2='9'/%3E%3Cline x1='20' y1='14' x2='23' y2='14'/%3E%3Cline x1='1' y1='9' x2='4' y2='9'/%3E%3Cline x1='1' y1='14' x2='4' y2='14'/%3E%3C/svg%3E");
-  background-repeat:no-repeat;background-size:contain}
-.wri-image::before{content:"";display:block;width:14px;height:14px;
-  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%23eab308' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z'/%3E%3Cpolyline points='3.27 6.96 12 12.01 20.73 6.96'/%3E%3Cline x1='12' y1='22.08' x2='12' y2='12'/%3E%3C/svg%3E");
-  background-repeat:no-repeat;background-size:contain}
-.wri-priv::before{content:"";display:block;width:14px;height:14px;
-  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%23a78bfa' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z'/%3E%3Cline x1='12' y1='8' x2='12' y2='12'/%3E%3Cline x1='12' y1='16' x2='12.01' y2='16'/%3E%3C/svg%3E");
-  background-repeat:no-repeat;background-size:contain}
-.wri-netpol::before{content:"";display:block;width:14px;height:14px;
-  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%2360a5fa' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='3' y='11' width='18' height='11' rx='2' ry='2'/%3E%3Cpath d='M7 11V7a5 5 0 0 1 9.9-1'/%3E%3C/svg%3E");
-  background-repeat:no-repeat;background-size:contain}
-.wri-pvc::before{content:"";display:block;width:14px;height:14px;
-  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cellipse cx='12' cy='5' rx='9' ry='3'/%3E%3Cpath d='M21 12c0 1.66-4 3-9 3s-9-1.34-9-3'/%3E%3Cpath d='M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5'/%3E%3C/svg%3E");
-  background-repeat:no-repeat;background-size:contain}
-.wri-zero::before{content:"";display:block;width:14px;height:14px;
-  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='6' y='4' width='4' height='16'/%3E%3Crect x='14' y='4' width='4' height='16'/%3E%3C/svg%3E");
-  background-repeat:no-repeat;background-size:contain}
-.wri-default::before{content:"";display:block;width:14px;height:14px;
-  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cline x1='12' y1='8' x2='12' y2='12'/%3E%3Cline x1='12' y1='16' x2='12.01' y2='16'/%3E%3C/svg%3E");
-  background-repeat:no-repeat;background-size:contain}
-.wr-top{display:flex;align-items:center;gap:0.5rem;flex-wrap:wrap}
-.badge{padding:2px 8px;border-radius:20px;font-size:0.64rem;font-weight:700;letter-spacing:0.5px}
-.badge.c{background:rgba(239,68,68,0.15);color:#f87171}
-.badge.w{background:rgba(245,158,11,0.15);color:#fbbf24}
-.type-lbl{font-size:0.72rem;color:var(--text-muted)}
-.age-lbl{margin-left:auto;font-size:0.7rem;color:var(--text-muted);white-space:nowrap;background:rgba(255,255,255,0.05);padding:1px 7px;border-radius:4px}
-.wr-name{font-size:0.93rem;font-weight:700;color:var(--text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.wr-ns{font-size:0.73rem;color:var(--text-muted)}
-.wr-reason{font-size:0.78rem;color:var(--text-secondary);line-height:1.55;display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden}
-.wr-cmd{display:flex;align-items:center;gap:0.5rem;background:rgba(0,0,0,0.3);border:1px solid var(--border);border-radius:var(--radius-xs);padding:0.5rem 0.75rem;margin-top:auto}
-.wr-cmd code{font-family:'Consolas','Monaco',monospace;font-size:0.7rem;color:var(--primary-light);flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.copy-btn{background:transparent;border:1px solid var(--border);border-radius:4px;color:var(--text-muted);cursor:pointer;font-size:0.64rem;padding:2px 7px;white-space:nowrap;transition:all 0.15s;flex-shrink:0}
-.copy-btn:hover{background:var(--surface-hover);color:var(--text)}
-.all-clear-box{background:var(--surface);border:1px solid rgba(16,185,129,0.25);border-radius:var(--radius);padding:2.5rem;text-align:center;color:var(--text-muted)}
-.all-clear-box .icon{font-size:2.5rem;margin-bottom:0.5rem}
-.footer{text-align:center;padding:1.5rem 0;color:var(--text-muted);font-size:0.75rem;border-top:1px solid var(--border);margin-top:1rem}
-@media(max-width:640px){.wr-grid{grid-template-columns:1fr}.summary-bar{flex-direction:column}}
+/* ── Filter bar ── */
+.inc-filters{display:flex;gap:.6rem;flex-wrap:wrap;align-items:center;margin-bottom:.85rem}
+.inc-search{flex:1;min-width:260px;display:flex;align-items:center;gap:.5rem;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);padding:.55rem .9rem;transition:border-color .15s}
+.inc-search:focus-within{border-color:var(--primary-light)}
+.inc-search svg{color:var(--text-muted);flex-shrink:0}
+.inc-search input{background:none;border:none;outline:none;color:var(--text);font:inherit;font-size:.85rem;width:100%}
+.inc-search input::placeholder{color:var(--text-muted)}
+.inc-select{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text-secondary);font:inherit;font-size:.82rem;padding:.55rem .75rem;outline:none;cursor:pointer;transition:border-color .15s}
+.inc-select:hover,.inc-select:focus{border-color:#475569}
+.inc-select.active-filter{border-color:rgba(129,140,248,.55);color:var(--primary-light)}
+.inc-btn{background:var(--primary-light);border:none;border-radius:var(--radius-sm);color:#fff;font:inherit;font-size:.82rem;font-weight:600;padding:.55rem 1.1rem;cursor:pointer;white-space:nowrap;transition:opacity .15s}
+.inc-btn:hover{opacity:.85}
+.inc-btn-clear{background:transparent;border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text-muted);font:inherit;font-size:.82rem;padding:.55rem .9rem;cursor:pointer;transition:all .15s}
+.inc-btn-clear:hover{border-color:#475569;color:var(--text)}
+
+/* ── Summary strip ── */
+.inc-summary{display:flex;gap:1.5rem;margin-bottom:.85rem;font-size:.78rem;color:var(--text-muted);flex-wrap:wrap;align-items:center}
+.inc-summary b{color:var(--text);font-weight:700}
+.inc-sum-crit b{color:#f87171}
+.inc-sum-reo b{color:#fbbf24}
+.inc-sum-res b{color:#4ade80}
+.inc-total{margin-left:auto;font-size:.75rem}
+
+/* ── Table ── */
+.inc-tbl-wrap{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);overflow:hidden}
+.inc-tbl{width:100%;border-collapse:collapse;font-size:.82rem}
+.inc-tbl th{text-align:left;padding:.65rem .9rem;font-size:.64rem;text-transform:uppercase;letter-spacing:.5px;color:var(--text-muted);border-bottom:1px solid var(--border);font-weight:600;white-space:nowrap;background:rgba(0,0,0,.15);cursor:default}
+.inc-tbl th.sortable{cursor:pointer;user-select:none}
+.inc-tbl th.sortable:hover{color:var(--text)}
+.inc-tbl th .sort-icon{margin-left:3px;opacity:.5;font-size:.58rem}
+.inc-tbl th.sort-active{color:var(--primary-light)}
+.inc-tbl th.sort-active .sort-icon{opacity:1}
+.inc-tbl td{padding:.6rem .9rem;border-bottom:1px solid rgba(51,65,85,.5);vertical-align:middle;color:var(--text-secondary);white-space:nowrap}
+.inc-tbl tbody tr:last-child td{border-bottom:none}
+.inc-tbl tbody tr{cursor:pointer;transition:background .1s}
+.inc-tbl tbody tr:hover{background:var(--surface-hover)}
+.inc-tbl tr.inc-row-resolved td{opacity:.6}
+.inc-tbl tr.inc-row-resolved:hover td{opacity:.85}
+
+/* severity badge */
+.inc-sev{display:inline-flex;padding:2px 9px;border-radius:20px;font-size:.62rem;font-weight:700;text-transform:uppercase;letter-spacing:.5px;white-space:nowrap}
+.inc-sev-critical{background:rgba(239,68,68,.15);color:#f87171}
+.inc-sev-high{background:rgba(245,158,11,.15);color:#fbbf24}
+.inc-sev-medium{background:rgba(100,116,139,.18);color:#94a3b8}
+.inc-sev-low{background:rgba(100,116,139,.12);color:#64748b}
+
+/* incident name cell */
+.inc-name{font-weight:600;color:var(--text);max-width:220px;overflow:hidden;text-overflow:ellipsis}
+.inc-type{font-family:'Consolas','Monaco',monospace;font-size:.7rem;color:var(--text-muted);margin-top:1px}
+
+/* namespace */
+.inc-ns{font-family:'Consolas','Monaco',monospace;font-size:.76rem;max-width:160px;overflow:hidden;text-overflow:ellipsis}
+
+/* status dot */
+.inc-status{display:inline-flex;align-items:center;gap:.4rem;font-size:.74rem;font-weight:600;white-space:nowrap}
+.inc-dot{width:8px;height:8px;border-radius:50%;flex-shrink:0}
+.inc-status-active .inc-dot{background:#f87171;box-shadow:0 0 6px rgba(248,113,113,.5)}
+.inc-status-active{color:#f87171}
+.inc-status-resolved .inc-dot{background:#4ade80}
+.inc-status-resolved{color:#4ade80}
+.inc-status-reopened .inc-dot{background:#fbbf24;box-shadow:0 0 5px rgba(251,191,36,.45)}
+.inc-status-reopened{color:#fbbf24}
+.inc-reopen-n{font-size:.62rem;color:var(--text-muted);font-weight:500;margin-left:1px}
+
+/* numbers */
+.inc-num{font-variant-numeric:tabular-nums;text-align:right;color:var(--text-secondary)}
+.inc-age{color:var(--text-muted);font-size:.76rem}
+.inc-dash{color:var(--text-muted)}
+
+/* trend */
+.inc-trend{font-size:.74rem;font-weight:600;white-space:nowrap}
+.inc-trend-accelerating{color:#f87171}
+.inc-trend-stable{color:var(--text-muted)}
+.inc-trend-recovering{color:#4ade80}
+
+/* arrow */
+.inc-arrow{color:var(--text-muted);font-size:.85rem;text-align:center}
+
+/* ── Empty state ── */
+.inc-empty{padding:3rem;text-align:center;color:var(--text-muted)}
+.inc-empty-icon{font-size:2rem;margin-bottom:.75rem;opacity:.4}
+.inc-empty-msg{font-size:.9rem;margin-bottom:.4rem;color:var(--text-secondary)}
+.inc-empty-sub{font-size:.78rem}
+
+/* ── Pagination ── */
+.inc-pager{display:flex;justify-content:space-between;align-items:center;padding:.75rem 1rem;font-size:.76rem;color:var(--text-muted);border-top:1px solid var(--border);background:rgba(0,0,0,.1);flex-wrap:wrap;gap:.5rem}
+.inc-pager-btns{display:flex;gap:.3rem;flex-wrap:wrap}
+.inc-pg{border:1px solid var(--border);background:none;color:var(--text-secondary);border-radius:6px;padding:3px 10px;font:inherit;font-size:.75rem;cursor:pointer;transition:all .12s}
+.inc-pg:hover{background:var(--surface-hover);color:var(--text)}
+.inc-pg.inc-pg-cur{background:rgba(99,102,241,.2);border-color:var(--primary-light);color:var(--primary-light);font-weight:700}
+.inc-pg:disabled{opacity:.35;cursor:default}
+
+/* ── War Room callout ── */
+.inc-wr-banner{display:flex;align-items:center;justify-content:space-between;background:rgba(99,102,241,.07);border:1px solid rgba(129,140,248,.2);border-radius:var(--radius-sm);padding:.65rem 1rem;margin-bottom:1rem;font-size:.8rem;color:var(--text-muted)}
+.inc-wr-link{color:var(--primary-light);text-decoration:none;font-weight:600;font-size:.8rem}
+.inc-wr-link:hover{text-decoration:underline}
 </style>
 </head>
 <body>
 <div class="layout">
 {{template "sidebar.html" .}}
 <main class="main">
+
   <div class="page-hdr">
     <div>
-      <h1>🔍 Incidents</h1>
-      <p>{{.ClusterName}} &mdash; {{.StatusDesc}}</p>
+      <h1>Incidents</h1>
+      <p>The system of record — every incident this cluster has seen, active and resolved.</p>
     </div>
     <div class="page-meta">
       <div>Last scanned: <strong id="inc-age">just now</strong></div>
-      <a class="back-link" href="{{.DashURL}}">← Back to Dashboard</a>
     </div>
   </div>
 
-  <div class="summary-bar">
-    <div class="summary-chip {{.CritChipClass}}">
-      <div class="summary-num">{{len .Critical}}</div>
-      <div class="summary-lbl">Critical<br>Issues</div>
-    </div>
-    <div class="summary-chip {{.WarnChipClass}}">
-      <div class="summary-num">{{len .Warnings}}</div>
-      <div class="summary-lbl">High<br>Severity</div>
-    </div>
+  <!-- War Room callout -->
+  <div class="inc-wr-banner">
+    <span>Need immediate triage? <a class="inc-wr-link" href="{{.WrHref}}">War Room shows the top incidents ranked by impact →</a></span>
+    {{if .CriticalCount}}<span style="color:#f87171;font-weight:600">{{.CriticalCount}} critical active</span>{{end}}
   </div>
 
-  <div class="wr-section">
-    <div class="wr-section-hdr">
-      <h2>🔴 Critical Issues</h2>
-      <span class="cnt-chip c">{{len .Critical}}</span>
+  <!-- Filter form -->
+  <form method="GET" action="/incidents" id="inc-form">
+    <input type="hidden" name="cluster" value="{{.ClusterName}}">
+    <div class="inc-filters">
+      <div class="inc-search">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <input type="text" name="q" placeholder="Search — workload name, namespace, issue type…" value="{{.Filter.Text}}" autocomplete="off">
+      </div>
+      <select name="ns" class="inc-select{{if .Filter.Namespace}} active-filter{{end}}" onchange="this.form.submit()">
+        <option value="">Namespace: All</option>
+        {{range .Namespaces}}<option value="{{.}}"{{if eq . $.Filter.Namespace}} selected{{end}}>{{.}}</option>{{end}}
+      </select>
+      <select name="type" class="inc-select{{if .Filter.IssueType}} active-filter{{end}}" onchange="this.form.submit()">
+        <option value="">Type: All</option>
+        <option value="crash_loop"{{if eq .Filter.IssueType "crash_loop"}} selected{{end}}>crash_loop</option>
+        <option value="image_pull_backoff"{{if eq .Filter.IssueType "image_pull_backoff"}} selected{{end}}>image_pull_backoff</option>
+        <option value="oom_killed"{{if eq .Filter.IssueType "oom_killed"}} selected{{end}}>oom_killed</option>
+        <option value="privileged_container"{{if eq .Filter.IssueType "privileged_container"}} selected{{end}}>privileged_container</option>
+        <option value="unprotected_namespace"{{if eq .Filter.IssueType "unprotected_namespace"}} selected{{end}}>unprotected_namespace</option>
+      </select>
+      <select name="severity" class="inc-select{{if .Filter.Severity}} active-filter{{end}}" onchange="this.form.submit()">
+        <option value="">Severity: All</option>
+        <option value="critical"{{if eq .Filter.Severity "critical"}} selected{{end}}>Critical</option>
+        <option value="high"{{if eq .Filter.Severity "high"}} selected{{end}}>High</option>
+        <option value="medium"{{if eq .Filter.Severity "medium"}} selected{{end}}>Medium</option>
+      </select>
+      <select name="status" class="inc-select{{if .Filter.Status}} active-filter{{end}}" onchange="this.form.submit()">
+        <option value="active"{{if eq .Filter.Status "active"}} selected{{end}}>Active</option>
+        <option value=""{{if eq .Filter.Status ""}} selected{{end}}>All</option>
+        <option value="resolved"{{if eq .Filter.Status "resolved"}} selected{{end}}>Resolved</option>
+        <option value="reopened"{{if eq .Filter.Status "reopened"}} selected{{end}}>Reopened</option>
+      </select>
+      <select name="sort" class="inc-select" onchange="this.form.submit()">
+        <option value="severity"{{if eq .Filter.SortBy "severity"}} selected{{end}}>Sort: Severity</option>
+        <option value="first_seen"{{if eq .Filter.SortBy "first_seen"}} selected{{end}}>Sort: First detected</option>
+        <option value="last_seen"{{if eq .Filter.SortBy "last_seen"}} selected{{end}}>Sort: Last seen</option>
+        <option value="restarts"{{if eq .Filter.SortBy "restarts"}} selected{{end}}>Sort: Restarts</option>
+      </select>
+      <button type="submit" class="inc-btn">Search</button>
+      {{if or .Filter.Text .Filter.Namespace .Filter.IssueType .Filter.Severity}}
+      <a href="/incidents?cluster={{.ClusterName}}" class="inc-btn-clear">Clear</a>
+      {{end}}
     </div>
-    {{if eq (len .Critical) 0}}
-    <div class="all-clear-box">
-      <div class="icon">✅</div>
-      <div>No crash-looping, OOMKilled, or ImagePullBackOff pods detected</div>
+  </form>
+
+  <!-- Summary strip -->
+  <div class="inc-summary">
+    {{if .ActiveCount}}<span class="inc-sum-crit"><b>{{.ActiveCount}}</b> active critical</span>{{end}}
+    {{if .ReopenedCount}}<span class="inc-sum-reo"><b>{{.ReopenedCount}}</b> reopened</span>{{end}}
+    {{if .ResolvedCount}}<span class="inc-sum-res"><b>{{.ResolvedCount}}</b> resolved</span>{{end}}
+    <span class="inc-total"><b style="color:var(--text)">{{.Total}}</b> incidents in memory{{if or .Filter.Text .Filter.Namespace .Filter.IssueType .Filter.Severity .Filter.Status}} matching filters{{end}}</span>
+  </div>
+
+  <!-- Registry table -->
+  <div class="inc-tbl-wrap">
+    {{if .Incidents}}
+    <table class="inc-tbl">
+      <thead>
+        <tr>
+          <th>Severity</th>
+          <th>Incident</th>
+          <th>Namespace</th>
+          <th>Status</th>
+          <th class="sortable{{if eq .Filter.SortBy "first_seen"}} sort-active{{end}}">
+            <a href="?cluster={{.ClusterName}}&q={{.Filter.Text}}&ns={{.Filter.Namespace}}&type={{.Filter.IssueType}}&severity={{.Filter.Severity}}&status={{.Filter.Status}}&sort=first_seen" style="color:inherit;text-decoration:none">
+              First detected <span class="sort-icon">▲▼</span>
+            </a>
+          </th>
+          <th class="sortable{{if eq .Filter.SortBy "last_seen"}} sort-active{{end}}">
+            <a href="?cluster={{.ClusterName}}&q={{.Filter.Text}}&ns={{.Filter.Namespace}}&type={{.Filter.IssueType}}&severity={{.Filter.Severity}}&status={{.Filter.Status}}&sort=last_seen" style="color:inherit;text-decoration:none">
+              Last seen <span class="sort-icon">▲▼</span>
+            </a>
+          </th>
+          <th class="sortable{{if eq .Filter.SortBy "restarts"}} sort-active{{end}}" style="text-align:right">
+            <a href="?cluster={{.ClusterName}}&q={{.Filter.Text}}&ns={{.Filter.Namespace}}&type={{.Filter.IssueType}}&severity={{.Filter.Severity}}&status={{.Filter.Status}}&sort=restarts" style="color:inherit;text-decoration:none">
+              Restarts <span class="sort-icon">▲▼</span>
+            </a>
+          </th>
+          <th>Trend</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {{range .Incidents}}
+        <tr class="{{if eq .Status "resolved"}}inc-row-resolved{{end}}"
+            onclick="window.location='/investigate?pod={{.Resource}}&ns={{.Namespace}}&type={{.IssueType}}&cluster={{$.ClusterName}}'">
+          <td>
+            <span class="inc-sev inc-sev-{{.Severity}}">{{.Severity}}</span>
+          </td>
+          <td>
+            <div class="inc-name">
+              {{if eq .IssueType "unprotected_namespace"}}{{.Namespace}}{{else}}{{.Resource}}{{end}}
+            </div>
+            <div class="inc-type">{{.IssueType}}</div>
+          </td>
+          <td class="inc-ns">{{.Namespace}}</td>
+          <td>
+            {{if eq .Status "resolved"}}
+              <span class="inc-status inc-status-resolved"><span class="inc-dot"></span>Resolved</span>
+            {{else if gt .ReopenCount 0}}
+              <span class="inc-status inc-status-reopened"><span class="inc-dot"></span>Reopened<span class="inc-reopen-n">×{{.ReopenCount}}</span></span>
+            {{else}}
+              <span class="inc-status inc-status-active"><span class="inc-dot"></span>Active</span>
+            {{end}}
+          </td>
+          <td class="inc-age">{{firstDetected .FirstSeen}}</td>
+          <td class="inc-age">{{lastSeen .LastSeen}}</td>
+          <td class="inc-num">
+            {{if gt .RestartCount 0}}{{.RestartCount}}{{else}}<span class="inc-dash">—</span>{{end}}
+          </td>
+          <td>
+            {{if .Trend}}
+              <span class="inc-trend inc-trend-{{.Trend}}">
+                {{if eq .Trend "accelerating"}}↑ accelerating
+                {{else if eq .Trend "stable"}}→ stable
+                {{else if eq .Trend "recovering"}}↓ recovering
+                {{else}}{{.Trend}}{{end}}
+              </span>
+            {{else if eq .Status "resolved"}}
+              <span class="inc-age">recovered in {{recoveredIn .FirstSeen .LastSeen}}</span>
+            {{else}}
+              <span class="inc-dash">—</span>
+            {{end}}
+          </td>
+          <td class="inc-arrow">→</td>
+        </tr>
+        {{end}}
+      </tbody>
+    </table>
+
+    <!-- Pagination -->
+    <div class="inc-pager">
+      <span>
+        Showing <b style="color:var(--text)">{{pageStart .Page .PerPage}}–{{pageEnd .Page .PerPage .Total}}</b>
+        of <b style="color:var(--text)">{{.Total}}</b>
+        {{if gt .Total 1}}incidents{{else}}incident{{end}}
+        · sorted by {{.Filter.SortBy}}, newest first
+      </span>
+      <div class="inc-pager-btns">
+        {{if gt .Page 1}}
+        <a href="?cluster={{.ClusterName}}&q={{.Filter.Text}}&ns={{.Filter.Namespace}}&type={{.Filter.IssueType}}&severity={{.Filter.Severity}}&status={{.Filter.Status}}&sort={{.Filter.SortBy}}&page={{prevPage .Page}}">
+          <button class="inc-pg">‹ Prev</button>
+        </a>
+        {{end}}
+        {{range pageRange .Page .TotalPages}}
+        <a href="?cluster={{.ClusterName}}&q={{$.Filter.Text}}&ns={{$.Filter.Namespace}}&type={{$.Filter.IssueType}}&severity={{$.Filter.Severity}}&status={{$.Filter.Status}}&sort={{$.Filter.SortBy}}&page={{.}}">
+          <button class="inc-pg{{if eq . $.Page}} inc-pg-cur{{end}}">{{.}}</button>
+        </a>
+        {{end}}
+        {{if lt .Page .TotalPages}}
+        <a href="?cluster={{.ClusterName}}&q={{.Filter.Text}}&ns={{.Filter.Namespace}}&type={{.Filter.IssueType}}&severity={{.Filter.Severity}}&status={{.Filter.Status}}&sort={{.Filter.SortBy}}&page={{nextPage .Page .TotalPages}}">
+          <button class="inc-pg">Next ›</button>
+        </a>
+        {{end}}
+      </div>
     </div>
+
     {{else}}
-    <div class="wr-grid">
-      {{range .Critical}}{{renderCard .}}{{end}}
+    <!-- Empty state -->
+    <div class="inc-empty">
+      <div class="inc-empty-icon">🔍</div>
+      <div class="inc-empty-msg">No incidents match your filters</div>
+      <div class="inc-empty-sub">
+        {{if or .Filter.Text .Filter.Namespace .Filter.IssueType .Filter.Severity}}
+          Try clearing some filters — <a href="/incidents?cluster={{.ClusterName}}" style="color:var(--primary-light)">show all active</a>
+        {{else}}
+          No active incidents detected. This cluster looks healthy.
+        {{end}}
+      </div>
     </div>
     {{end}}
   </div>
 
-  <div class="wr-section">
-    <div class="wr-section-hdr">
-      <h2>🟡 High Severity</h2>
-      <span class="cnt-chip w">{{len .Warnings}}</span>
-    </div>
-    {{if eq (len .Warnings) 0}}
-    <div class="all-clear-box">
-      <div class="icon">✅</div>
-      <div>No unprotected namespaces, orphaned PVCs, or zero-replica workloads detected</div>
-    </div>
-    {{else}}
-    <div class="wr-grid">
-      {{range .Warnings}}{{renderCard .}}{{end}}
-    </div>
-    {{end}}
-  </div>
-
-  <div class="footer">OpsCart FinOps Engine &middot; Incidents &middot; All active issues &mdash; verify with owners before acting</div>
 </main>
 </div>
 <script>
 (function(){
-  var TS={{.ScannedAtMs}},el=document.getElementById('inc-age');
+  var el = document.getElementById('inc-age');
+  var TS = Date.now();
   function upd(){
-    var s=Math.floor((Date.now()-TS)/1000);
-    var t=s<5?'just now':s<60?s+'s ago':Math.floor(s/60)+'m ago';
-    if(el)el.textContent=t;
+    var s = Math.floor((Date.now()-TS)/1000);
+    var t = s<5?'just now':s<60?s+'s ago':Math.floor(s/60)+'m ago';
+    if(el) el.textContent = t;
   }
-  setInterval(upd,1000);upd();
+  setInterval(upd,1000); upd();
+  // submit form on Enter in search box
+  var inp = document.querySelector('.inc-search input');
+  if(inp) inp.addEventListener('keydown', function(e){
+    if(e.key==='Enter'){ e.preventDefault(); document.getElementById('inc-form').submit(); }
+  });
 })();
 </script>
 </body>

--- a/deploy/dashboard.yaml
+++ b/deploy/dashboard.yaml
@@ -127,6 +127,10 @@ spec:
           env:
             - name: OPSCART_DB_PATH
               value: /data/opscart.db
+            # Resolved incidents/events older than this are pruned each scan
+            # cycle; 0 = keep forever.
+            - name: OPSCART_RETENTION_DAYS
+              value: "90"
           ports:
             - name: http
               containerPort: 8080

--- a/helm/opscart-watcher/templates/deployment.yaml
+++ b/helm/opscart-watcher/templates/deployment.yaml
@@ -49,6 +49,8 @@ spec:
           env:
             - name: OPSCART_DB_PATH
               value: /data/opscart.db
+            - name: OPSCART_RETENTION_DAYS
+              value: {{ .Values.retentionDays | quote }}
           ports:
             - name: http
               containerPort: {{ .Values.service.targetPort }}

--- a/helm/opscart-watcher/values.yaml
+++ b/helm/opscart-watcher/values.yaml
@@ -29,6 +29,8 @@ persistence:
   storageClassName: ""   # empty = cluster default
   existingClaim: ""      # use a pre-created PVC instead of templating one
 
+retentionDays: 90   # resolved incidents/events older than this are pruned each scan cycle; 0 = keep forever
+
 resources:
   requests:
     cpu: 100m

--- a/pkg/store/null.go
+++ b/pkg/store/null.go
@@ -1,5 +1,7 @@
 package store
 
+import "time"
+
 // NullStore is a no-op Store implementation used when persistence is
 // disabled.
 type NullStore struct{}
@@ -36,6 +38,14 @@ func (NullStore) GetIncidentHistory(cluster string, fingerprint string) (*Incide
 
 func (NullStore) GetIncidentTimeline(cluster string, fingerprint string) ([]IncidentEvent, error) {
 	return nil, nil
+}
+
+func (NullStore) QueryIncidents(f IncidentFilter) ([]IncidentSummary, int, error) {
+	return nil, 0, nil
+}
+
+func (NullStore) PruneOlderThan(cluster string, cutoff time.Time) (int, error) {
+	return 0, nil
 }
 
 func (NullStore) Close() error {

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -3,6 +3,7 @@ package store
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	_ "modernc.org/sqlite"
@@ -13,7 +14,7 @@ var _ Store = (*SQLiteStore)(nil)
 // schemaVersion is stored in PRAGMA user_version. Bump it whenever the
 // schema changes, and teach migrateSchema how to reach it from the
 // previous version.
-const schemaVersion = 3
+const schemaVersion = 4
 
 // restartMilestones are the restart-count thresholds that generate a
 // RestartMilestone timeline event when crossed.
@@ -27,6 +28,8 @@ var restartMilestones = []int{10, 50, 100, 500, 1000, 2500, 5000, 10000}
 const resolveThreshold = 3
 
 const schema = `
+PRAGMA auto_vacuum = INCREMENTAL;
+
 CREATE TABLE IF NOT EXISTS cluster_snapshots (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
     scan_id         TEXT    NOT NULL,
@@ -61,6 +64,9 @@ CREATE TABLE IF NOT EXISTS incidents (
     missing_scans         INTEGER NOT NULL DEFAULT 0
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_inc_fp ON incidents(cluster, fingerprint);
+CREATE INDEX IF NOT EXISTS idx_incidents_cluster_status ON incidents(cluster, status);
+CREATE INDEX IF NOT EXISTS idx_incidents_cluster_ns ON incidents(cluster, namespace);
+CREATE INDEX IF NOT EXISTS idx_incidents_cluster_first ON incidents(cluster, first_seen);
 
 CREATE TABLE IF NOT EXISTS scan_history (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -177,6 +183,17 @@ func migrateSchema(db *sql.DB) error {
 		    message       TEXT
 		);
 		CREATE INDEX IF NOT EXISTS idx_incident_events_incident ON incident_events(incident_id, occurred_at);
+	`); err != nil {
+		return err
+	}
+
+	// Query-path indexes for the incidents registry (QueryIncidents). Added
+	// unconditionally and idempotently regardless of the version being
+	// migrated from — cheap to check, safe to re-run.
+	if _, err := tx.Exec(`
+		CREATE INDEX IF NOT EXISTS idx_incidents_cluster_status ON incidents(cluster, status);
+		CREATE INDEX IF NOT EXISTS idx_incidents_cluster_ns ON incidents(cluster, namespace);
+		CREATE INDEX IF NOT EXISTS idx_incidents_cluster_first ON incidents(cluster, first_seen);
 	`); err != nil {
 		return err
 	}
@@ -668,6 +685,414 @@ func (s *SQLiteStore) GetIncidentTimeline(cluster string, fingerprint string) ([
 		})
 	}
 	return out, rows.Err()
+}
+
+// inClause builds a "?,?,?" placeholder string and matching args slice for
+// an IN(...) clause over ids. Callers must guard len(ids) == 0 themselves
+// (an empty IN() is invalid SQL).
+func inClause(ids []int64) (string, []any) {
+	placeholders := make([]string, len(ids))
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	return strings.Join(placeholders, ","), args
+}
+
+// orderByClause maps IncidentFilter.SortBy to a trusted (non-user-supplied)
+// ORDER BY expression. Every branch is a fixed string from this switch, so
+// interpolating it into the query below is not a SQL-injection risk. A
+// secondary "id" sort keeps pagination deterministic when the primary key
+// has ties.
+func orderByClause(sortBy string, desc bool) string {
+	col := "last_seen"
+	switch sortBy {
+	case "severity":
+		col = `CASE severity
+			WHEN 'critical' THEN 0
+			WHEN 'high' THEN 1
+			WHEN 'medium' THEN 2
+			WHEN 'low' THEN 3
+			ELSE 4
+		END`
+	case "first_seen":
+		col = "first_seen"
+	case "restarts":
+		col = "current_restart_count"
+	case "last_seen", "":
+		col = "last_seen"
+	}
+	dir := "ASC"
+	if desc {
+		dir = "DESC"
+	}
+	return col + " " + dir + ", id " + dir
+}
+
+// trendEvent is one DETECTED/RestartMilestone event, used by deriveTrend.
+type trendEvent struct {
+	occurredAt   int64
+	restartCount int
+}
+
+// batchReopenCounts returns, for each incident id, the number of REOPENED
+// events in its journal. One query for the whole page — never per-row.
+func (s *SQLiteStore) batchReopenCounts(ids []int64) (map[int64]int, error) {
+	counts := make(map[int64]int, len(ids))
+	if len(ids) == 0 {
+		return counts, nil
+	}
+	placeholders, args := inClause(ids)
+	rows, err := s.db.Query(fmt.Sprintf(
+		`SELECT incident_id, COUNT(*) FROM incident_events
+		 WHERE incident_id IN (%s) AND event_type = 'REOPENED'
+		 GROUP BY incident_id`,
+		placeholders,
+	), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id int64
+		var count int
+		if err := rows.Scan(&id, &count); err != nil {
+			return nil, err
+		}
+		counts[id] = count
+	}
+	return counts, rows.Err()
+}
+
+// batchTrendEvents returns, for each incident id, its two most recent
+// DETECTED/RestartMilestone events (newest first) — the only journal
+// entries that carry both a restart count and a timestamp without scanning
+// every event. One windowed query for the whole page.
+func (s *SQLiteStore) batchTrendEvents(ids []int64) (map[int64][]trendEvent, error) {
+	out := make(map[int64][]trendEvent, len(ids))
+	if len(ids) == 0 {
+		return out, nil
+	}
+	placeholders, args := inClause(ids)
+	rows, err := s.db.Query(fmt.Sprintf(`
+		SELECT incident_id, occurred_at, restart_count FROM (
+			SELECT incident_id, occurred_at, restart_count,
+				ROW_NUMBER() OVER (
+					PARTITION BY incident_id
+					ORDER BY occurred_at DESC, id DESC
+				) AS rn
+			FROM incident_events
+			WHERE incident_id IN (%s)
+			  AND (event_type = 'DETECTED'
+				OR (event_type = 'UPDATED' AND event_reason = 'RestartMilestone'))
+		) WHERE rn <= 2
+		ORDER BY incident_id, occurred_at DESC
+	`, placeholders), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id int64
+		var e trendEvent
+		if err := rows.Scan(&id, &e.occurredAt, &e.restartCount); err != nil {
+			return nil, err
+		}
+		out[id] = append(out[id], e)
+	}
+	return out, rows.Err()
+}
+
+// deriveTrend classifies an active incident's restart trajectory as
+// "accelerating" or "stable" from its two most recent milestone-relevant
+// events (DETECTED and RestartMilestone) — the cheapest points in the
+// journal that carry both a restart count and a timestamp.
+//
+// Heuristic: lifetimeRate is total restarts/day since first_seen. recentRate
+// is restarts/day between the two most recent events. If recentRate exceeds
+// lifetimeRate by more than 25%, the incident is "accelerating" (restarting
+// faster than its own history predicts). Otherwise — including incidents
+// with fewer than two such events, or whose most recent event is more than
+// 24h old (no recent movement to compare) — it is "stable".
+//
+// This intentionally approximates a 48h window with whatever two events
+// happen to exist rather than sampling restart_count on a fixed schedule,
+// so it stays a single indexed query with no per-row journal scan.
+// "recovering" is reserved for a future trend dimension (e.g. severity
+// de-escalation): restart counts are monotonically non-decreasing within an
+// incident's active lifetime, so this heuristic never emits it.
+func deriveTrend(events []trendEvent, currentRestart int, firstSeenUnix int64) string {
+	now := time.Now().Unix()
+
+	daysSinceFirst := float64(now-firstSeenUnix) / 86400
+	if daysSinceFirst < 1 {
+		daysSinceFirst = 1
+	}
+	lifetimeRate := float64(currentRestart) / daysSinceFirst
+
+	if len(events) < 2 {
+		return "stable"
+	}
+	// events[0] is the most recent (see batchTrendEvents' DESC ordering).
+	latest, prev := events[0], events[1]
+
+	if now-latest.occurredAt > 24*3600 {
+		return "stable"
+	}
+
+	elapsedHours := float64(latest.occurredAt-prev.occurredAt) / 3600
+	if elapsedHours < 1 {
+		elapsedHours = 1
+	}
+	recentRate := float64(latest.restartCount-prev.restartCount) / (elapsedHours / 24)
+
+	if recentRate > lifetimeRate*1.25 {
+		return "accelerating"
+	}
+	return "stable"
+}
+
+// QueryIncidents implements the incidents registry: a filtered, sorted,
+// paginated view over the incidents table plus derived per-row fields
+// (ReopenCount, Trend) computed with two batched follow-up queries rather
+// than per-row lookups.
+func (s *SQLiteStore) QueryIncidents(f IncidentFilter) ([]IncidentSummary, int, error) {
+	where := []string{"cluster = ?"}
+	args := []any{f.Cluster}
+
+	if f.Text != "" {
+		like := "%" + f.Text + "%"
+		where = append(where, "(resource LIKE ? OR namespace LIKE ? OR issue_type LIKE ?)")
+		args = append(args, like, like, like)
+	}
+	if f.Namespace != "" {
+		where = append(where, "namespace = ?")
+		args = append(args, f.Namespace)
+	}
+	if f.IssueType != "" {
+		where = append(where, "issue_type = ?")
+		args = append(args, f.IssueType)
+	}
+	if f.Severity != "" {
+		where = append(where, "severity = ?")
+		args = append(args, f.Severity)
+	}
+	if !f.SinceFirst.IsZero() {
+		where = append(where, "first_seen >= ?")
+		args = append(args, f.SinceFirst.Unix())
+	}
+	switch f.Status {
+	case "active":
+		where = append(where, "status = 'active'")
+	case "resolved":
+		where = append(where, "status = 'resolved'")
+	case "reopened":
+		where = append(where, `status = 'active' AND id IN (
+			SELECT incident_id FROM incident_events WHERE event_type = 'REOPENED'
+		)`)
+	}
+	whereClause := "WHERE " + strings.Join(where, " AND ")
+
+	var total int
+	if err := s.db.QueryRow(
+		"SELECT COUNT(*) FROM incidents "+whereClause, args...,
+	).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+	if total == 0 {
+		return nil, 0, nil
+	}
+
+	perPage := f.PerPage
+	if perPage <= 0 {
+		perPage = 50
+	}
+	if perPage > 200 {
+		perPage = 200
+	}
+	page := f.Page
+	if page < 1 {
+		page = 1
+	}
+	offset := (page - 1) * perPage
+
+	rowArgs := append(append([]any{}, args...), perPage, offset)
+	rows, err := s.db.Query(fmt.Sprintf(
+		`SELECT id, fingerprint, namespace, resource, issue_type, severity,
+			status, first_seen, last_seen, current_restart_count
+		 FROM incidents %s ORDER BY %s LIMIT ? OFFSET ?`,
+		whereClause, orderByClause(f.SortBy, f.SortDesc),
+	), rowArgs...)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	type rawRow struct {
+		id                     int64
+		fingerprint, namespace string
+		resource, issueType    string
+		severity, status       string
+		firstSeen, lastSeen    int64
+		restartCount           int
+	}
+	var raws []rawRow
+	ids := make([]int64, 0, perPage)
+	for rows.Next() {
+		var r rawRow
+		if err := rows.Scan(
+			&r.id, &r.fingerprint, &r.namespace, &r.resource, &r.issueType,
+			&r.severity, &r.status, &r.firstSeen, &r.lastSeen, &r.restartCount,
+		); err != nil {
+			rows.Close()
+			return nil, 0, err
+		}
+		raws = append(raws, r)
+		ids = append(ids, r.id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
+	rows.Close()
+
+	reopenCounts, err := s.batchReopenCounts(ids)
+	if err != nil {
+		return nil, 0, err
+	}
+	trendInputs, err := s.batchTrendEvents(ids)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	items := make([]IncidentSummary, 0, len(raws))
+	for _, r := range raws {
+		summary := IncidentSummary{
+			Fingerprint:  r.fingerprint,
+			Namespace:    r.namespace,
+			Resource:     r.resource,
+			IssueType:    r.issueType,
+			Severity:     r.severity,
+			Status:       r.status,
+			ReopenCount:  reopenCounts[r.id],
+			FirstSeen:    time.Unix(r.firstSeen, 0),
+			LastSeen:     time.Unix(r.lastSeen, 0),
+			RestartCount: r.restartCount,
+		}
+		if r.status == "active" {
+			summary.Trend = deriveTrend(trendInputs[r.id], r.restartCount, r.firstSeen)
+		}
+		items = append(items, summary)
+	}
+
+	return items, total, nil
+}
+
+// PruneOlderThan removes data older than cutoff for cluster, in one
+// transaction:
+//   - Resolved incidents (and their full event history) are deleted once
+//     last_seen falls before cutoff.
+//   - Active incidents are never deleted regardless of age — only their
+//     event journal is trimmed, and even then the DETECTED event is kept
+//     forever so an incident's first-seen provenance always survives.
+//   - cluster_snapshots and scan_history rows older than cutoff are deleted
+//     outright — they carry no active/resolved notion of their own.
+//
+// The returned count is the number of resolved incidents deleted.
+func (s *SQLiteStore) PruneOlderThan(cluster string, cutoff time.Time) (int, error) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	cutoffUnix := cutoff.Unix()
+
+	rows, err := tx.Query(
+		`SELECT id FROM incidents WHERE cluster = ? AND status = 'resolved' AND last_seen < ?`,
+		cluster, cutoffUnix,
+	)
+	if err != nil {
+		return 0, err
+	}
+	var resolvedIDs []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		resolvedIDs = append(resolvedIDs, id)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	rows.Close()
+
+	if len(resolvedIDs) > 0 {
+		placeholders, idArgs := inClause(resolvedIDs)
+		if _, err := tx.Exec(
+			fmt.Sprintf(`DELETE FROM incident_events WHERE incident_id IN (%s)`, placeholders),
+			idArgs...,
+		); err != nil {
+			return 0, err
+		}
+		if _, err := tx.Exec(
+			fmt.Sprintf(`DELETE FROM incidents WHERE id IN (%s)`, placeholders),
+			idArgs...,
+		); err != nil {
+			return 0, err
+		}
+	}
+
+	if _, err := tx.Exec(
+		`DELETE FROM incident_events
+		 WHERE occurred_at < ?
+		   AND event_type != 'DETECTED'
+		   AND incident_id IN (SELECT id FROM incidents WHERE cluster = ? AND status = 'active')`,
+		cutoffUnix, cluster,
+	); err != nil {
+		return 0, err
+	}
+
+	if _, err := tx.Exec(
+		`DELETE FROM cluster_snapshots WHERE cluster = ? AND scanned_at < ?`,
+		cluster, cutoffUnix,
+	); err != nil {
+		return 0, err
+	}
+
+	if _, err := tx.Exec(
+		`DELETE FROM scan_history WHERE cluster = ? AND scanned_at < ?`,
+		cluster, cutoffUnix,
+	); err != nil {
+		return 0, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+
+	pruned := len(resolvedIDs)
+	if pruned > 0 {
+		// Reclaim the pages just freed above. PRAGMA incremental_vacuum
+		// (not VACUUM) because: VACUUM rewrites the entire database file
+		// and cannot run inside a transaction — on this store's
+		// single-writer connection (SetMaxOpenConns(1) in OpenSQLite) it
+		// would stall every other DB operation for its duration, which is
+		// unacceptable on a per-scan-cycle cadence. incremental_vacuum only
+		// touches pages already marked free by this prune, runs standalone
+		// with no explicit transaction, and is checkpointed into the WAL
+		// like any other write. It requires auto_vacuum=INCREMENTAL, set at
+		// schema creation for new databases; databases created before this
+		// schema version keep auto_vacuum=NONE (retrofitting it requires a
+		// full VACUUM, which we avoid for the same reason), so this call is
+		// simply a no-op for them — freed pages are still reused for new
+		// rows either way, making this a disk-usage optimization rather
+		// than a correctness concern. Best-effort: errors are ignored.
+		_, _ = s.db.Exec("PRAGMA incremental_vacuum")
+	}
+
+	return pruned, nil
 }
 
 func (s *SQLiteStore) Close() error {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -13,6 +13,8 @@ type Store interface {
 	GetLatestSnapshot(cluster string) (*SnapshotData, error)
 	GetIncidentHistory(cluster string, fingerprint string) (*IncidentRecord, error)
 	GetIncidentTimeline(cluster string, fingerprint string) ([]IncidentEvent, error)
+	QueryIncidents(f IncidentFilter) (items []IncidentSummary, total int, err error)
+	PruneOlderThan(cluster string, cutoff time.Time) (pruned int, err error)
 	Close() error
 }
 
@@ -82,4 +84,47 @@ type IncidentEvent struct {
 	Severity     string
 	State        string
 	Message      string
+}
+
+// IncidentFilter narrows a QueryIncidents call. Cluster is required; every
+// other field is optional and its zero value means "no filter on this
+// dimension".
+type IncidentFilter struct {
+	Cluster    string
+	Text       string // matches resource, namespace, issue_type (LIKE, case-insensitive)
+	Namespace  string // exact, empty = all
+	IssueType  string // exact, empty = all
+	Severity   string // exact, empty = all
+	Status     string // "active" | "resolved" | "reopened" | "" (all)
+	SinceFirst time.Time
+	SortBy     string // "severity" | "first_seen" | "last_seen" | "restarts"
+	SortDesc   bool
+	Page       int // 1-based
+	PerPage    int // default 50, cap 200
+}
+
+// IncidentSummary is one row of a QueryIncidents result page.
+type IncidentSummary struct {
+	Fingerprint  string
+	Namespace    string
+	Resource     string
+	IssueType    string
+	Severity     string
+	Status       string // active | resolved
+	ReopenCount  int
+	FirstSeen    time.Time
+	LastSeen     time.Time
+	RestartCount int
+	Trend        string // "accelerating" | "stable" | "recovering" | ""
+}
+
+// RetentionCutoff computes the cutoff time for PruneOlderThan given a
+// retention window in days. days <= 0 disables retention ("keep forever"),
+// signaled by enabled=false; callers must not call PruneOlderThan in that
+// case.
+func RetentionCutoff(days int, now time.Time) (cutoff time.Time, enabled bool) {
+	if days <= 0 {
+		return time.Time{}, false
+	}
+	return now.AddDate(0, 0, -days), true
 }

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -1046,3 +1046,624 @@ func TestMigration_Idempotent(t *testing.T) {
 		t.Fatalf("expected user_version=%d, got %d", schemaVersion, version)
 	}
 }
+
+// TestMigration_QueryIndexesIdempotent verifies that opening a database from
+// the previous schema version (which lacks the incidents-registry query
+// indexes) adds them exactly once, without error, whether opened one or
+// multiple times.
+func TestMigration_QueryIndexesIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "v3.db")
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open v3 db: %v", err)
+	}
+	if _, err := db.Exec(`
+		CREATE TABLE incidents (
+		    id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+		    fingerprint           TEXT    NOT NULL,
+		    cluster               TEXT    NOT NULL,
+		    namespace             TEXT    NOT NULL,
+		    resource              TEXT    NOT NULL,
+		    issue_type            TEXT    NOT NULL,
+		    severity              TEXT    NOT NULL,
+		    first_seen            INTEGER NOT NULL,
+		    last_seen             INTEGER NOT NULL,
+		    details_json          TEXT,
+		    status                TEXT    NOT NULL DEFAULT 'active',
+		    last_scan_id          TEXT,
+		    current_restart_count INTEGER NOT NULL DEFAULT 0,
+		    missing_scans         INTEGER NOT NULL DEFAULT 0
+		);
+		CREATE UNIQUE INDEX idx_inc_fp ON incidents(cluster, fingerprint);
+
+		CREATE TABLE incident_events (
+		    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+		    incident_id   INTEGER NOT NULL,
+		    scan_id       TEXT    NOT NULL,
+		    occurred_at   INTEGER NOT NULL,
+		    event_type    TEXT    NOT NULL,
+		    event_reason  TEXT,
+		    restart_count INTEGER,
+		    severity      TEXT,
+		    state         TEXT,
+		    message       TEXT
+		);
+		CREATE INDEX idx_incident_events_incident ON incident_events(incident_id, occurred_at);
+
+		CREATE TABLE cluster_snapshots (
+		    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+		    scan_id         TEXT    NOT NULL,
+		    cluster         TEXT    NOT NULL,
+		    scanned_at      INTEGER NOT NULL,
+		    incident_score  INTEGER NOT NULL,
+		    critical_count  INTEGER NOT NULL,
+		    warning_count   INTEGER NOT NULL,
+		    security_score  INTEGER NOT NULL,
+		    waste_count     INTEGER NOT NULL,
+		    monthly_cost    REAL    NOT NULL,
+		    pod_count       INTEGER,
+		    namespace_count INTEGER,
+		    node_count      INTEGER
+		);
+
+		CREATE TABLE scan_history (
+		    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+		    scan_id     TEXT    NOT NULL,
+		    cluster     TEXT    NOT NULL,
+		    scanned_at  INTEGER NOT NULL,
+		    duration_ms INTEGER,
+		    success     INTEGER NOT NULL DEFAULT 1,
+		    error       TEXT,
+		    version     TEXT
+		);
+
+		PRAGMA user_version = 3;
+	`); err != nil {
+		t.Fatalf("create v3 schema: %v", err)
+	}
+	db.Close()
+
+	assertMigrated := func() {
+		s, err := OpenSQLite(path)
+		if err != nil {
+			t.Fatalf("OpenSQLite: %v", err)
+		}
+		defer s.Close()
+
+		var version int
+		if err := s.db.QueryRow("PRAGMA user_version").Scan(&version); err != nil {
+			t.Fatalf("PRAGMA user_version: %v", err)
+		}
+		if version != schemaVersion {
+			t.Fatalf("expected user_version=%d, got %d", schemaVersion, version)
+		}
+
+		rows, err := s.db.Query(`PRAGMA index_list(incidents)`)
+		if err != nil {
+			t.Fatalf("PRAGMA index_list: %v", err)
+		}
+		defer rows.Close()
+		names := map[string]bool{}
+		for rows.Next() {
+			var seq, unique, partial int
+			var name, origin string
+			if err := rows.Scan(&seq, &name, &unique, &origin, &partial); err != nil {
+				t.Fatalf("scan index_list row: %v", err)
+			}
+			names[name] = true
+		}
+		if err := rows.Err(); err != nil {
+			t.Fatalf("index_list rows: %v", err)
+		}
+		for _, want := range []string{"idx_incidents_cluster_status", "idx_incidents_cluster_ns", "idx_incidents_cluster_first"} {
+			if !names[want] {
+				t.Fatalf("expected index %s to exist, got %v", want, names)
+			}
+		}
+	}
+
+	// First open performs the migration; second open must be a no-op.
+	assertMigrated()
+	assertMigrated()
+}
+
+// ── Incidents registry: QueryIncidents ──────────────────────────────────────
+
+// insertRawIncident inserts an incidents row directly via SQL, bypassing
+// UpsertIncidents, so tests can control first_seen/last_seen/status/
+// restart_count precisely instead of relying on time.Now().
+func insertRawIncident(t *testing.T, s *SQLiteStore, cluster string, inc IncidentData, status string, firstSeen, lastSeen time.Time) int64 {
+	t.Helper()
+	res, err := s.db.Exec(
+		`INSERT INTO incidents (
+			fingerprint, cluster, namespace, resource, issue_type, severity,
+			first_seen, last_seen, details_json, status, last_scan_id,
+			current_restart_count, missing_scans
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'scan-fixture', ?, 0)`,
+		inc.Fingerprint, cluster, inc.Namespace, inc.Resource, inc.IssueType, inc.Severity,
+		firstSeen.Unix(), lastSeen.Unix(), inc.DetailsJSON, status, inc.RestartCount,
+	)
+	if err != nil {
+		t.Fatalf("insertRawIncident: %v", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("insertRawIncident LastInsertId: %v", err)
+	}
+	return id
+}
+
+// insertRawEvent inserts an incident_events row directly, for precise
+// control over occurred_at/restart_count in trend and retention fixtures.
+func insertRawEvent(t *testing.T, s *SQLiteStore, incidentID int64, eventType, eventReason string, restartCount int, occurredAt time.Time) {
+	t.Helper()
+	_, err := s.db.Exec(
+		`INSERT INTO incident_events (
+			incident_id, scan_id, occurred_at, event_type, event_reason,
+			restart_count, severity, state, message
+		) VALUES (?, 'scan-fixture', ?, ?, ?, ?, 'critical', 'active', 'fixture')`,
+		incidentID, occurredAt.Unix(), eventType, eventReason, restartCount,
+	)
+	if err != nil {
+		t.Fatalf("insertRawEvent: %v", err)
+	}
+}
+
+func TestQueryIncidents_Filters(t *testing.T) {
+	s := openTestStore(t)
+	now := time.Now()
+
+	incA := IncidentData{Fingerprint: "ns-a/Deployment/svc-a/crash_loop", Namespace: "ns-a", Resource: "svc-a", IssueType: "crash_loop", Severity: "critical", RestartCount: 50}
+	incB := IncidentData{Fingerprint: "ns-b/Deployment/svc-b/oom", Namespace: "ns-b", Resource: "svc-b", IssueType: "oom", Severity: "medium", RestartCount: 5}
+	incC := IncidentData{Fingerprint: "ns-a/Deployment/svc-c/image_pull", Namespace: "ns-a", Resource: "svc-c", IssueType: "image_pull", Severity: "high", RestartCount: 0}
+
+	insertRawIncident(t, s, "test-cluster", incA, "active", now.Add(-10*24*time.Hour), now.Add(-1*time.Hour))
+	insertRawIncident(t, s, "test-cluster", incB, "resolved", now.Add(-5*24*time.Hour), now.Add(-2*time.Hour))
+	insertRawIncident(t, s, "test-cluster", incC, "active", now.Add(-1*time.Hour), now)
+
+	// Text filter matches resource/namespace/issue_type, case-insensitive.
+	items, total, err := s.QueryIncidents(IncidentFilter{Cluster: "test-cluster", Text: "SVC-A"})
+	if err != nil {
+		t.Fatalf("QueryIncidents(text): %v", err)
+	}
+	if total != 1 || len(items) != 1 || items[0].Resource != "svc-a" {
+		t.Fatalf("expected 1 match for text=SVC-A, got total=%d items=%+v", total, items)
+	}
+
+	// Namespace filter, exact.
+	if _, total, err = s.QueryIncidents(IncidentFilter{Cluster: "test-cluster", Namespace: "ns-a"}); err != nil {
+		t.Fatalf("QueryIncidents(namespace): %v", err)
+	} else if total != 2 {
+		t.Fatalf("expected 2 incidents in ns-a, got %d", total)
+	}
+
+	// IssueType filter.
+	if items, total, err = s.QueryIncidents(IncidentFilter{Cluster: "test-cluster", IssueType: "oom"}); err != nil {
+		t.Fatalf("QueryIncidents(issue_type): %v", err)
+	} else if total != 1 || items[0].IssueType != "oom" {
+		t.Fatalf("expected 1 oom incident, got total=%d items=%+v", total, items)
+	}
+
+	// Severity filter.
+	if _, total, err = s.QueryIncidents(IncidentFilter{Cluster: "test-cluster", Severity: "critical"}); err != nil {
+		t.Fatalf("QueryIncidents(severity): %v", err)
+	} else if total != 1 {
+		t.Fatalf("expected 1 critical incident, got %d", total)
+	}
+
+	// Status filter: active vs resolved.
+	if _, total, err = s.QueryIncidents(IncidentFilter{Cluster: "test-cluster", Status: "resolved"}); err != nil {
+		t.Fatalf("QueryIncidents(status=resolved): %v", err)
+	} else if total != 1 {
+		t.Fatalf("expected 1 resolved incident, got %d", total)
+	}
+	if _, total, err = s.QueryIncidents(IncidentFilter{Cluster: "test-cluster", Status: "active"}); err != nil {
+		t.Fatalf("QueryIncidents(status=active): %v", err)
+	} else if total != 2 {
+		t.Fatalf("expected 2 active incidents, got %d", total)
+	}
+
+	// SinceFirst: only incidents first_seen within the last 3 days -> incC.
+	if _, total, err = s.QueryIncidents(IncidentFilter{Cluster: "test-cluster", SinceFirst: now.Add(-3 * 24 * time.Hour)}); err != nil {
+		t.Fatalf("QueryIncidents(since_first): %v", err)
+	} else if total != 1 {
+		t.Fatalf("expected 1 incident first_seen within last 3 days, got %d", total)
+	}
+}
+
+func TestQueryIncidents_Pagination(t *testing.T) {
+	s := openTestStore(t)
+	now := time.Now()
+
+	for i := 0; i < 5; i++ {
+		inc := IncidentData{
+			Fingerprint: fmt.Sprintf("default/Deployment/svc-%d/crash_loop", i),
+			Namespace:   "default", Resource: fmt.Sprintf("svc-%d", i), IssueType: "crash_loop", Severity: "critical",
+		}
+		insertRawIncident(t, s, "test-cluster", inc, "active",
+			now.Add(-time.Duration(i)*time.Hour), now.Add(-time.Duration(i)*time.Hour))
+	}
+
+	items1, total1, err := s.QueryIncidents(IncidentFilter{Cluster: "test-cluster", PerPage: 2, Page: 1, SortBy: "first_seen", SortDesc: true})
+	if err != nil {
+		t.Fatalf("QueryIncidents(page1): %v", err)
+	}
+	if total1 != 5 {
+		t.Fatalf("expected total=5, got %d", total1)
+	}
+	if len(items1) != 2 {
+		t.Fatalf("expected 2 items on page 1, got %d", len(items1))
+	}
+
+	items2, total2, err := s.QueryIncidents(IncidentFilter{Cluster: "test-cluster", PerPage: 2, Page: 2, SortBy: "first_seen", SortDesc: true})
+	if err != nil {
+		t.Fatalf("QueryIncidents(page2): %v", err)
+	}
+	if total2 != 5 {
+		t.Fatalf("expected total=5 on page 2, got %d", total2)
+	}
+	if len(items2) != 2 {
+		t.Fatalf("expected 2 items on page 2, got %d", len(items2))
+	}
+
+	items3, total3, err := s.QueryIncidents(IncidentFilter{Cluster: "test-cluster", PerPage: 2, Page: 3, SortBy: "first_seen", SortDesc: true})
+	if err != nil {
+		t.Fatalf("QueryIncidents(page3): %v", err)
+	}
+	if total3 != 5 {
+		t.Fatalf("expected total=5 on page 3, got %d", total3)
+	}
+	if len(items3) != 1 {
+		t.Fatalf("expected 1 item on page 3, got %d", len(items3))
+	}
+
+	seen := map[string]bool{}
+	for _, it := range append(append(items1, items2...), items3...) {
+		if seen[it.Fingerprint] {
+			t.Fatalf("fingerprint %s appeared on more than one page", it.Fingerprint)
+		}
+		seen[it.Fingerprint] = true
+	}
+	if len(seen) != 5 {
+		t.Fatalf("expected 5 distinct fingerprints across pages, got %d", len(seen))
+	}
+
+	// PerPage default (<=0) and cap (>200) both resolve without error; with
+	// only 5 rows in the fixture we can't observe the cap directly, but this
+	// exercises the clamp path.
+	if _, _, err = s.QueryIncidents(IncidentFilter{Cluster: "test-cluster"}); err != nil {
+		t.Fatalf("QueryIncidents(default perPage): %v", err)
+	}
+	itemsCapped, _, err := s.QueryIncidents(IncidentFilter{Cluster: "test-cluster", PerPage: 9999})
+	if err != nil {
+		t.Fatalf("QueryIncidents(capped perPage): %v", err)
+	}
+	if len(itemsCapped) != 5 {
+		t.Fatalf("expected all 5 rows with an oversized PerPage, got %d", len(itemsCapped))
+	}
+}
+
+func TestQueryIncidents_SortOrders(t *testing.T) {
+	s := openTestStore(t)
+	now := time.Now()
+
+	low := IncidentData{Fingerprint: "default/Deployment/svc-low/crash_loop", Namespace: "default", Resource: "svc-low", IssueType: "crash_loop", Severity: "low", RestartCount: 1}
+	crit := IncidentData{Fingerprint: "default/Deployment/svc-crit/crash_loop", Namespace: "default", Resource: "svc-crit", IssueType: "crash_loop", Severity: "critical", RestartCount: 100}
+	med := IncidentData{Fingerprint: "default/Deployment/svc-med/crash_loop", Namespace: "default", Resource: "svc-med", IssueType: "crash_loop", Severity: "medium", RestartCount: 50}
+
+	insertRawIncident(t, s, "test-cluster", low, "active", now.Add(-3*time.Hour), now.Add(-3*time.Hour))
+	insertRawIncident(t, s, "test-cluster", crit, "active", now.Add(-2*time.Hour), now.Add(-30*time.Minute))
+	insertRawIncident(t, s, "test-cluster", med, "active", now.Add(-1*time.Hour), now.Add(-90*time.Minute))
+
+	items, _, err := s.QueryIncidents(IncidentFilter{Cluster: "test-cluster", SortBy: "severity"})
+	if err != nil {
+		t.Fatalf("QueryIncidents(sort=severity): %v", err)
+	}
+	if len(items) != 3 || items[0].Severity != "critical" || items[1].Severity != "medium" || items[2].Severity != "low" {
+		t.Fatalf("expected severity order critical,medium,low, got %+v", items)
+	}
+
+	items, _, err = s.QueryIncidents(IncidentFilter{Cluster: "test-cluster", SortBy: "restarts", SortDesc: true})
+	if err != nil {
+		t.Fatalf("QueryIncidents(sort=restarts desc): %v", err)
+	}
+	if items[0].RestartCount != 100 || items[2].RestartCount != 1 {
+		t.Fatalf("expected restarts desc order, got %+v", items)
+	}
+
+	items, _, err = s.QueryIncidents(IncidentFilter{Cluster: "test-cluster", SortBy: "first_seen"})
+	if err != nil {
+		t.Fatalf("QueryIncidents(sort=first_seen): %v", err)
+	}
+	if items[0].Resource != "svc-low" {
+		t.Fatalf("expected svc-low first (oldest first_seen), got %+v", items)
+	}
+
+	items, _, err = s.QueryIncidents(IncidentFilter{Cluster: "test-cluster", SortBy: "last_seen", SortDesc: true})
+	if err != nil {
+		t.Fatalf("QueryIncidents(sort=last_seen desc): %v", err)
+	}
+	if items[0].Resource != "svc-crit" {
+		t.Fatalf("expected svc-crit first (most recent last_seen), got %+v", items)
+	}
+}
+
+func TestQueryIncidents_ReopenCountAndStatus(t *testing.T) {
+	s := openTestStore(t)
+
+	inc := IncidentData{Fingerprint: "default/Deployment/svc-a/crash_loop", Namespace: "default", Resource: "svc-a", IssueType: "crash_loop", Severity: "critical"}
+	other := IncidentData{Fingerprint: "default/Deployment/svc-b/oom", Namespace: "default", Resource: "svc-b", IssueType: "oom", Severity: "medium"}
+
+	if err := s.UpsertIncidents("test-cluster", "scan-1", []IncidentData{inc, other}); err != nil {
+		t.Fatalf("UpsertIncidents(1): %v", err)
+	}
+	// Resolve + reopen svc-a (inc) twice; svc-b (other) stays present/active
+	// throughout and is never resolved.
+	for i := 0; i < 2; i++ {
+		driveToResolved(t, s, "test-cluster", []IncidentData{other}, fmt.Sprintf("scan-miss-%d", i))
+		if err := s.UpsertIncidents("test-cluster", fmt.Sprintf("scan-reopen-%d", i), []IncidentData{inc, other}); err != nil {
+			t.Fatalf("UpsertIncidents(reopen %d): %v", i, err)
+		}
+	}
+
+	items, total, err := s.QueryIncidents(IncidentFilter{Cluster: "test-cluster", Status: "reopened"})
+	if err != nil {
+		t.Fatalf("QueryIncidents(status=reopened): %v", err)
+	}
+	if total != 1 || len(items) != 1 || items[0].Fingerprint != inc.Fingerprint {
+		t.Fatalf("expected only svc-a under status=reopened, got total=%d items=%+v", total, items)
+	}
+	if items[0].ReopenCount != 2 {
+		t.Fatalf("expected ReopenCount=2, got %d", items[0].ReopenCount)
+	}
+	if items[0].Status != "active" {
+		t.Fatalf("expected reopened incident status=active, got %s", items[0].Status)
+	}
+
+	itemsOther, totalOther, err := s.QueryIncidents(IncidentFilter{Cluster: "test-cluster", Text: "svc-b"})
+	if err != nil {
+		t.Fatalf("QueryIncidents(text=svc-b): %v", err)
+	}
+	if totalOther != 1 || itemsOther[0].ReopenCount != 0 {
+		t.Fatalf("expected svc-b ReopenCount=0 (never resolved), got total=%d items=%+v", totalOther, itemsOther)
+	}
+}
+
+func TestQueryIncidents_Trend(t *testing.T) {
+	s := openTestStore(t)
+	now := time.Now()
+
+	// Resolved incidents never get a trend, regardless of history.
+	resolved := IncidentData{Fingerprint: "default/Deployment/svc-resolved/crash_loop", Namespace: "default", Resource: "svc-resolved", IssueType: "crash_loop", Severity: "critical", RestartCount: 20}
+	insertRawIncident(t, s, "test-cluster", resolved, "resolved", now.Add(-10*24*time.Hour), now.Add(-5*24*time.Hour))
+
+	// Active incident with only the initial DETECTED event: not enough
+	// history to judge a rate -> "stable".
+	single := IncidentData{Fingerprint: "default/Deployment/svc-single/crash_loop", Namespace: "default", Resource: "svc-single", IssueType: "crash_loop", Severity: "critical", RestartCount: 5}
+	singleID := insertRawIncident(t, s, "test-cluster", single, "active", now.Add(-2*time.Hour), now.Add(-1*time.Hour))
+	insertRawEvent(t, s, singleID, "DETECTED", "Detected", 0, now.Add(-2*time.Hour))
+
+	// Active incident with a sharp recent spike vs. its lifetime rate -> "accelerating".
+	fast := IncidentData{Fingerprint: "default/Deployment/svc-fast/crash_loop", Namespace: "default", Resource: "svc-fast", IssueType: "crash_loop", Severity: "critical", RestartCount: 130}
+	fastID := insertRawIncident(t, s, "test-cluster", fast, "active", now.Add(-30*24*time.Hour), now.Add(-30*time.Minute))
+	insertRawEvent(t, s, fastID, "DETECTED", "Detected", 0, now.Add(-30*24*time.Hour))
+	insertRawEvent(t, s, fastID, "UPDATED", "RestartMilestone", 100, now.Add(-2*time.Hour))
+	insertRawEvent(t, s, fastID, "UPDATED", "RestartMilestone", 130, now.Add(-1*time.Hour))
+
+	// Active incident whose recent rate roughly matches its lifetime average -> "stable".
+	slow := IncidentData{Fingerprint: "default/Deployment/svc-slow/crash_loop", Namespace: "default", Resource: "svc-slow", IssueType: "crash_loop", Severity: "critical", RestartCount: 52}
+	slowID := insertRawIncident(t, s, "test-cluster", slow, "active", now.Add(-30*24*time.Hour), now.Add(-1*time.Hour))
+	insertRawEvent(t, s, slowID, "DETECTED", "Detected", 0, now.Add(-30*24*time.Hour))
+	insertRawEvent(t, s, slowID, "UPDATED", "RestartMilestone", 50, now.Add(-10*24*time.Hour))
+	insertRawEvent(t, s, slowID, "UPDATED", "RestartMilestone", 52, now.Add(-1*time.Hour))
+
+	items, _, err := s.QueryIncidents(IncidentFilter{Cluster: "test-cluster", SortBy: "first_seen"})
+	if err != nil {
+		t.Fatalf("QueryIncidents: %v", err)
+	}
+
+	byResource := map[string]IncidentSummary{}
+	for _, it := range items {
+		byResource[it.Resource] = it
+	}
+
+	if got := byResource["svc-resolved"].Trend; got != "" {
+		t.Fatalf("expected resolved incident to have empty Trend, got %q", got)
+	}
+	if got := byResource["svc-single"].Trend; got != "stable" {
+		t.Fatalf("expected svc-single Trend=stable (insufficient history), got %q", got)
+	}
+	if got := byResource["svc-fast"].Trend; got != "accelerating" {
+		t.Fatalf("expected svc-fast Trend=accelerating, got %q", got)
+	}
+	if got := byResource["svc-slow"].Trend; got != "stable" {
+		t.Fatalf("expected svc-slow Trend=stable, got %q", got)
+	}
+}
+
+// ── Retention ────────────────────────────────────────────────────────────────
+
+func TestRetentionCutoff(t *testing.T) {
+	now := time.Now()
+
+	if cutoff, enabled := RetentionCutoff(0, now); enabled || !cutoff.IsZero() {
+		t.Fatalf("expected retention disabled (enabled=false, zero cutoff) for days=0, got enabled=%v cutoff=%v", enabled, cutoff)
+	}
+	if cutoff, enabled := RetentionCutoff(-5, now); enabled || !cutoff.IsZero() {
+		t.Fatalf("expected retention disabled for negative days, got enabled=%v cutoff=%v", enabled, cutoff)
+	}
+
+	cutoff, enabled := RetentionCutoff(90, now)
+	if !enabled {
+		t.Fatalf("expected retention enabled for days=90")
+	}
+	if want := now.AddDate(0, 0, -90); !cutoff.Equal(want) {
+		t.Fatalf("expected cutoff=%v, got %v", want, cutoff)
+	}
+}
+
+// TestRetentionDisabled_PrunesNothing mirrors the scan-loop guard in
+// cmd/opscart-dashboard/main.go: when RetentionCutoff reports the feature
+// disabled (days<=0), the caller must never invoke PruneOlderThan at all —
+// so even a very old, resolved incident is left untouched.
+func TestRetentionDisabled_PrunesNothing(t *testing.T) {
+	s := openTestStore(t)
+	now := time.Now()
+
+	old := IncidentData{Fingerprint: "default/Deployment/svc-ancient/crash_loop", Namespace: "default", Resource: "svc-ancient", IssueType: "crash_loop", Severity: "critical"}
+	insertRawIncident(t, s, "test-cluster", old, "resolved", now.Add(-400*24*time.Hour), now.Add(-400*24*time.Hour))
+
+	if _, enabled := RetentionCutoff(0, now); enabled {
+		t.Fatalf("expected retention disabled for days=0")
+	}
+	// No PruneOlderThan call is made — confirm nothing changed.
+
+	var count int
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM incidents WHERE cluster = 'test-cluster'").Scan(&count); err != nil {
+		t.Fatalf("count incidents: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected the ancient incident untouched, got %d rows", count)
+	}
+}
+
+func TestPruneOlderThan(t *testing.T) {
+	s := openTestStore(t)
+	now := time.Now()
+	cutoff := now.Add(-30 * 24 * time.Hour)
+
+	// Resolved and old -> pruned, along with all of its events.
+	oldResolved := IncidentData{Fingerprint: "default/Deployment/svc-old-resolved/crash_loop", Namespace: "default", Resource: "svc-old-resolved", IssueType: "crash_loop", Severity: "critical"}
+	oldResolvedID := insertRawIncident(t, s, "test-cluster", oldResolved, "resolved", now.Add(-60*24*time.Hour), now.Add(-40*24*time.Hour))
+	insertRawEvent(t, s, oldResolvedID, "DETECTED", "Detected", 0, now.Add(-60*24*time.Hour))
+	insertRawEvent(t, s, oldResolvedID, "RESOLVED", "Resolved", 5, now.Add(-40*24*time.Hour))
+
+	// Resolved but recent -> kept.
+	recentResolved := IncidentData{Fingerprint: "default/Deployment/svc-recent-resolved/oom", Namespace: "default", Resource: "svc-recent-resolved", IssueType: "oom", Severity: "medium"}
+	insertRawIncident(t, s, "test-cluster", recentResolved, "resolved", now.Add(-10*24*time.Hour), now.Add(-2*24*time.Hour))
+
+	// Active and old (first_seen/last_seen far in the past) -> the incident
+	// row is never deleted; only its stale non-DETECTED events are trimmed,
+	// and DETECTED survives regardless of age.
+	oldActive := IncidentData{Fingerprint: "default/Deployment/svc-old-active/crash_loop", Namespace: "default", Resource: "svc-old-active", IssueType: "crash_loop", Severity: "high"}
+	oldActiveID := insertRawIncident(t, s, "test-cluster", oldActive, "active", now.Add(-90*24*time.Hour), now.Add(-1*time.Hour))
+	insertRawEvent(t, s, oldActiveID, "DETECTED", "Detected", 0, now.Add(-90*24*time.Hour))
+	insertRawEvent(t, s, oldActiveID, "UPDATED", "SeverityChanged", 3, now.Add(-89*24*time.Hour))
+	insertRawEvent(t, s, oldActiveID, "UPDATED", "RestartMilestone", 10, now.Add(-1*time.Hour))
+
+	if _, err := s.db.Exec(
+		`INSERT INTO cluster_snapshots (scan_id, cluster, scanned_at, incident_score, critical_count, warning_count, security_score, waste_count, monthly_cost)
+		 VALUES ('scan-old', 'test-cluster', ?, 10, 1, 1, 90, 0, 100.0)`,
+		now.Add(-45*24*time.Hour).Unix(),
+	); err != nil {
+		t.Fatalf("insert old snapshot: %v", err)
+	}
+	if _, err := s.db.Exec(
+		`INSERT INTO cluster_snapshots (scan_id, cluster, scanned_at, incident_score, critical_count, warning_count, security_score, waste_count, monthly_cost)
+		 VALUES ('scan-recent', 'test-cluster', ?, 10, 1, 1, 90, 0, 100.0)`,
+		now.Add(-1*24*time.Hour).Unix(),
+	); err != nil {
+		t.Fatalf("insert recent snapshot: %v", err)
+	}
+	if _, err := s.db.Exec(
+		`INSERT INTO scan_history (scan_id, cluster, scanned_at, success) VALUES ('scan-old', 'test-cluster', ?, 1)`,
+		now.Add(-45*24*time.Hour).Unix(),
+	); err != nil {
+		t.Fatalf("insert old scan_history: %v", err)
+	}
+	if _, err := s.db.Exec(
+		`INSERT INTO scan_history (scan_id, cluster, scanned_at, success) VALUES ('scan-recent', 'test-cluster', ?, 1)`,
+		now.Add(-1*24*time.Hour).Unix(),
+	); err != nil {
+		t.Fatalf("insert recent scan_history: %v", err)
+	}
+
+	pruned, err := s.PruneOlderThan("test-cluster", cutoff)
+	if err != nil {
+		t.Fatalf("PruneOlderThan: %v", err)
+	}
+	if pruned != 1 {
+		t.Fatalf("expected 1 pruned incident, got %d", pruned)
+	}
+
+	var count int
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM incidents WHERE id = ?", oldResolvedID).Scan(&count); err != nil {
+		t.Fatalf("count old-resolved incidents: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected old-resolved incident deleted, still have %d rows", count)
+	}
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM incident_events WHERE incident_id = ?", oldResolvedID).Scan(&count); err != nil {
+		t.Fatalf("count old-resolved events: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected old-resolved incident's events deleted, still have %d rows", count)
+	}
+
+	rec, err := s.GetIncidentHistory("test-cluster", recentResolved.Fingerprint)
+	if err != nil {
+		t.Fatalf("GetIncidentHistory(recent-resolved): %v", err)
+	}
+	if rec == nil {
+		t.Fatalf("expected recent-resolved incident to survive pruning")
+	}
+
+	rec, err = s.GetIncidentHistory("test-cluster", oldActive.Fingerprint)
+	if err != nil {
+		t.Fatalf("GetIncidentHistory(old-active): %v", err)
+	}
+	if rec == nil || rec.Status != "active" {
+		t.Fatalf("expected old-active incident to survive pruning as active, got %+v", rec)
+	}
+
+	events, err := s.GetIncidentTimeline("test-cluster", oldActive.Fingerprint)
+	if err != nil {
+		t.Fatalf("GetIncidentTimeline(old-active): %v", err)
+	}
+	var hasDetected, hasSeverityChanged, hasMilestone bool
+	for _, e := range events {
+		switch e.EventReason {
+		case "Detected":
+			hasDetected = true
+		case "SeverityChanged":
+			hasSeverityChanged = true
+		case "RestartMilestone":
+			hasMilestone = true
+		}
+	}
+	if !hasDetected {
+		t.Fatalf("expected DETECTED event to survive pruning regardless of age, got %+v", events)
+	}
+	if hasSeverityChanged {
+		t.Fatalf("expected old non-DETECTED event to be pruned, got %+v", events)
+	}
+	if !hasMilestone {
+		t.Fatalf("expected recent event to survive, got %+v", events)
+	}
+
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM cluster_snapshots WHERE scan_id = 'scan-old'").Scan(&count); err != nil {
+		t.Fatalf("count old snapshot: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected old snapshot pruned, still have %d rows", count)
+	}
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM cluster_snapshots WHERE scan_id = 'scan-recent'").Scan(&count); err != nil {
+		t.Fatalf("count recent snapshot: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected recent snapshot kept, got %d rows", count)
+	}
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM scan_history WHERE scan_id = 'scan-old'").Scan(&count); err != nil {
+		t.Fatalf("count old scan_history: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected old scan_history pruned, still have %d rows", count)
+	}
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM scan_history WHERE scan_id = 'scan-recent'").Scan(&count); err != nil {
+		t.Fatalf("count recent scan_history: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected recent scan_history kept, got %d rows", count)
+	}
+}


### PR DESCRIPTION
Replaces the scan-cache stub with a proper system of record:
- QueryIncidents store method: text search, namespace/type/severity/status filters, sort (severity/first_seen/last_seen/restarts), pagination
- Trend derivation from incident_events (accelerating/stable)
- Reopen count from event journal; resolved incidents shown at reduced opacity
- Retention: OPSCART_RETENTION_DAYS (default 90), pruned each scan cycle
- Schema v4: 3 new indexes; retentionDays in Helm values + deploy manifest
- War Room callout banner; empty state; summary strip with active/reopened/resolved counts
- Incident name shows namespace for unprotected_namespace type