### PR TITLE
feat(warroom): ranking by restart count, registry link, from-context …

### DIFF
--- a/cmd/opscart-dashboard/main.go
+++ b/cmd/opscart-dashboard/main.go
@@ -654,6 +654,8 @@ type warRoomPageData struct {
 	Warnings      []warRoomIssue
 	ScannedAtMs   int64
 	Sidebar       template.HTML
+	TotalIssues   int
+	IncidentsHref string
 }
 
 func collectWarRoomIssues(scan *clusterScan, limit int) []warRoomIssue {
@@ -709,14 +711,18 @@ func collectWarRoomIssues(scan *clusterScan, limit int) []warRoomIssue {
 			}
 		}
 	}
-
-	// Sort: critical before high
+	// Sort: critical first, then by restart count descending (highest impact first)
 	severityOrder := map[string]int{"critical": 0, "high": 1, "medium": 2, "low": 3}
 	sort.SliceStable(issues, func(i, j int) bool {
-		return severityOrder[issues[i].Severity] < severityOrder[issues[j].Severity]
+		si := severityOrder[issues[i].Severity]
+		sj := severityOrder[issues[j].Severity]
+		if si != sj {
+			return si < sj
+		}
+		// Within same severity: higher restart count = more urgent
+		return issues[i].RestartCount > issues[j].RestartCount
 	})
 
-	// limit=0 means no cap (used by the HTML page to show all issues)
 	if limit > 0 && len(issues) > limit {
 		return issues[:limit]
 	}
@@ -1616,7 +1622,10 @@ func renderWarRoomPage(scan *clusterScan, activeCtx string, clusterList []string
 	if activeCtx != "" {
 		q = "?cluster=" + url.QueryEscape(activeCtx)
 	}
-
+	// Cap War Room at top 20 — full registry is in Incidents
+	if len(critical) > 20 {
+		critical = critical[:20]
+	}
 	critChipClass := "ok"
 	if len(critical) > 0 {
 		critChipClass = "c"
@@ -1636,6 +1645,8 @@ func renderWarRoomPage(scan *clusterScan, activeCtx string, clusterList []string
 		Warnings:      warnings,
 		ScannedAtMs:   scannedAt.UnixMilli(),
 		Sidebar:       template.HTML(buildSidebar("warroom", activeCtx, clusterName, clusterList, countCriticalIssues(scan))),
+		TotalIssues:   len(critical) + len(warnings),
+		IncidentsHref: "/incidents" + q,
 	}
 
 	var buf strings.Builder

--- a/cmd/opscart-dashboard/templates/warroom.html
+++ b/cmd/opscart-dashboard/templates/warroom.html
@@ -7,6 +7,9 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 {{template "base" .}}
 <style>
+.wr-registry-link{display:flex;align-items:center;justify-content:space-between;background:rgba(99,102,241,.07);border:1px solid rgba(129,140,248,.2);border-radius:var(--radius-sm);padding:.65rem 1rem;margin-bottom:1.5rem;font-size:.8rem;color:var(--text-muted)}
+.wr-registry-link a{color:var(--primary-light);font-weight:600;text-decoration:none}
+.wr-registry-link a:hover{text-decoration:underline}
 .summary-bar{display:flex;gap:1rem;margin-bottom:2rem;flex-wrap:wrap}
 .summary-chip{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);padding:0.75rem 1.25rem;display:flex;align-items:center;gap:0.75rem;min-width:160px}
 .summary-chip.c{border-color:rgba(239,68,68,0.35)}
@@ -108,9 +111,16 @@
     </div>
   </div>
 
-  <div class="wr-section">
-    <div class="wr-section-hdr">
-      <h2>🔴 Critical Issues</h2>
+    {{if .TotalIssues}}
+    <div class="wr-registry-link">
+      <span>Ranked by severity · restart count</span>
+      <a href="{{.IncidentsHref}}">View all {{.TotalIssues}} incidents in registry →</a>
+    </div>
+    {{end}}
+
+    <div class="wr-section">
+      <div class="wr-section-hdr">
+        <h2>🔴 Critical Issues</h2>
       <span class="cnt-chip c">{{len .Critical}}</span>
     </div>
     {{if eq (len .Critical) 0}}


### PR DESCRIPTION
…navigation

- War Room sorted by severity then restart count descending
- Banner linking to Incidents registry with total count
- Investigation page: context-aware back link and sidebar highlight via from=incidents|warroom query param