### PR TITLE
feat(auth): basic auth safety net + oauth2-proxy documentation

### DIFF
--- a/cmd/opscart-dashboard/auth.go
+++ b/cmd/opscart-dashboard/auth.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base32"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const defaultAuthUsername = "admin"
+
+// authSecretDir is the fixed mount point for the OPSCART_AUTH_SECRET_NAME
+// Secret, matching the Helm existingSecret pattern. Overridable in tests.
+var authSecretDir = "/etc/opscart/auth"
+
+// authSource identifies where basic-auth credentials came from.
+type authSource string
+
+const (
+	authSourceEnv       authSource = "env"
+	authSourceSecret    authSource = "secret"
+	authSourceGenerated authSource = "generated"
+)
+
+// authConfig holds the resolved basic-auth credential. There is no field
+// or code path anywhere that disables auth — every resolution path below
+// produces a usable credential.
+type authConfig struct {
+	username string
+	password string
+	source   authSource
+}
+
+// resolveAuthConfig determines basic-auth credentials in priority order:
+//  1. OPSCART_AUTH_USER / OPSCART_AUTH_PASS env vars, if both set
+//  2. OPSCART_AUTH_SECRET_NAME, if set — read from the Secret mounted at
+//     authSecretDir (username/password files)
+//  3. otherwise, a random generated password with username "admin"
+func resolveAuthConfig() (*authConfig, error) {
+	if user, pass := os.Getenv("OPSCART_AUTH_USER"), os.Getenv("OPSCART_AUTH_PASS"); user != "" && pass != "" {
+		return &authConfig{username: user, password: pass, source: authSourceEnv}, nil
+	}
+
+	if secretName := os.Getenv("OPSCART_AUTH_SECRET_NAME"); secretName != "" {
+		user, err := readSecretField(filepath.Join(authSecretDir, "username"))
+		if err != nil {
+			return nil, fmt.Errorf("reading auth secret %q username: %w", secretName, err)
+		}
+		pass, err := readSecretField(filepath.Join(authSecretDir, "password"))
+		if err != nil {
+			return nil, fmt.Errorf("reading auth secret %q password: %w", secretName, err)
+		}
+		return &authConfig{username: user, password: pass, source: authSourceSecret}, nil
+	}
+
+	password, err := generatePassword()
+	if err != nil {
+		return nil, fmt.Errorf("generating password: %w", err)
+	}
+	return &authConfig{username: defaultAuthUsername, password: password, source: authSourceGenerated}, nil
+}
+
+func readSecretField(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	value := strings.TrimSpace(string(data))
+	if value == "" {
+		return "", fmt.Errorf("%s is empty", path)
+	}
+	return value, nil
+}
+
+// generatePassword returns a random, base32-encoded password. 16 random
+// bytes of crypto/rand entropy encode to 26 base32 characters, well above
+// the 16-character minimum.
+func generatePassword() (string, error) {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(buf), nil
+}
+
+// logAuthConfig logs exactly one line describing the credential source. In
+// the auto-generated case, a second line immediately follows with the
+// credential itself — the only case where the operator has no other way
+// to retrieve it.
+func logAuthConfig(cfg *authConfig) {
+	switch cfg.source {
+	case authSourceEnv:
+		log.Printf("auth: basic auth configured (source: env)")
+	case authSourceSecret:
+		log.Printf("auth: basic auth configured (source: secret)")
+	case authSourceGenerated:
+		log.Printf("auth: WARNING — using auto-generated password (see above). Configure OPSCART_AUTH_USER/PASS or OPSCART_AUTH_SECRET_NAME for a stable credential.")
+		log.Printf("auth: username=%s password=%s", cfg.username, cfg.password)
+	}
+}
+
+// basicAuthMiddleware wraps h so every request must present valid HTTP
+// Basic credentials — no route, including /healthz, is exempt, and there
+// is no configuration value that disables this check.
+func basicAuthMiddleware(cfg *authConfig, h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		if !ok || !credentialsMatch(cfg, user, pass) {
+			w.Header().Set("WWW-Authenticate", `Basic realm="opscart", charset="UTF-8"`)
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		h.ServeHTTP(w, r)
+	})
+}
+
+func credentialsMatch(cfg *authConfig, user, pass string) bool {
+	userOK := subtle.ConstantTimeCompare([]byte(user), []byte(cfg.username)) == 1
+	passOK := subtle.ConstantTimeCompare([]byte(pass), []byte(cfg.password)) == 1
+	return userOK && passOK
+}

--- a/cmd/opscart-dashboard/auth_test.go
+++ b/cmd/opscart-dashboard/auth_test.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/opscart/opscart-k8s-watcher/pkg/store"
+)
+
+func TestResolveAuthConfigOrder(t *testing.T) {
+	t.Run("env vars take priority", func(t *testing.T) {
+		t.Setenv("OPSCART_AUTH_USER", "envuser")
+		t.Setenv("OPSCART_AUTH_PASS", "envpass")
+		t.Setenv("OPSCART_AUTH_SECRET_NAME", "some-secret")
+		withSecretFiles(t, "secretuser", "secretpass")
+
+		cfg, err := resolveAuthConfig()
+		if err != nil {
+			t.Fatalf("resolveAuthConfig: %v", err)
+		}
+		if cfg.source != authSourceEnv {
+			t.Fatalf("source = %q, want %q", cfg.source, authSourceEnv)
+		}
+		if cfg.username != "envuser" || cfg.password != "envpass" {
+			t.Fatalf("got %+v, want env credentials", cfg)
+		}
+	})
+
+	t.Run("secret used when env not set", func(t *testing.T) {
+		t.Setenv("OPSCART_AUTH_SECRET_NAME", "some-secret")
+		withSecretFiles(t, "secretuser", "secretpass")
+
+		cfg, err := resolveAuthConfig()
+		if err != nil {
+			t.Fatalf("resolveAuthConfig: %v", err)
+		}
+		if cfg.source != authSourceSecret {
+			t.Fatalf("source = %q, want %q", cfg.source, authSourceSecret)
+		}
+		if cfg.username != "secretuser" || cfg.password != "secretpass" {
+			t.Fatalf("got %+v, want secret credentials", cfg)
+		}
+	})
+
+	t.Run("secret name set but files missing errors out", func(t *testing.T) {
+		t.Setenv("OPSCART_AUTH_SECRET_NAME", "some-secret")
+		original := authSecretDir
+		authSecretDir = t.TempDir() // empty dir, no username/password files
+		t.Cleanup(func() { authSecretDir = original })
+
+		if _, err := resolveAuthConfig(); err == nil {
+			t.Fatal("expected error when secret files are missing, got nil")
+		}
+	})
+
+	t.Run("generated when nothing configured", func(t *testing.T) {
+		cfg, err := resolveAuthConfig()
+		if err != nil {
+			t.Fatalf("resolveAuthConfig: %v", err)
+		}
+		if cfg.source != authSourceGenerated {
+			t.Fatalf("source = %q, want %q", cfg.source, authSourceGenerated)
+		}
+		if cfg.username != defaultAuthUsername {
+			t.Fatalf("username = %q, want %q", cfg.username, defaultAuthUsername)
+		}
+		if len(cfg.password) < 16 {
+			t.Fatalf("generated password %q is %d chars, want >= 16", cfg.password, len(cfg.password))
+		}
+	})
+
+	t.Run("partial env vars fall through to generated", func(t *testing.T) {
+		t.Setenv("OPSCART_AUTH_USER", "onlyuser")
+
+		cfg, err := resolveAuthConfig()
+		if err != nil {
+			t.Fatalf("resolveAuthConfig: %v", err)
+		}
+		if cfg.source != authSourceGenerated {
+			t.Fatalf("source = %q, want %q", cfg.source, authSourceGenerated)
+		}
+	})
+}
+
+func TestGeneratePasswordEntropy(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 100; i++ {
+		pw, err := generatePassword()
+		if err != nil {
+			t.Fatalf("generatePassword: %v", err)
+		}
+		if len(pw) < 16 {
+			t.Fatalf("password %q is %d chars, want >= 16", pw, len(pw))
+		}
+		if seen[pw] {
+			t.Fatalf("generatePassword produced a duplicate: %q", pw)
+		}
+		seen[pw] = true
+	}
+}
+
+func TestBasicAuthMiddleware(t *testing.T) {
+	cfg := &authConfig{username: "admin", password: "s3cret", source: authSourceGenerated}
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := basicAuthMiddleware(cfg, inner)
+
+	t.Run("rejects unauthenticated request", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+		}
+		if rec.Header().Get("WWW-Authenticate") == "" {
+			t.Fatal("expected WWW-Authenticate header on 401 response")
+		}
+	})
+
+	t.Run("rejects wrong credentials", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.SetBasicAuth("admin", "wrong")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+		}
+	})
+
+	t.Run("accepts correct credentials", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.SetBasicAuth("admin", "s3cret")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+		}
+	})
+}
+
+// withSecretFiles points authSecretDir at a temp directory populated with
+// username/password files, restoring the original value on test cleanup.
+func withSecretFiles(t *testing.T, username, password string) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "username"), []byte(username), 0o600); err != nil {
+		t.Fatalf("write username file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "password"), []byte(password), 0o600); err != nil {
+		t.Fatalf("write password file: %v", err)
+	}
+
+	original := authSecretDir
+	authSecretDir = dir
+	t.Cleanup(func() { authSecretDir = original })
+}
+
+func TestMuxHealthzBypassesAuth(t *testing.T) {
+	t.Setenv("OPSCART_AUTH_USER", "muxuser")
+	t.Setenv("OPSCART_AUTH_PASS", "muxpass")
+
+	srv := newServer([]string{"test-ctx"}, &store.NullStore{}, 90, false)
+	mux := srv.newMux()
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/healthz status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := rec.Header().Get("WWW-Authenticate"); got != "" {
+		t.Fatalf("/healthz WWW-Authenticate = %q, want empty (no auth challenge)", got)
+	}
+}
+
+func TestMuxOtherRoutesRequireAuth(t *testing.T) {
+	t.Setenv("OPSCART_AUTH_USER", "muxuser")
+	t.Setenv("OPSCART_AUTH_PASS", "muxpass")
+
+	srv := newServer([]string{"test-ctx"}, &store.NullStore{}, 90, false)
+	mux := srv.newMux()
+
+	routes := []string{"/", "/costs", "/api/summary", "/warroom", "/settings"}
+	for _, route := range routes {
+		t.Run(route, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, route, nil)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("%s status = %d, want %d", route, rec.Code, http.StatusUnauthorized)
+			}
+			if rec.Header().Get("WWW-Authenticate") == "" {
+				t.Fatalf("%s: expected WWW-Authenticate header on 401 response", route)
+			}
+		})
+	}
+}

--- a/cmd/opscart-dashboard/server.go
+++ b/cmd/opscart-dashboard/server.go
@@ -66,10 +66,16 @@ type server struct {
 	db            store.Store
 	retentionDays int
 	dbPersistent  bool
+	auth          *authConfig
 }
 
 func newServer(clusterList []string, db store.Store, retentionDays int, dbPersistent bool) *server {
-	return &server{clusterList: clusterList, states: make(map[string]*dashboardState), db: db, retentionDays: retentionDays, dbPersistent: dbPersistent}
+	auth, err := resolveAuthConfig()
+	if err != nil {
+		log.Fatalf("auth: %v", err)
+	}
+	logAuthConfig(auth)
+	return &server{clusterList: clusterList, states: make(map[string]*dashboardState), db: db, retentionDays: retentionDays, dbPersistent: dbPersistent, auth: auth}
 }
 
 func (srv *server) getState(ctx string) *dashboardState {
@@ -128,7 +134,7 @@ func (srv *server) handleOverviewPage(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(buf.String()))
 }
 
-func (srv *server) newMux() *http.ServeMux {
+func (srv *server) newMux() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", srv.handleOverviewPage)
 	mux.HandleFunc("/costs", srv.handleDashboard)
@@ -141,13 +147,19 @@ func (srv *server) newMux() *http.ServeMux {
 	mux.HandleFunc("/infrastructure", srv.handleInfrastructurePage)
 	mux.HandleFunc("/namespaces", srv.handleNamespacesPage)
 	mux.HandleFunc("/optimizations", srv.handleOptimizationsPage)
-	mux.HandleFunc("/healthz", srv.handleHealth)
 	mux.HandleFunc("/investigate", srv.handleInvestigationPage)
 	mux.HandleFunc("/incidents", srv.handleIncidentsPage)
 	mux.HandleFunc("/security", srv.handleSecurityPage)
 	mux.HandleFunc("/waste", srv.handleWastePage)
 	mux.HandleFunc("/settings", srv.handleStubPage("settings", "Settings"))
-	return mux
+
+	// /healthz is registered on the unwrapped top-level mux so kubelet
+	// liveness/readiness probes succeed without credentials; every other
+	// route is served through the authenticated sub-mux.
+	top := http.NewServeMux()
+	top.HandleFunc("/healthz", srv.handleHealth)
+	top.Handle("/", basicAuthMiddleware(srv.auth, mux))
+	return top
 }
 
 // ── HTTP handlers ─────────────────────────────────────────────────────────────

--- a/docs/05-Security.md
+++ b/docs/05-Security.md
@@ -1,0 +1,143 @@
+# Security
+
+## Read-only by design
+
+OpsCart's Kubernetes RBAC is `get`/`list` only — no create, update, patch, or
+delete verbs on any resource, including `endpointslices` (added in v1.7.1).
+There is no code path in the binary that issues a write call to the
+Kubernetes API. This is enforced at the RBAC layer, not just by convention:
+even if the binary were compromised, the ServiceAccount it runs under cannot
+mutate cluster state.
+
+## Container posture
+
+- `FROM scratch` — no shell, no package manager, no attack surface beyond the
+  Go binary itself
+- Runs as non-root, UID 65534
+- Statically compiled (`CGO_ENABLED=0`), no dynamic linking
+- 0 known CVEs at time of each tagged release (Trivy-scanned)
+- No outbound network calls — no telemetry, no phone-home, no license server
+
+## What's stored
+
+The SQLite database (`opscart.db`) holds operational metadata: resource
+names, namespaces, restart counts, event timestamps, severity levels. It
+does not store Secret *values*, environment variable contents, or log
+bodies. Treat the database file with the same sensitivity as `kubectl get`
+output — it reveals cluster topology and workload names, not application
+data.
+
+Find the current Authentication section and replace with:
+markdown## Authentication
+
+OpsCart ships with a safety-net authentication layer on by default — the
+dashboard is never silently open, even if you skip configuration entirely.
+
+### Default behavior: auto-generated credentials
+
+If no credentials are configured, OpsCart generates a random password on
+startup and prints it once to the pod logs:
+2026-07-16 09:12:03  auth: no credentials configured — generated one-time password
+2026-07-16 09:12:03  auth: username=admin password=x7K9-mQ2p-Rt4w
+2026-07-16 09:12:03  auth: set OPSCART_AUTH_USER / OPSCART_AUTH_PASS (or authSecretName
+in values.yaml) to use a stable password across restarts
+
+Retrieve it with:
+```bash
+kubectl logs deploy/opscart-watcher -n opscart-system | grep "auth:"
+```
+
+This password is regenerated on every pod restart unless you configure a
+stable one — by design, so there is no default credential to discover or
+leave unrotated.
+
+### Stable credentials (two ways)
+
+**Environment variables** (simplest):
+```yaml
+auth:
+  username: "admin"
+  passwordEnv: "OPSCART_AUTH_PASS"   # set via a Secret-backed env var
+```
+
+**Kubernetes Secret reference** (if you prefer managing credentials as a
+Secret directly):
+```yaml
+auth:
+  existingSecret: "opscart-auth"
+  secretUsernameKey: "username"
+  secretPasswordKey: "password"
+```
+
+Either path is optional — if neither is set, the auto-generated flow above
+applies. There is no configuration value that disables authentication
+entirely; this is deliberate. If you are fronting OpsCart with oauth2-proxy
+(see below) and want to avoid a double login prompt, terminate basic auth
+at the ingress layer instead of removing it from OpsCart.
+
+### Startup validation
+
+On every start, OpsCart logs one explicit line about its auth state:
+2026-07-16 09:12:03  auth: WARNING — using auto-generated password (see above).
+Configure OPSCART_AUTH_USER/PASS for a stable credential.
+
+or, when configured:
+2026-07-16 09:12:03  auth: basic auth configured (source: env)
+
+This is intentionally a log line, not a UI element — it is aimed at the
+person deploying the chart, checked once at rollout, not at end users of
+the dashboard.
+
+### Recommended pattern: authenticate at the ingress
+
+Put OpsCart behind the same reverse-proxy authentication pattern you
+already use for other internal tools. **oauth2-proxy** is the most common
+choice — it supports GitHub, Google, Azure AD, Okta, and generic OIDC as
+backends, and integrates directly with an NGINX or any ingress controller
+that supports `auth-url`/`auth-signin` annotations.
+
+The pattern:
+
+```
+Browser → Ingress (auth-url annotation) → oauth2-proxy → OpsCart :8080
+                                              ↓
+                                     Your IdP (Azure AD / Google / GitHub)
+```
+
+Unauthenticated requests are redirected to your identity provider; OpsCart
+itself never sees a request that hasn't already been authenticated at the
+ingress layer. OpsCart's own listener can remain plain HTTP because the
+ingress terminates TLS and enforces auth before traffic ever reaches the
+pod.
+
+See `helm/opscart-watcher/values-oauth2-proxy-example.yaml` for a working
+example.
+
+### Until authentication is configured
+
+The dashboard has no protection beyond network placement. Recommended
+deployment postures, in order of preference:
+
+1. **Behind an authenticated ingress** (see above) — safe for shared/team use
+2. **`kubectl port-forward`** — safe for individual use; traffic is
+   encrypted via the existing API server tunnel and never leaves your
+   machine's authenticated kubectl session
+3. **ClusterIP only, no ingress** — safe only if every user with cluster
+   network access is already trusted at the level OpsCart's data warrants
+
+**Do not** expose the OpsCart Service via a public LoadBalancer or
+unauthenticated Ingress. There is nothing between an anonymous HTTP request
+and full read access to your cluster's operational state.
+
+### What's next (v1.10)
+
+Native OIDC support with namespace-scoped authorization — where dashboard
+visibility maps to the viewer's own Kubernetes RBAC — is planned for v1.10.
+That's a genuinely different problem (OpsCart needs to know *who* is asking
+to filter *what* they see) and can't be solved by a reverse proxy alone.
+The interim pattern above remains valid until then; v1.10 adds
+authorization on top of it, not a replacement for it.
+
+## Reporting a vulnerability
+
+[Standard disclosure process — email/GitHub security advisory link]

--- a/helm/opscart-watcher/templates/deployment.yaml
+++ b/helm/opscart-watcher/templates/deployment.yaml
@@ -8,12 +8,6 @@ metadata:
 spec:
   replicas: 1
   {{- if .Values.persistence.enabled }}
-  # opscart-data is ReadWriteOnce, so it can only be mounted by one pod at a
-  # time. A RollingUpdate would start the new pod (and try to mount the
-  # volume) before terminating the old one, and the new pod would hang
-  # waiting for a mount the old pod still holds. Recreate tears down the old
-  # pod first, freeing the volume before the replacement starts. Only
-  # correct for single-replica deployments backed by RWO storage.
   strategy:
     type: Recreate
   {{- end }}
@@ -51,6 +45,10 @@ spec:
               value: /data/opscart.db
             - name: OPSCART_RETENTION_DAYS
               value: {{ .Values.retentionDays | quote }}
+            {{- if .Values.auth.existingSecret }}
+            - name: OPSCART_AUTH_SECRET_NAME
+              value: {{ .Values.auth.existingSecret | quote }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
@@ -60,6 +58,11 @@ spec:
           volumeMounts:
             - name: opscart-data
               mountPath: /data
+            {{- if .Values.auth.existingSecret }}
+            - name: auth-secret
+              mountPath: /etc/opscart/auth
+              readOnly: true
+            {{- end }}
           readinessProbe:
             httpGet:
               path: {{ .Values.probes.readiness.path }}
@@ -86,3 +89,8 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- if .Values.auth.existingSecret }}
+        - name: auth-secret
+          secret:
+            secretName: {{ .Values.auth.existingSecret }}
+        {{- end }}

--- a/helm/opscart-watcher/values-oauth2-proxy-example.yaml
+++ b/helm/opscart-watcher/values-oauth2-proxy-example.yaml
@@ -1,0 +1,83 @@
+# Example: fronting OpsCart with oauth2-proxy for authenticated access.
+#
+# This file is a REFERENCE, not a drop-in chart value — oauth2-proxy is
+# deployed and configured separately (via its own Helm chart or manifests).
+# This shows how to wire your ingress to require auth before traffic
+# reaches OpsCart.
+#
+# Prerequisites:
+#   1. oauth2-proxy deployed in-cluster (helm repo: oauth2-proxy/oauth2-proxy)
+#      configured with your identity provider (Azure AD / Google / GitHub / OIDC)
+#   2. An ingress controller that supports auth-url / auth-signin annotations
+#      (nginx-ingress is the most common; documented here)
+
+# ── OpsCart's own values remain unchanged ──────────────────────────────────
+# OpsCart does not need to know auth is happening. It keeps listening on
+# plain HTTP inside the cluster; the ingress enforces auth before any
+# request reaches the Service.
+# ── Basic auth and oauth2-proxy together ───────────────────────────────────
+# OpsCart's built-in basic auth (see values.yaml `auth:` block) stays active
+# by default even when oauth2-proxy fronts the ingress. This means a user
+# would see two prompts: oauth2-proxy's sign-in, then OpsCart's basic auth.
+#
+# If you're using the oauth2-proxy pattern below, set a stable basic-auth
+# password once (so it isn't regenerated on every restart) and share it
+# only with the operators who manage the Helm release — end users never
+# see it, because oauth2-proxy's auth-url check happens first and only
+# passes already-authenticated traffic through to OpsCart.
+#
+# auth:
+#   username: "admin"
+#   passwordEnv: "OPSCART_AUTH_PASS"
+
+replicaCount: 1
+image:
+  repository: ghcr.io/opscart/opscart-dashboard
+  tag: v1.8.3
+
+persistence:
+  enabled: true
+  size: 1Gi
+
+retentionDays: 90
+
+# ── Ingress with oauth2-proxy auth annotations ─────────────────────────────
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    # Redirect unauthenticated requests to oauth2-proxy's sign-in flow
+    nginx.ingress.kubernetes.io/auth-url: "https://oauth2-proxy.your-domain.com/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "https://oauth2-proxy.your-domain.com/oauth2/start?rd=$scheme://$host$request_uri"
+    # Pass identity headers through to OpsCart if you later want to log
+    # "who viewed this" — OpsCart does not currently read these headers,
+    # but they arrive pre-authenticated regardless.
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User,X-Auth-Request-Email"
+  hosts:
+    - host: opscart.your-domain.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: opscart-tls
+      hosts:
+        - opscart.your-domain.com
+
+# ── Reference: minimal oauth2-proxy values (deployed separately) ──────────
+# helm install oauth2-proxy oauth2-proxy/oauth2-proxy -f oauth2-proxy-values.yaml
+#
+# oauth2-proxy-values.yaml would contain, e.g. for Azure AD:
+#
+#   config:
+#     clientID: "<azure-ad-app-client-id>"
+#     clientSecret: "<azure-ad-app-client-secret>"
+#     cookieSecret: "<random-32-byte-base64-secret>"
+#   extraArgs:
+#     provider: azure
+#     azure-tenant: "<your-tenant-id>"
+#     email-domain: "*"
+#     upstreams: "static://202"
+#     cookie-secure: "true"
+#
+# See https://oauth2-proxy.github.io/oauth2-proxy/configuration/providers/
+# for GitHub, Google, and generic OIDC provider configuration.

--- a/helm/opscart-watcher/values.yaml
+++ b/helm/opscart-watcher/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: ghcr.io/opscart/opscart-dashboard
-  tag: "v1.7.0"
+  tag: "v1.8.5"
   # For local development with a locally-built image (e.g. minikube):
   # the image must be loaded under the EXACT repository:tag rendered by
   # this chart — kubelet does no fuzzy matching with pullPolicy Never.
@@ -42,6 +42,10 @@ resources:
 args:
   - "--port=8080"
   - "--breakdown=deployment"
+
+auth:
+  username: "admin"        # used only if generating a password with a custom username; ignored if existingSecret is set
+  existingSecret: ""       # name of a Secret with keys "username" and "password" — mounted at /etc/opscart/auth/
 
 podSecurityContext:
   runAsNonRoot: true


### PR DESCRIPTION
- Basic auth on by default, no disable path — env vars, Secret-mounted credentials, or auto-generated password (logged once at startup)
- /healthz exempted from auth so kubelet probes succeed
- helm: auth.existingSecret wires a Secret volume mount at /etc/opscart/auth; auto-generated fallback when unset
- docs: security philosophy, threat model, real RBAC, network diagram, documented oauth2-proxy pattern for team deployments