### PR TITLE
feat: persistence-mode indicator + /healthz JSON

### DIFF
--- a/cmd/opscart-dashboard/main.go
+++ b/cmd/opscart-dashboard/main.go
@@ -243,10 +243,11 @@ type server struct {
 	states        map[string]*dashboardState
 	db            store.Store
 	retentionDays int
+	dbPersistent  bool
 }
 
-func newServer(clusterList []string, db store.Store, retentionDays int) *server {
-	return &server{clusterList: clusterList, states: make(map[string]*dashboardState), db: db, retentionDays: retentionDays}
+func newServer(clusterList []string, db store.Store, retentionDays int, dbPersistent bool) *server {
+	return &server{clusterList: clusterList, states: make(map[string]*dashboardState), db: db, retentionDays: retentionDays, dbPersistent: dbPersistent}
 }
 
 func (srv *server) getState(ctx string) *dashboardState {
@@ -349,15 +350,17 @@ func runDashboard(_ *cobra.Command, _ []string) error {
 		}
 	}
 	var db store.Store
+	dbPersistent := false
 	if sqlDB, err := store.OpenSQLite(dbPath); err != nil {
 		log.Printf("store: persistence disabled (%v)", err)
 		db = &store.NullStore{}
 	} else {
 		db = sqlDB
+		dbPersistent = true
 		log.Printf("store: operational memory at %s", dbPath)
 	}
 	defer db.Close()
-	srv := newServer(cl, db, retentionDays)
+	srv := newServer(cl, db, retentionDays, dbPersistent)
 
 	log.Printf("Scanning cluster %q ...", displayName(cl[0]))
 	if err := srv.getState(cl[0]).refresh(cl); err != nil {
@@ -378,7 +381,7 @@ func runDashboard(_ *cobra.Command, _ []string) error {
 	mux.HandleFunc("/infrastructure", srv.handleInfrastructurePage)
 	mux.HandleFunc("/namespaces", srv.handleNamespacesPage)
 	mux.HandleFunc("/optimizations", srv.handleOptimizationsPage)
-	mux.HandleFunc("/healthz", handleHealth)
+	mux.HandleFunc("/healthz", srv.handleHealth)
 	mux.HandleFunc("/investigate", srv.handleInvestigationPage)
 	mux.HandleFunc("/incidents", srv.handleIncidentsPage)
 	mux.HandleFunc("/security", srv.handleSecurityPage)
@@ -626,9 +629,14 @@ func (srv *server) handleWarRoom(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(issues)
 }
 
-func handleHealth(w http.ResponseWriter, _ *http.Request) {
+func (srv *server) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	persistence := "ephemeral"
+	if srv.dbPersistent {
+		persistence = "persistent"
+	}
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprintln(w, "ok")
+	fmt.Fprintf(w, `{"status":"ok","persistence":"%s"}`, persistence)
 }
 
 // ── War Room helpers ──────────────────────────────────────────────────────────

--- a/cmd/opscart-dashboard/main_test.go
+++ b/cmd/opscart-dashboard/main_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/opscart/opscart-k8s-watcher/pkg/store"
+)
+
+func TestHandleHealth(t *testing.T) {
+	tests := []struct {
+		name            string
+		dbPersistent    bool
+		wantPersistence string
+	}{
+		{name: "SQLiteStore", dbPersistent: true, wantPersistence: "persistent"},
+		{name: "NullStore", dbPersistent: false, wantPersistence: "ephemeral"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var db store.Store
+			if tt.dbPersistent {
+				sqlDB, err := store.OpenSQLite(filepath.Join(t.TempDir(), "test.db"))
+				if err != nil {
+					t.Fatalf("OpenSQLite: %v", err)
+				}
+				defer sqlDB.Close()
+				db = sqlDB
+			} else {
+				db = &store.NullStore{}
+			}
+
+			srv := newServer([]string{"test-ctx"}, db, 90, tt.dbPersistent)
+
+			req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+			rec := httptest.NewRecorder()
+			srv.handleHealth(rec, req)
+
+			resp := rec.Result()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+			}
+			if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+				t.Fatalf("Content-Type = %q, want %q", ct, "application/json")
+			}
+
+			var body struct {
+				Status      string `json:"status"`
+				Persistence string `json:"persistence"`
+			}
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if body.Status != "ok" {
+				t.Errorf("status field = %q, want %q", body.Status, "ok")
+			}
+			if body.Persistence != tt.wantPersistence {
+				t.Errorf("persistence = %q, want %q", body.Persistence, tt.wantPersistence)
+			}
+		})
+	}
+}

--- a/cmd/opscart-dashboard/templates/base.html
+++ b/cmd/opscart-dashboard/templates/base.html
@@ -60,4 +60,17 @@ body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--t
 .section{animation:fadeIn 0.3s ease both}
 @media(max-width:1024px){.layout{grid-template-columns:1fr}.sidebar{display:none}}
 </style>
+<script>
+(function(){
+  fetch('/healthz').then(function(r){return r.json();}).then(function(d){
+    if(d.persistence==='ephemeral'){
+      var b=document.createElement('div');
+      b.style.cssText='position:fixed;bottom:1rem;right:1rem;background:rgba(245,158,11,0.12);border:1px solid rgba(245,158,11,0.35);border-radius:8px;padding:6px 14px;font-size:0.72rem;color:#fbbf24;font-family:Inter,sans-serif;z-index:9999;cursor:default;backdrop-filter:blur(4px)';
+      b.title='Incident history will not survive pod restarts. Check volume permissions (fsGroup / volumePermissions.enabled).';
+      b.textContent='\u26a0 Ephemeral mode \u2014 history not persisted';
+      document.body.appendChild(b);
+    }
+  }).catch(function(){});
+})();
+</script>
 {{end}}


### PR DESCRIPTION
- /healthz returns JSON {status, persistence: persistent|ephemeral}
- Amber fixed badge on all pages when running in ephemeral/NullStore mode
- Closes silent-fallback gap: operators see the warning without reading logs