### PR TITLE
fix: duplicate milestone events + probe failure detection

### DIFF
--- a/cmd/opscart-dashboard/main.go
+++ b/cmd/opscart-dashboard/main.go
@@ -2784,6 +2784,8 @@ func zombieTypeForStatus(status string) string {
 		return "oomkilled"
 	case "ImagePullBackOff":
 		return "image_pull_backoff"
+	case "ProbeFailure":
+		return "probe_failure"
 	default:
 		return "crash_loop"
 	}
@@ -2793,6 +2795,8 @@ func kubectlCmdForIssue(issueType, resource, namespace string) string {
 	switch issueType {
 	case "crash_loop":
 		return fmt.Sprintf("kubectl logs %s -n %s --previous", resource, namespace)
+	case "probe_failure":
+		return fmt.Sprintf("kubectl describe pod %s -n %s", resource, namespace)
 	default:
 		return fmt.Sprintf("kubectl describe pod %s -n %s", resource, namespace)
 	}

--- a/pkg/analyzer/waste.go
+++ b/pkg/analyzer/waste.go
@@ -391,6 +391,32 @@ func (w *WasteAuditor) detectStalePods(audit *WasteAudit, filterNamespace string
 				}
 			}
 		}
+		{
+			var totalRestarts int32
+			var notReady int
+			for _, cs := range pod.Status.ContainerStatuses {
+				totalRestarts += cs.RestartCount
+				if !cs.Ready {
+					notReady++
+				}
+			}
+			if notReady > 0 && totalRestarts > 10 && pod.Status.Phase == corev1.PodRunning {
+				audit.StalePods = append(audit.StalePods, StalePod{
+					Name:         pod.Name,
+					Namespace:    pod.Namespace,
+					Kind:         StalePodZombie,
+					AgeDays:      ageDays,
+					RestartCount: totalRestarts,
+					Status:       "ProbeFailure",
+					Reason: fmt.Sprintf(
+						"%d/%d containers not ready after %d restarts — startup or liveness probe likely failing.",
+						notReady, len(pod.Status.ContainerStatuses), totalRestarts,
+					),
+					Score: float64(ageDays)*0.4 + float64(totalRestarts)*0.3,
+				})
+				goto nextPod
+			}
+		}
 
 		// ── IDLE detection: old pod, no recent restart activity ──────
 		// Age gate applies here: we only flag idle pods that have been

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -392,16 +392,23 @@ func (s *SQLiteStore) UpsertIncidents(cluster string, scanID string, incidents [
 				}
 			}
 			if milestone := highestMilestoneCrossed(prevRestart, inc.RestartCount); milestone > 0 {
-				err = insertIncidentEvent(tx, incidentID, scanID, now, "UPDATED", "RestartMilestone",
-					inc.RestartCount, inc.Severity, "active",
-					fmt.Sprintf("Restart count exceeded %d", milestone))
+				var lastMilestone int
+				_ = tx.QueryRow(
+					`SELECT COALESCE(MAX(restart_count), 0) FROM incident_events
+					 WHERE incident_id=? AND event_reason='RestartMilestone'`,
+					incidentID,
+				).Scan(&lastMilestone)
+				if lastMilestone < milestone {
+					err = insertIncidentEvent(tx, incidentID, scanID, now, "UPDATED", "RestartMilestone",
+						inc.RestartCount, inc.Severity, "active",
+						fmt.Sprintf("Restart count exceeded %d", milestone))
+				}
 			}
 		}
 		if err != nil {
 			return err
 		}
 	}
-
 	return tx.Commit()
 }
 


### PR DESCRIPTION
- Milestone dedup: guard RestartMilestone events using MAX(restart_count) of existing milestone events; prevents duplicate entries when restart count is stable across consecutive scans
- Probe failure: detect pods with Running phase, not-ready containers, and >10 restarts that never enter CrashLoopBackOff due to probe-kill pattern (phase=Running, 1/N containers ready, high restart count)