### PR TITLE
fix: absorb rapid resolve/reopen flapping in incident_events

### DIFF
--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -27,6 +27,16 @@ var restartMilestones = []int{10, 50, 100, 500, 1000, 2500, 5000, 10000}
 // resolved/reopened churn in the timeline.
 const resolveThreshold = 3
 
+// flapAbsorptionWindow is the gap after a RESOLVED event within which a
+// reappearance is treated as a continuation of the same active period
+// rather than a genuine recurrence. Some issue types (e.g. probe_failure)
+// have underlying conditions that flap scan-to-scan, so the incident can
+// satisfy neither the crash-loop nor probe-failure detection criteria for
+// a scan or two, get resolved by the debounce above, and then immediately
+// reappear — producing thousands of alternating RESOLVED/REOPENED events
+// for what is really one continuous problem.
+const flapAbsorptionWindow = 15 * time.Minute
+
 const schema = `
 PRAGMA auto_vacuum = INCREMENTAL;
 
@@ -381,35 +391,85 @@ func (s *SQLiteStore) UpsertIncidents(cluster string, scanID string, incidents [
 				inc.RestartCount, inc.Severity, "active",
 				fmt.Sprintf("%s first detected", inc.IssueType))
 		case prevStatus == "resolved":
-			err = insertIncidentEvent(tx, incidentID, scanID, now, "REOPENED", "Reopened",
-				inc.RestartCount, inc.Severity, "active", "Incident reoccurred")
+			var absorbed bool
+			absorbed, err = absorbRecentResolution(tx, incidentID, now)
+			if err != nil {
+				return err
+			}
+			if !absorbed {
+				err = insertIncidentEvent(tx, incidentID, scanID, now, "REOPENED", "Reopened",
+					inc.RestartCount, inc.Severity, "active", "Incident reoccurred")
+			} else {
+				err = emitDriftEvents(tx, incidentID, scanID, now, prevSeverity, prevRestart, inc)
+			}
 		default:
-			if prevSeverity != inc.Severity {
-				if err = insertIncidentEvent(tx, incidentID, scanID, now, "UPDATED", "SeverityChanged",
-					inc.RestartCount, inc.Severity, "active",
-					fmt.Sprintf("Severity changed %s → %s", prevSeverity, inc.Severity)); err != nil {
-					return err
-				}
-			}
-			if milestone := highestMilestoneCrossed(prevRestart, inc.RestartCount); milestone > 0 {
-				var lastMilestone int
-				_ = tx.QueryRow(
-					`SELECT COALESCE(MAX(restart_count), 0) FROM incident_events
-					 WHERE incident_id=? AND event_reason='RestartMilestone'`,
-					incidentID,
-				).Scan(&lastMilestone)
-				if lastMilestone < milestone {
-					err = insertIncidentEvent(tx, incidentID, scanID, now, "UPDATED", "RestartMilestone",
-						inc.RestartCount, inc.Severity, "active",
-						fmt.Sprintf("Restart count exceeded %d", milestone))
-				}
-			}
+			err = emitDriftEvents(tx, incidentID, scanID, now, prevSeverity, prevRestart, inc)
 		}
 		if err != nil {
 			return err
 		}
 	}
 	return tx.Commit()
+}
+
+// absorbRecentResolution checks whether the incident's most recent RESOLVED
+// event occurred within flapAbsorptionWindow of now. If so, that RESOLVED
+// event was premature — it deletes it and returns true so the caller skips
+// emitting a REOPENED event, treating the reappearance as a continuation of
+// the same active period rather than a new one. Returns false (with no
+// changes) if the incident has no RESOLVED event or the gap is too large,
+// meaning the caller should treat this as a genuine recurrence.
+func absorbRecentResolution(tx *sql.Tx, incidentID int64, now int64) (bool, error) {
+	var eventID, occurredAt int64
+	err := tx.QueryRow(
+		`SELECT id, occurred_at FROM incident_events
+		 WHERE incident_id=? AND event_type='RESOLVED'
+		 ORDER BY occurred_at DESC LIMIT 1`,
+		incidentID,
+	).Scan(&eventID, &occurredAt)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	if time.Duration(now-occurredAt)*time.Second >= flapAbsorptionWindow {
+		return false, nil
+	}
+	if _, err := tx.Exec(`DELETE FROM incident_events WHERE id=?`, eventID); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// emitDriftEvents records SeverityChanged/RestartMilestone events for an
+// incident that is already (or was just flap-absorbed back to) active,
+// comparing against its previously stored severity/restart count.
+func emitDriftEvents(tx *sql.Tx, incidentID int64, scanID string, now int64, prevSeverity string, prevRestart int, inc IncidentData) error {
+	if prevSeverity != inc.Severity {
+		if err := insertIncidentEvent(tx, incidentID, scanID, now, "UPDATED", "SeverityChanged",
+			inc.RestartCount, inc.Severity, "active",
+			fmt.Sprintf("Severity changed %s → %s", prevSeverity, inc.Severity)); err != nil {
+			return err
+		}
+	}
+	if milestone := highestMilestoneCrossed(prevRestart, inc.RestartCount); milestone > 0 {
+		var lastMilestone int
+		_ = tx.QueryRow(
+			`SELECT COALESCE(MAX(restart_count), 0) FROM incident_events
+			 WHERE incident_id=? AND event_reason='RestartMilestone'`,
+			incidentID,
+		).Scan(&lastMilestone)
+		if lastMilestone < milestone {
+			if err := insertIncidentEvent(tx, incidentID, scanID, now, "UPDATED", "RestartMilestone",
+				inc.RestartCount, inc.Severity, "active",
+				fmt.Sprintf("Restart count exceeded %d", milestone)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // ResolveMissing debounces resolution over resolveThreshold consecutive

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -27,6 +27,29 @@ func driveToResolved(t *testing.T, s *SQLiteStore, cluster string, present []Inc
 	}
 }
 
+// backdateIncidentEvents shifts every recorded event for the given incident
+// back in time by `age`, simulating a resolution (and the history leading
+// up to it) that happened well in the past without sleeping in tests, since
+// UpsertIncidents/ResolveMissing always stamp events with the real wall
+// clock. Shifting the whole history (not just the RESOLVED event) preserves
+// event ordering — only backdating RESOLVED would place it before DETECTED.
+func backdateIncidentEvents(t *testing.T, s *SQLiteStore, cluster, fingerprint string, age time.Duration) {
+	t.Helper()
+	var incidentID int64
+	if err := s.db.QueryRow(
+		"SELECT id FROM incidents WHERE cluster=? AND fingerprint=?",
+		cluster, fingerprint,
+	).Scan(&incidentID); err != nil {
+		t.Fatalf("lookup incident id: %v", err)
+	}
+	if _, err := s.db.Exec(
+		`UPDATE incident_events SET occurred_at = occurred_at - ? WHERE incident_id=?`,
+		int64(age.Seconds()), incidentID,
+	); err != nil {
+		t.Fatalf("backdate incident events: %v", err)
+	}
+}
+
 func openTestStore(t *testing.T) *SQLiteStore {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "test.db")
@@ -516,6 +539,9 @@ func TestTimeline_ReopenedAfterResolve(t *testing.T) {
 	}
 	// resolve it: incident absent for resolveThreshold consecutive scans
 	driveToResolved(t, s, "test-cluster", nil, "scan-miss")
+	// push the resolution outside flapAbsorptionWindow so this reappearance
+	// reads as a genuine recurrence, not a flap
+	backdateIncidentEvents(t, s, "test-cluster", inc.Fingerprint, flapAbsorptionWindow+time.Minute)
 
 	// reappears after genuine resolution
 	if err := s.UpsertIncidents("test-cluster", "scan-reopen", []IncidentData{inc}); err != nil {
@@ -704,6 +730,9 @@ func TestDebounce_ReopensAfterGenuineResolve(t *testing.T) {
 	if rec.Status != "resolved" {
 		t.Fatalf("expected genuinely resolved, got %s", rec.Status)
 	}
+	// push the resolution outside flapAbsorptionWindow so this reappearance
+	// reads as a genuine recurrence, not a flap
+	backdateIncidentEvents(t, s, "test-cluster", inc.Fingerprint, flapAbsorptionWindow+time.Minute)
 
 	if err := s.UpsertIncidents("test-cluster", "scan-reopen", []IncidentData{inc}); err != nil {
 		t.Fatalf("UpsertIncidents(reopen): %v", err)
@@ -724,6 +753,117 @@ func TestDebounce_ReopensAfterGenuineResolve(t *testing.T) {
 	last := events[len(events)-1]
 	if last.EventType != "REOPENED" || last.EventReason != "Reopened" {
 		t.Fatalf("expected trailing REOPENED event, got %+v", last)
+	}
+}
+
+// ── Flap absorption ──────────────────────────────────────────────────────────
+
+func TestFlapAbsorption_ReappearsWithinWindow_NoReopenEventEmitted(t *testing.T) {
+	s := openTestStore(t)
+
+	inc := IncidentData{Fingerprint: "default/Deployment/svc-a/probe_failure", Namespace: "default", Resource: "svc-a", IssueType: "probe_failure", Severity: "warning"}
+
+	if err := s.UpsertIncidents("test-cluster", "scan-1", []IncidentData{inc}); err != nil {
+		t.Fatalf("UpsertIncidents(1): %v", err)
+	}
+	driveToResolved(t, s, "test-cluster", nil, "scan-miss")
+
+	rec, err := s.GetIncidentHistory("test-cluster", inc.Fingerprint)
+	if err != nil {
+		t.Fatalf("GetIncidentHistory: %v", err)
+	}
+	if rec.Status != "resolved" {
+		t.Fatalf("expected resolved before flap, got %s", rec.Status)
+	}
+
+	// reappears moments later (well within flapAbsorptionWindow) — this is
+	// the flap this feature absorbs, not a genuine recurrence.
+	if err := s.UpsertIncidents("test-cluster", "scan-flap", []IncidentData{inc}); err != nil {
+		t.Fatalf("UpsertIncidents(flap): %v", err)
+	}
+
+	rec, err = s.GetIncidentHistory("test-cluster", inc.Fingerprint)
+	if err != nil {
+		t.Fatalf("GetIncidentHistory: %v", err)
+	}
+	if rec.Status != "active" {
+		t.Fatalf("expected active after absorbed flap, got %s", rec.Status)
+	}
+
+	events, err := s.GetIncidentTimeline("test-cluster", inc.Fingerprint)
+	if err != nil {
+		t.Fatalf("GetIncidentTimeline: %v", err)
+	}
+	if len(events) != 1 || events[0].EventType != "DETECTED" {
+		t.Fatalf("expected only the initial DETECTED event (RESOLVED removed, no REOPENED), got %+v", events)
+	}
+}
+
+func TestFlapAbsorption_ReappearsAfterWindow_ReopenedEmitted(t *testing.T) {
+	s := openTestStore(t)
+
+	inc := IncidentData{Fingerprint: "default/Deployment/svc-a/probe_failure", Namespace: "default", Resource: "svc-a", IssueType: "probe_failure", Severity: "warning"}
+
+	if err := s.UpsertIncidents("test-cluster", "scan-1", []IncidentData{inc}); err != nil {
+		t.Fatalf("UpsertIncidents(1): %v", err)
+	}
+	driveToResolved(t, s, "test-cluster", nil, "scan-miss")
+	backdateIncidentEvents(t, s, "test-cluster", inc.Fingerprint, flapAbsorptionWindow+time.Minute)
+
+	if err := s.UpsertIncidents("test-cluster", "scan-reopen", []IncidentData{inc}); err != nil {
+		t.Fatalf("UpsertIncidents(reopen): %v", err)
+	}
+
+	events, err := s.GetIncidentTimeline("test-cluster", inc.Fingerprint)
+	if err != nil {
+		t.Fatalf("GetIncidentTimeline: %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events (DETECTED, RESOLVED, REOPENED), got %d: %+v", len(events), events)
+	}
+	if events[1].EventType != "RESOLVED" {
+		t.Fatalf("expected RESOLVED event to be retained (gap exceeded the window), got %+v", events[1])
+	}
+	if events[2].EventType != "REOPENED" || events[2].EventReason != "Reopened" {
+		t.Fatalf("expected trailing REOPENED event, got %+v", events[2])
+	}
+}
+
+func TestFlapAbsorption_MultipleRapidFlapsLeaveOnlyDetected(t *testing.T) {
+	s := openTestStore(t)
+
+	inc := IncidentData{Fingerprint: "default/Deployment/svc-a/probe_failure", Namespace: "default", Resource: "svc-a", IssueType: "probe_failure", Severity: "warning"}
+
+	if err := s.UpsertIncidents("test-cluster", "scan-1", []IncidentData{inc}); err != nil {
+		t.Fatalf("UpsertIncidents(1): %v", err)
+	}
+
+	// 5 resolve/reopen cycles, ~3 minutes apart — mirrors the flapping
+	// probe_failure pattern this feature exists to absorb.
+	for cycle := 0; cycle < 5; cycle++ {
+		driveToResolved(t, s, "test-cluster", nil, fmt.Sprintf("cycle%d-miss", cycle))
+		backdateIncidentEvents(t, s, "test-cluster", inc.Fingerprint, 3*time.Minute)
+
+		scanID := fmt.Sprintf("cycle%d-reappear", cycle)
+		if err := s.UpsertIncidents("test-cluster", scanID, []IncidentData{inc}); err != nil {
+			t.Fatalf("UpsertIncidents(%s): %v", scanID, err)
+		}
+	}
+
+	rec, err := s.GetIncidentHistory("test-cluster", inc.Fingerprint)
+	if err != nil {
+		t.Fatalf("GetIncidentHistory: %v", err)
+	}
+	if rec.Status != "active" {
+		t.Fatalf("expected active after flap cycles settle, got %s", rec.Status)
+	}
+
+	events, err := s.GetIncidentTimeline("test-cluster", inc.Fingerprint)
+	if err != nil {
+		t.Fatalf("GetIncidentTimeline: %v", err)
+	}
+	if len(events) != 1 || events[0].EventType != "DETECTED" {
+		t.Fatalf("expected only the original DETECTED event to survive 5 flap cycles, got %+v", events)
 	}
 }
 
@@ -1402,6 +1542,9 @@ func TestQueryIncidents_ReopenCountAndStatus(t *testing.T) {
 	// throughout and is never resolved.
 	for i := 0; i < 2; i++ {
 		driveToResolved(t, s, "test-cluster", []IncidentData{other}, fmt.Sprintf("scan-miss-%d", i))
+		// push each resolution outside flapAbsorptionWindow so the reopen
+		// below counts as a genuine recurrence, not an absorbed flap
+		backdateIncidentEvents(t, s, "test-cluster", inc.Fingerprint, flapAbsorptionWindow+time.Minute)
 		if err := s.UpsertIncidents("test-cluster", fmt.Sprintf("scan-reopen-%d", i), []IncidentData{inc, other}); err != nil {
 			t.Fatalf("UpsertIncidents(reopen %d): %v", i, err)
 		}


### PR DESCRIPTION
Incidents whose underlying condition flaps scan-to-scan (probe_failure: not-ready state briefly clearing between failures) produced thousands of alternating RESOLVED/REOPENED events for one continuous problem. Reappearance within 15 min of a RESOLVED event now absorbs silently. Reappearance after 15+ min unchanged (genuine recurrence).