### PR TITLE
Feature/overview memory scoreboard

### DIFF
--- a/cmd/opscart-dashboard/main_test.go
+++ b/cmd/opscart-dashboard/main_test.go
@@ -865,3 +865,94 @@ func TestOverviewTemplate_HealthCardsNoViewAllUnderCap(t *testing.T) {
 		t.Errorf("did not expect a workloads View all link under the cap")
 	}
 }
+
+func TestInvestigateURL(t *testing.T) {
+	tests := []struct {
+		name                                string
+		namespace, resource, issueType, ctx string
+		want                                string
+	}{
+		{
+			name:      "all fields present builds deep link with escaped params",
+			namespace: "payments prod", resource: "payments-api/abc123", issueType: "crash_loop", ctx: "my cluster",
+			want: "/investigate?pod=payments-api%2Fabc123&ns=payments+prod&type=crash_loop&cluster=my+cluster&from=warroom",
+		},
+		{
+			name:      "empty namespace falls back to /warroom",
+			namespace: "", resource: "payments-api", issueType: "crash_loop", ctx: "test-cluster",
+			want: "/warroom",
+		},
+		{
+			name:      "empty resource falls back to /warroom",
+			namespace: "payments", resource: "", issueType: "crash_loop", ctx: "test-cluster",
+			want: "/warroom",
+		},
+		{
+			name:      "empty issueType falls back to /warroom",
+			namespace: "payments", resource: "payments-api", issueType: "", ctx: "test-cluster",
+			want: "/warroom",
+		},
+		{
+			name:      "all three empty falls back to /warroom",
+			namespace: "", resource: "", issueType: "", ctx: "test-cluster",
+			want: "/warroom",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := investigateURL(tt.namespace, tt.resource, tt.issueType, tt.ctx); got != tt.want {
+				t.Errorf("investigateURL(%q, %q, %q, %q) = %q, want %q", tt.namespace, tt.resource, tt.issueType, tt.ctx, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildTopIssues_URLDeepLinksToInvestigation drives buildTopIssues
+// end-to-end from a scan fixture (through collectWarRoomIssues, matching
+// how buildOverviewData actually calls it) and asserts the grouped
+// crash_loop row's URL is a real Investigation deep link, not the old
+// hardcoded "/warroom".
+func TestBuildTopIssues_URLDeepLinksToInvestigation(t *testing.T) {
+	scan := &clusterScan{
+		wasteAudit: &analyzer.WasteAudit{
+			StalePods: []analyzer.StalePod{
+				{Name: "payments-api-abc123", Namespace: "payments", Kind: analyzer.StalePodZombie, Status: "CrashLoopBackOff", RestartCount: 10, AgeDays: 2},
+			},
+		},
+	}
+	wrIssues := collectWarRoomIssues(scan, 0)
+	issues := buildTopIssues(scan, wrIssues, "test-cluster")
+
+	if len(issues) == 0 {
+		t.Fatalf("expected at least one topIssue")
+	}
+	want := "/investigate?pod=payments-api-abc123&ns=payments&type=crash_loop&cluster=test-cluster&from=warroom"
+	if issues[0].URL != want {
+		t.Errorf("URL = %q, want %q", issues[0].URL, want)
+	}
+}
+
+// TestBuildTopIssues_AggregateRowsKeepTheirOwnURL proves the fix is scoped
+// to grouped incident rows: the orphaned-PVCs aggregate row has no single
+// Namespace/Resource/IssueType to deep-link to, so it must keep its
+// existing "/optimizations" URL rather than falling back to "/warroom".
+func TestBuildTopIssues_AggregateRowsKeepTheirOwnURL(t *testing.T) {
+	scan := &clusterScan{
+		wasteAudit: &analyzer.WasteAudit{
+			OrphanedPVCs: []analyzer.OrphanedPVC{
+				{Name: "pvc-1", Namespace: "default", SizeGB: 10, Status: analyzer.PVCReleased, AgeDays: 30},
+			},
+		},
+	}
+	issues := buildTopIssues(scan, nil, "test-cluster")
+	if len(issues) == 0 {
+		t.Fatalf("expected at least one topIssue")
+	}
+	if issues[0].URL != "/optimizations" {
+		t.Errorf("expected aggregated orphaned-PVC row to keep its own URL, got %q", issues[0].URL)
+	}
+	if issues[0].Namespace != "" || issues[0].Resource != "" || issues[0].IssueType != "" {
+		t.Errorf("expected aggregate row to have no matching key, got Namespace=%q Resource=%q IssueType=%q",
+			issues[0].Namespace, issues[0].Resource, issues[0].IssueType)
+	}
+}

--- a/cmd/opscart-dashboard/main_test.go
+++ b/cmd/opscart-dashboard/main_test.go
@@ -392,16 +392,16 @@ func fullyPopulatedOverviewData() overviewPageData {
 			LongestActiveDays: 12, LongestActiveName: "payments-api",
 			MostUnstableNamespace: "payments", MostUnstableCount: 9,
 		},
-		RecentEvents: []store.RecentEvent{
+		RecentEvents: formatChangeLines([]store.RecentEvent{
 			{Resource: "payments-api", EventReason: "RestartMilestone", OccurredAt: time.Now().Add(-5 * time.Minute)},
 			{Resource: "checkout-worker", EventReason: "Resolved", OccurredAt: time.Now().Add(-2 * time.Hour)},
-		},
+		}),
 
-		ChangesSinceLastView: []store.RecentEvent{
+		ChangesSinceLastView: formatChangeLines([]store.RecentEvent{
 			{Resource: "payments-api", EventReason: "SeverityChanged", OccurredAt: time.Now().Add(-1 * time.Minute)},
 			{Resource: "checkout-api", EventReason: "Detected", OccurredAt: time.Now().Add(-10 * time.Minute)},
 			{Resource: "checkout-api", EventReason: "Reopened", OccurredAt: time.Now().Add(-20 * time.Minute)},
-		},
+		}),
 		LastViewedLabel: "24h ago",
 
 		NamespaceHealthList: []namespaceHealth{
@@ -500,16 +500,16 @@ func TestOverviewTemplate_RendersEmptyData(t *testing.T) {
 func TestOverviewTemplate_FeedsCapAtFive(t *testing.T) {
 	data := fullyPopulatedOverviewData()
 
-	makeEvents := func(n int) []store.RecentEvent {
-		out := make([]store.RecentEvent, n)
+	makeEvents := func(n int) []changeLine {
+		raw := make([]store.RecentEvent, n)
 		for i := 0; i < n; i++ {
-			out[i] = store.RecentEvent{
+			raw[i] = store.RecentEvent{
 				Resource:    "svc-" + strconv.Itoa(i),
 				EventReason: "Detected",
 				OccurredAt:  time.Now().Add(-time.Duration(i) * time.Minute),
 			}
 		}
-		return out
+		return formatChangeLines(raw)
 	}
 	data.ChangesSinceLastView = makeEvents(9)
 	data.RecentEvents = makeEvents(7)
@@ -547,20 +547,18 @@ func (s *queryIncidentsStubStore) QueryIncidents(f store.IncidentFilter) ([]stor
 // pod/deployment involved) — the sentence must use Namespace instead, not
 // that placeholder.
 func TestBuildOverviewVerdict_UnprotectedNamespaceUsesNamespaceNotLiteralResource(t *testing.T) {
-	stub := &queryIncidentsStubStore{
-		items: []store.IncidentSummary{
-			{
-				Namespace: "payments-prod",
-				Resource:  "namespace",
-				IssueType: "unprotected_namespace",
-				Severity:  "high",
-				FirstSeen: time.Now().Add(-3 * 24 * time.Hour),
-			},
+	topIssues := []topIssue{
+		{
+			Title:              "1 namespace missing NetworkPolicy",
+			Namespace:          "payments-prod",
+			Resource:           "namespace",
+			IssueType:          "unprotected_namespace",
+			GroupSize:          1,
+			FirstDetectedLabel: "3d ago",
 		},
-		total: 1,
 	}
 
-	line1, _ := buildOverviewVerdict(stub, "test-cluster")
+	line1, _ := buildOverviewVerdict(topIssues, 0, time.Now())
 
 	if strings.Contains(line1, "namespace has been") {
 		t.Fatalf("expected verdict to use the real namespace, not the literal placeholder %q: got %q", "namespace", line1)
@@ -574,27 +572,163 @@ func TestBuildOverviewVerdict_UnprotectedNamespaceUsesNamespaceNotLiteralResourc
 // covers the same substitution for idle_namespace, and the ReopenCount
 // branch rather than the default one.
 func TestBuildOverviewVerdict_IdleNamespaceUsesNamespaceNotLiteralResource(t *testing.T) {
-	stub := &queryIncidentsStubStore{
-		items: []store.IncidentSummary{
-			{
-				Namespace:   "batch-jobs",
-				Resource:    "namespace",
-				IssueType:   "idle_namespace",
-				Severity:    "medium",
-				FirstSeen:   time.Now().Add(-5 * 24 * time.Hour),
-				ReopenCount: 2,
-			},
+	topIssues := []topIssue{
+		{
+			Title:              "1 idle namespace",
+			Namespace:          "batch-jobs",
+			Resource:           "namespace",
+			IssueType:          "idle_namespace",
+			GroupSize:          1,
+			FirstDetectedLabel: "5d ago",
+			ReopenCountVal:     2,
 		},
-		total: 1,
 	}
 
-	line1, _ := buildOverviewVerdict(stub, "test-cluster")
+	line1, _ := buildOverviewVerdict(topIssues, 0, time.Now())
 
 	if strings.Contains(line1, "namespace reoccurred") {
 		t.Fatalf("expected verdict to use the real namespace, not the literal placeholder %q: got %q", "namespace", line1)
 	}
 	if !strings.Contains(line1, "batch-jobs reoccurred") {
 		t.Fatalf("expected verdict to mention namespace %q, got: %q", "batch-jobs", line1)
+	}
+}
+
+// TestBuildOverviewVerdict_MatchesTopIssuesZero is Fix 2's core regression
+// test: the verdict sentence must be built from the exact same topIssues[0]
+// the "if you only fix one thing today" banner and Top 5's first row
+// render — previously buildOverviewVerdict ran its own independent
+// db.QueryIncidents call and could (and did) disagree with Top 5 about
+// which issue was "worst".
+func TestBuildOverviewVerdict_MatchesTopIssuesZero(t *testing.T) {
+	topIssues := []topIssue{
+		{
+			Title: "5 pods crash-looping", Namespace: "checkout", Resource: "checkout-api-abc123",
+			IssueType: "crash_loop", GroupSize: 5, FirstDetectedLabel: "2d ago", TrendVal: "accelerating",
+		},
+		{
+			Title: "2 namespaces missing NetworkPolicy", Namespace: "payments", Resource: "namespace",
+			IssueType: "unprotected_namespace", GroupSize: 2, FirstDetectedLabel: "1d ago",
+		},
+	}
+
+	line1, _ := buildOverviewVerdict(topIssues, 0, time.Now())
+
+	if !strings.Contains(line1, "checkout-api-abc123") {
+		t.Fatalf("expected verdict to describe topIssues[0] (checkout-api-abc123), got: %q", line1)
+	}
+	if strings.Contains(line1, "payments") {
+		t.Fatalf("expected verdict to NOT describe topIssues[1], got: %q", line1)
+	}
+	if !strings.Contains(line1, "5 workloads need attention") {
+		t.Fatalf("expected verdict's count to come from topIssues[0].GroupSize (5), got: %q", line1)
+	}
+}
+
+// TestBuildOverviewVerdict_EmptyTopIssues covers the "no active incidents"
+// fallback now that there's no db.QueryIncidents call to short-circuit on.
+func TestBuildOverviewVerdict_EmptyTopIssues(t *testing.T) {
+	line1, line2 := buildOverviewVerdict(nil, 0, time.Now())
+	if line1 != "No active incidents detected." || line2 != "" {
+		t.Fatalf("got line1=%q line2=%q, want the no-incidents fallback", line1, line2)
+	}
+}
+
+// TestBuildOverviewVerdict_AggregateRowFallsBackToTitle covers topIssues[0]
+// being an aggregate row (no single Namespace/Resource/IssueType) — e.g. a
+// cluster with only orphaned-PVC waste and no crash-looping pods.
+func TestBuildOverviewVerdict_AggregateRowFallsBackToTitle(t *testing.T) {
+	topIssues := []topIssue{
+		{Title: "3 orphaned PVCs wasting money", Severity: "medium"},
+	}
+	line1, _ := buildOverviewVerdict(topIssues, 0, time.Now())
+	if !strings.Contains(line1, "3 orphaned PVCs wasting money") {
+		t.Fatalf("expected verdict to fall back to the aggregate row's title, got: %q", line1)
+	}
+}
+
+// TestBuildOverviewVerdict_Line2ResolvedSinceCursor covers Fix 2: line2
+// shows the resolved-since-cursor count when >0, empty when 0 — and never
+// a hollow "0 incidents resolved" sentence. Also covers line2 appearing
+// even when there are no active incidents (topIssues empty) — confirming
+// resolved-since-cursor and topIssues are independent.
+func TestBuildOverviewVerdict_Line2ResolvedSinceCursor(t *testing.T) {
+	t.Run("zero resolved leaves line2 empty", func(t *testing.T) {
+		_, line2 := buildOverviewVerdict(nil, 0, time.Now().Add(-24*time.Hour))
+		if line2 != "" {
+			t.Fatalf("expected empty line2 for zero resolved, got %q", line2)
+		}
+	})
+
+	t.Run("one resolved uses singular wording", func(t *testing.T) {
+		_, line2 := buildOverviewVerdict(nil, 1, time.Now().Add(-24*time.Hour))
+		if line2 != "1 incident resolved since yesterday." {
+			t.Fatalf("line2 = %q, want %q", line2, "1 incident resolved since yesterday.")
+		}
+	})
+
+	t.Run("multiple resolved uses plural wording and correct count", func(t *testing.T) {
+		_, line2 := buildOverviewVerdict(nil, 3, time.Now().Add(-24*time.Hour))
+		if line2 != "3 incidents resolved since yesterday." {
+			t.Fatalf("line2 = %q, want %q", line2, "3 incidents resolved since yesterday.")
+		}
+	})
+
+	t.Run("line2 appears alongside a real line1 when there IS an active issue", func(t *testing.T) {
+		topIssues := []topIssue{
+			{Title: "1 pod crash-looping", Namespace: "payments", Resource: "payments-api-abc123", IssueType: "crash_loop", GroupSize: 1, FirstDetectedLabel: "2d ago"},
+		}
+		line1, line2 := buildOverviewVerdict(topIssues, 2, time.Now().Add(-24*time.Hour))
+		if !strings.Contains(line1, "payments-api-abc123") {
+			t.Fatalf("expected line1 to still describe the active issue, got %q", line1)
+		}
+		if line2 != "2 incidents resolved since yesterday." {
+			t.Fatalf("line2 = %q, want %q", line2, "2 incidents resolved since yesterday.")
+		}
+	})
+}
+
+// TestSinceCursorPhrase covers the "since yesterday" vs "since your last
+// visit" wording choice: "yesterday" only reads honestly when the cursor
+// is roughly a day old (the default for a first-time visitor); anything
+// meaningfully more recent or older uses the always-accurate fallback.
+func TestSinceCursorPhrase(t *testing.T) {
+	tests := []struct {
+		name    string
+		elapsed time.Duration
+		want    string
+	}{
+		{"exactly 24h (the first-time-visitor default) reads as yesterday", 24 * time.Hour, "since yesterday"},
+		{"18h lower bound reads as yesterday", 18 * time.Hour, "since yesterday"},
+		{"36h upper bound reads as yesterday", 36 * time.Hour, "since yesterday"},
+		{"a few minutes ago is not yesterday", 5 * time.Minute, "since your last visit"},
+		{"a week ago is not yesterday", 7 * 24 * time.Hour, "since your last visit"},
+		{"zero elapsed (impossible but defensive) is not yesterday", 0, "since your last visit"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sinceCursorPhrase(tt.elapsed); got != tt.want {
+				t.Errorf("sinceCursorPhrase(%v) = %q, want %q", tt.elapsed, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCountResolvedSince covers the reused-not-requeried plumbing: the
+// count comes from filtering the already-fetched changeLine slice
+// (GetChangesSince's result), not a second query.
+func TestCountResolvedSince(t *testing.T) {
+	changes := []changeLine{
+		{Phrase: "payments-api recovered", EventReason: "Resolved"},
+		{Phrase: "checkout-api reopened", EventReason: "Reopened"},
+		{Phrase: "New: fraud-svc", EventReason: "Detected"},
+		{Phrase: "orders-api recovered", EventReason: "Resolved"},
+	}
+	if got := countResolvedSince(changes); got != 2 {
+		t.Errorf("countResolvedSince = %d, want 2", got)
+	}
+	if got := countResolvedSince(nil); got != 0 {
+		t.Errorf("countResolvedSince(nil) = %d, want 0", got)
 	}
 }
 
@@ -930,6 +1064,44 @@ func TestBuildTopIssues_URLDeepLinksToInvestigation(t *testing.T) {
 	if issues[0].URL != want {
 		t.Errorf("URL = %q, want %q", issues[0].URL, want)
 	}
+	if issues[0].GroupSize != 1 {
+		t.Errorf("GroupSize = %d, want 1", issues[0].GroupSize)
+	}
+	if issues[0].ButtonLabel != "Fix now →" {
+		t.Errorf("ButtonLabel = %q, want %q", issues[0].ButtonLabel, "Fix now →")
+	}
+}
+
+// TestBuildTopIssues_MultiPodGroupRoutesToIncidentsRegistry covers a group
+// of more than one pod: rather than deep-linking to grp[0]'s pod as if it
+// were "the" incident, the row must route to the Incidents registry
+// filtered to this issue type, with a "View all N →" button.
+func TestBuildTopIssues_MultiPodGroupRoutesToIncidentsRegistry(t *testing.T) {
+	scan := &clusterScan{
+		wasteAudit: &analyzer.WasteAudit{
+			StalePods: []analyzer.StalePod{
+				{Name: "payments-api-abc123", Namespace: "payments", Kind: analyzer.StalePodZombie, Status: "CrashLoopBackOff", RestartCount: 10, AgeDays: 2},
+				{Name: "payments-worker-def456", Namespace: "payments", Kind: analyzer.StalePodZombie, Status: "CrashLoopBackOff", RestartCount: 5, AgeDays: 1},
+			},
+		},
+	}
+	wrIssues := collectWarRoomIssues(scan, 0)
+	issues := buildTopIssues(scan, wrIssues, "test-cluster")
+
+	if len(issues) == 0 {
+		t.Fatalf("expected at least one topIssue")
+	}
+	if issues[0].GroupSize != 2 {
+		t.Fatalf("expected GroupSize=2, got %d", issues[0].GroupSize)
+	}
+	wantURL := "/incidents?cluster=test-cluster&type=crash_loop&status=active"
+	if issues[0].URL != wantURL {
+		t.Errorf("URL = %q, want %q", issues[0].URL, wantURL)
+	}
+	wantLabel := "View all 2 →"
+	if issues[0].ButtonLabel != wantLabel {
+		t.Errorf("ButtonLabel = %q, want %q", issues[0].ButtonLabel, wantLabel)
+	}
 }
 
 // TestBuildTopIssues_AggregateRowsKeepTheirOwnURL proves the fix is scoped
@@ -954,5 +1126,85 @@ func TestBuildTopIssues_AggregateRowsKeepTheirOwnURL(t *testing.T) {
 	if issues[0].Namespace != "" || issues[0].Resource != "" || issues[0].IssueType != "" {
 		t.Errorf("expected aggregate row to have no matching key, got Namespace=%q Resource=%q IssueType=%q",
 			issues[0].Namespace, issues[0].Resource, issues[0].IssueType)
+	}
+	if issues[0].ButtonLabel != "View →" {
+		t.Errorf("expected aggregate row to keep its existing 'View →' label, got %q", issues[0].ButtonLabel)
+	}
+}
+
+// TestFormatChangeLine covers every event_reason category the What's
+// Changed / Recent Events feeds can show, asserting phrasing and that no
+// case produces empty or malformed text. RestartMilestone specifically
+// must NOT claim a trend judgment ("accelerating") or fabricate a
+// percentage — store.RecentEvent carries no restart count or trend data to
+// justify either.
+func TestFormatChangeLine(t *testing.T) {
+	tests := []struct {
+		eventReason string
+		wantPhrase  string
+	}{
+		{"Detected", "New: fraud-detection"},
+		{"Resolved", "fraud-detection recovered"},
+		{"Reopened", "fraud-detection reopened"},
+		{"RestartMilestone", "fraud-detection restart milestone reached"},
+		{"SeverityChanged", "fraud-detection severity changed"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.eventReason, func(t *testing.T) {
+			got := formatChangeLine(store.RecentEvent{
+				Resource: "fraud-detection", EventReason: tt.eventReason, OccurredAt: time.Now(),
+			})
+			if got.Phrase != tt.wantPhrase {
+				t.Errorf("Phrase = %q, want %q", got.Phrase, tt.wantPhrase)
+			}
+			if got.Phrase == "" {
+				t.Errorf("Phrase must not be empty for %q", tt.eventReason)
+			}
+			if got.EventReason != tt.eventReason {
+				t.Errorf("EventReason = %q, want %q (must match verbatim for the CSS class to resolve)", got.EventReason, tt.eventReason)
+			}
+			if strings.Contains(got.Phrase, "%") {
+				t.Errorf("Phrase %q must not fabricate a percentage — RestartMilestone carries no restart-count data", got.Phrase)
+			}
+			if strings.Contains(strings.ToLower(got.Phrase), "accelerat") {
+				t.Errorf("Phrase %q must not claim a trend judgment RecentEvent has no data to support", got.Phrase)
+			}
+		})
+	}
+
+	t.Run("unknown reason falls back to resource name, never empty", func(t *testing.T) {
+		got := formatChangeLine(store.RecentEvent{Resource: "mystery-svc", EventReason: "SomethingElse", OccurredAt: time.Now()})
+		if got.Phrase == "" {
+			t.Errorf("expected a non-empty fallback phrase, got empty")
+		}
+	})
+}
+
+// TestOverviewTemplate_ChangeDotCasingMatchesCSS is Fix 3's regression
+// test: for every event_reason category, the rendered .change-dot class
+// must match the CSS's Title-Case selectors (.change-dot.Detected,
+// .change-dot.Resolved, etc.) exactly — case-sensitive, as CSS class
+// matching always is.
+func TestOverviewTemplate_ChangeDotCasingMatchesCSS(t *testing.T) {
+	reasons := []string{"Detected", "Resolved", "Reopened", "RestartMilestone", "SeverityChanged"}
+
+	data := fullyPopulatedOverviewData()
+	var raw []store.RecentEvent
+	for _, r := range reasons {
+		raw = append(raw, store.RecentEvent{Resource: "svc", EventReason: r, OccurredAt: time.Now()})
+	}
+	data.RecentEvents = formatChangeLines(raw)
+
+	var buf strings.Builder
+	if err := getOverviewTmpl().Execute(&buf, data); err != nil {
+		t.Fatalf("template execution failed: %v", err)
+	}
+	out := buf.String()
+
+	for _, r := range reasons {
+		want := `class="change-dot ` + r + `"`
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in rendered output (must match .change-dot.%s CSS exactly), not found", want, r)
+		}
 	}
 }

--- a/cmd/opscart-dashboard/main_test.go
+++ b/cmd/opscart-dashboard/main_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/opscart/opscart-k8s-watcher/pkg/analyzer"
+	"github.com/opscart/opscart-k8s-watcher/pkg/models"
 	"github.com/opscart/opscart-k8s-watcher/pkg/store"
 )
 
@@ -215,4 +217,139 @@ func TestFormatCostDelta(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildNamespaceHealth(t *testing.T) {
+	t.Run("nil scan returns nil, no panic", func(t *testing.T) {
+		if got := buildNamespaceHealth(nil); got != nil {
+			t.Fatalf("expected nil, got %+v", got)
+		}
+	})
+
+	t.Run("scan with no report returns nil, no panic", func(t *testing.T) {
+		if got := buildNamespaceHealth(&clusterScan{}); got != nil {
+			t.Fatalf("expected nil, got %+v", got)
+		}
+	})
+
+	t.Run("mixed ready/not-ready pods across namespaces", func(t *testing.T) {
+		scan := &clusterScan{
+			report: &models.CloudCostReport{
+				NamespaceCosts: []models.NamespaceCostInfo{
+					{Name: "payments", PodCount: 4},
+					{Name: "checkout", PodCount: 3},
+				},
+			},
+			wasteAudit: &analyzer.WasteAudit{
+				StalePods: []analyzer.StalePod{
+					{Name: "payments-api-abc123", Namespace: "payments", Kind: analyzer.StalePodZombie, Status: "CrashLoopBackOff", RestartCount: 10, AgeDays: 2},
+					{Name: "payments-api-def456", Namespace: "payments", Kind: analyzer.StalePodZombie, Status: "OOMKilled", RestartCount: 5, AgeDays: 1},
+					// Idle (not zombie) — must NOT count against readiness.
+					{Name: "checkout-worker-ghi789", Namespace: "checkout", Kind: analyzer.StalePodIdle, AgeDays: 20},
+				},
+			},
+		}
+
+		got := buildNamespaceHealth(scan)
+		if len(got) != 2 {
+			t.Fatalf("expected 2 namespaces, got %d: %+v", len(got), got)
+		}
+		// worst health first: payments (2/4 = 0.5) before checkout (3/3 = 1.0)
+		if got[0] != (namespaceHealth{Name: "payments", Ready: 2, Total: 4}) {
+			t.Fatalf("got[0] = %+v, want payments 2/4", got[0])
+		}
+		if got[1] != (namespaceHealth{Name: "checkout", Ready: 3, Total: 3}) {
+			t.Fatalf("got[1] = %+v, want checkout 3/3", got[1])
+		}
+	})
+}
+
+func TestBuildWorkloadHealthGrid(t *testing.T) {
+	t.Run("nil scan returns nil, no panic", func(t *testing.T) {
+		if got := buildWorkloadHealthGrid(nil); got != nil {
+			t.Fatalf("expected nil, got %+v", got)
+		}
+	})
+
+	t.Run("empty scan returns empty, no panic", func(t *testing.T) {
+		if got := buildWorkloadHealthGrid(&clusterScan{}); len(got) != 0 {
+			t.Fatalf("expected empty, got %+v", got)
+		}
+	})
+
+	t.Run("mixed healthy and unhealthy workloads", func(t *testing.T) {
+		scan := &clusterScan{
+			report: &models.CloudCostReport{
+				NamespaceCosts: []models.NamespaceCostInfo{
+					{
+						Name: "payments", PodCount: 3,
+						Deployments: []models.DeploymentCostInfo{
+							{Name: "payments-api", Kind: "Deployment", Namespace: "payments", Replicas: 2},
+							{Name: "payments-worker", Kind: "Deployment", Namespace: "payments", Replicas: 1},
+						},
+					},
+					{
+						Name: "checkout", PodCount: 1,
+						Deployments: []models.DeploymentCostInfo{
+							{Name: "checkout-api", Kind: "Deployment", Namespace: "checkout", Replicas: 1},
+						},
+					},
+				},
+			},
+			wasteAudit: &analyzer.WasteAudit{
+				StalePods: []analyzer.StalePod{
+					{Name: "payments-api-abc123", Namespace: "payments", Kind: analyzer.StalePodZombie, Status: "CrashLoopBackOff", RestartCount: 50, AgeDays: 3},
+				},
+			},
+			secAudit: &models.SecurityAudit{
+				Issues: []models.SecurityIssue{
+					{Type: "privileged_container", Severity: "critical", Namespace: "checkout", Name: "checkout-api-xyz789", Resource: "pod"},
+				},
+			},
+			netAudit: &analyzer.NetworkPolicyAudit{
+				// Namespace-level issue — must NOT appear as a workload cell.
+				UnprotectedNamespaces: []analyzer.NamespaceNetworkStatus{
+					{Name: "payments", RiskLevel: "HIGH", PodCount: 3},
+				},
+			},
+		}
+
+		got := buildWorkloadHealthGrid(scan)
+		byName := map[string]string{}
+		for _, cell := range got {
+			byName[cell.Name] = cell.Severity
+		}
+
+		if len(got) != 3 {
+			t.Fatalf("expected 3 workload cells, got %d: %+v", len(got), got)
+		}
+		if sev := byName["payments-api"]; sev != "critical" {
+			t.Fatalf("payments-api severity = %q, want critical", sev)
+		}
+		if sev := byName["checkout-api"]; sev != "critical" {
+			t.Fatalf("checkout-api severity = %q, want critical", sev)
+		}
+		if sev, ok := byName["payments-worker"]; !ok || sev != "" {
+			t.Fatalf("payments-worker severity = %q (present=%v), want \"\" (healthy)", sev, ok)
+		}
+
+		// most-severe-first, alphabetical tiebreak; healthy entries last.
+		if got[0].Name != "checkout-api" || got[1].Name != "payments-api" || got[2].Name != "payments-worker" {
+			t.Fatalf("unexpected order: %+v", got)
+		}
+	})
+
+	t.Run("issue with no matching Deployments enumeration still surfaces", func(t *testing.T) {
+		scan := &clusterScan{
+			wasteAudit: &analyzer.WasteAudit{
+				StalePods: []analyzer.StalePod{
+					{Name: "orphan-svc-abc123", Namespace: "default", Kind: analyzer.StalePodZombie, Status: "CrashLoopBackOff", RestartCount: 8, AgeDays: 1},
+				},
+			},
+		}
+		got := buildWorkloadHealthGrid(scan)
+		if len(got) != 1 || got[0].Name != "orphan-svc" || got[0].Severity != "critical" {
+			t.Fatalf("expected single orphan-svc/critical cell, got %+v", got)
+		}
+	})
 }

--- a/cmd/opscart-dashboard/main_test.go
+++ b/cmd/opscart-dashboard/main_test.go
@@ -279,22 +279,10 @@ func TestBuildWorkloadHealthGrid(t *testing.T) {
 
 	t.Run("mixed healthy and unhealthy workloads", func(t *testing.T) {
 		scan := &clusterScan{
-			report: &models.CloudCostReport{
-				NamespaceCosts: []models.NamespaceCostInfo{
-					{
-						Name: "payments", PodCount: 3,
-						Deployments: []models.DeploymentCostInfo{
-							{Name: "payments-api", Kind: "Deployment", Namespace: "payments", Replicas: 2},
-							{Name: "payments-worker", Kind: "Deployment", Namespace: "payments", Replicas: 1},
-						},
-					},
-					{
-						Name: "checkout", PodCount: 1,
-						Deployments: []models.DeploymentCostInfo{
-							{Name: "checkout-api", Kind: "Deployment", Namespace: "checkout", Replicas: 1},
-						},
-					},
-				},
+			AllWorkloads: []models.WorkloadRef{
+				{Name: "payments-api", Kind: "Deployment", Namespace: "payments"},
+				{Name: "payments-worker", Kind: "Deployment", Namespace: "payments"},
+				{Name: "checkout-api", Kind: "Deployment", Namespace: "checkout"},
 			},
 			wasteAudit: &analyzer.WasteAudit{
 				StalePods: []analyzer.StalePod{
@@ -339,7 +327,7 @@ func TestBuildWorkloadHealthGrid(t *testing.T) {
 		}
 	})
 
-	t.Run("issue with no matching Deployments enumeration still surfaces", func(t *testing.T) {
+	t.Run("issue with no matching AllWorkloads entry still surfaces", func(t *testing.T) {
 		scan := &clusterScan{
 			wasteAudit: &analyzer.WasteAudit{
 				StalePods: []analyzer.StalePod{

--- a/cmd/opscart-dashboard/main_test.go
+++ b/cmd/opscart-dashboard/main_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -340,4 +341,139 @@ func TestBuildWorkloadHealthGrid(t *testing.T) {
 			t.Fatalf("expected single orphan-svc/critical cell, got %+v", got)
 		}
 	})
+}
+
+// fullyPopulatedOverviewData builds an overviewPageData with every optional
+// field populated (non-nil Scoreboard with both memory-line branches
+// non-empty, non-empty TopIssues/ChangesSinceLastView/RecentEvents/
+// NamespaceHealthList/WorkloadHealthGrid, every delta text set, every
+// WorkloadHealthGrid severity value including "" for healthy) so rendering
+// it exercises every {{if}}/{{range}} branch in overview.html — not just
+// the all-empty path a fresh scan takes.
+func fullyPopulatedOverviewData() overviewPageData {
+	return overviewPageData{
+		ClusterName:    "prod-eastus",
+		NamespaceCount: 4,
+		ScannedAtMS:    time.Now().UnixMilli(),
+		VerdictLine1:   "3 workloads need attention. payments-api has been crash-looping for 2 day(s) and its restart rate is accelerating.",
+		VerdictLine2:   "2 incidents resolved since yesterday.",
+
+		TopIssues: []topIssue{
+			{
+				Rank: 1, Title: "3 pods crash-looping", Subtitle: "payments-api, payments-worker, checkout-api",
+				Action: "kubectl logs payments-api -n payments", Severity: "critical", SeverityLbl: "CRITICAL",
+				CountText: "3 pods", URL: "/warroom",
+			},
+			{
+				Rank: 2, Title: "2 namespaces missing NetworkPolicy", Subtitle: "Including checkout, payments",
+				Severity: "high", SeverityLbl: "HIGH", CountText: "2 ns", URL: "/warroom",
+			},
+		},
+
+		CostDeltaText:          "+$45",
+		IncidentScoreDeltaText: "-10",
+		SecurityScoreDeltaText: "+5",
+
+		Scoreboard: &store.MemoryScoreboard{
+			TotalSeen: 42, Resolved: 30, Reopened: 4, Accelerating: 2,
+			LongestActiveDays: 12, LongestActiveName: "payments-api",
+			MostUnstableNamespace: "payments", MostUnstableCount: 9,
+		},
+		RecentEvents: []store.RecentEvent{
+			{Resource: "payments-api", EventReason: "RestartMilestone", OccurredAt: time.Now().Add(-5 * time.Minute)},
+			{Resource: "checkout-worker", EventReason: "Resolved", OccurredAt: time.Now().Add(-2 * time.Hour)},
+		},
+
+		ChangesSinceLastView: []store.RecentEvent{
+			{Resource: "payments-api", EventReason: "SeverityChanged", OccurredAt: time.Now().Add(-1 * time.Minute)},
+			{Resource: "checkout-api", EventReason: "Detected", OccurredAt: time.Now().Add(-10 * time.Minute)},
+			{Resource: "checkout-api", EventReason: "Reopened", OccurredAt: time.Now().Add(-20 * time.Minute)},
+		},
+		LastViewedLabel: "24h ago",
+
+		NamespaceHealthList: []namespaceHealth{
+			{Name: "payments", Ready: 2, Total: 4},
+			{Name: "checkout", Ready: 3, Total: 3},
+			{Name: "idle-ns", Ready: 0, Total: 0},
+		},
+		WorkloadHealthGrid: []workloadHealthCell{
+			{Name: "payments-api", Severity: "critical"},
+			{Name: "checkout-api", Severity: "high"},
+			{Name: "payments-worker", Severity: "medium"},
+			{Name: "checkout-worker", Severity: ""},
+		},
+
+		NodePoolCount: 3, PodCount: 48, CPUUtilization: 92, MemUtilization: 61,
+
+		IncidentScore: 62, IncidentScoreColor: "orange", IncidentScoreLabel: "Needs attention",
+		SecurityScore: 78, WasteCount: 6, MonthlyCost: 1234.56,
+
+		CostsHref: "/costs", WasteHref: "/waste", WrURL: "/warroom", IncidentsHref: "/incidents",
+
+		ActivePage: "dashboard",
+		Version:    "test",
+	}
+}
+
+// TestOverviewTemplate_RendersFullyPopulatedData drives getOverviewTmpl()
+// directly (not through buildOverviewData) with every optional field
+// populated, so every {{if}}/{{range}} branch in overview.html — not just
+// the empty-scan path other tests exercise — is proven to execute without
+// a "can't evaluate field" template error.
+func TestOverviewTemplate_RendersFullyPopulatedData(t *testing.T) {
+	data := fullyPopulatedOverviewData()
+
+	var buf strings.Builder
+	if err := getOverviewTmpl().Execute(&buf, data); err != nil {
+		t.Fatalf("template execution failed: %v", err)
+	}
+
+	out := buf.String()
+	wantSubstrings := []string{
+		"prod-eastus",
+		"If you only fix one thing today",
+		data.VerdictLine1,
+		data.VerdictLine2,
+		"payments-api",
+		"Longest active",
+		"Most unstable namespace",
+		"What's Changed Since Last Scan",
+		"Recent Events",
+		"checkout", /* namespace health row */
+		// html/template escapes "+" as a numeric entity even in text
+		// nodes; "-10" needs no such escaping.
+		"&#43;$45 from last scan",
+		"-10 from last scan",
+		"&#43;5 from last scan",
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered output missing %q", want)
+		}
+	}
+}
+
+// TestOverviewTemplate_RendersEmptyData exercises the opposite path: every
+// optional/slice field at its zero value (nil Scoreboard, no TopIssues, no
+// feed entries, no health lists), proving the template's empty-state
+// branches also execute cleanly rather than panicking on a nil pointer.
+func TestOverviewTemplate_RendersEmptyData(t *testing.T) {
+	data := overviewPageData{
+		ClusterName: "empty-cluster",
+		ScannedAtMS: time.Now().UnixMilli(),
+		ActivePage:  "dashboard",
+	}
+
+	var buf strings.Builder
+	if err := getOverviewTmpl().Execute(&buf, data); err != nil {
+		t.Fatalf("template execution failed on empty data: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "If you only fix one thing today") {
+		t.Errorf("expected fix-one-thing banner to be hidden when TopIssues is empty")
+	}
+	if !strings.Contains(out, "No operational memory yet") {
+		t.Errorf("expected Operational Memory empty state when Scoreboard is nil")
+	}
 }

--- a/cmd/opscart-dashboard/main_test.go
+++ b/cmd/opscart-dashboard/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -363,12 +364,24 @@ func fullyPopulatedOverviewData() overviewPageData {
 				Rank: 1, Title: "3 pods crash-looping", Subtitle: "payments-api, payments-worker, checkout-api",
 				Action: "kubectl logs payments-api -n payments", Severity: "critical", SeverityLbl: "CRITICAL",
 				CountText: "3 pods", URL: "/warroom",
+				Namespace: "payments", Resource: "payments-api-7d8f9c6b5-abc12", IssueType: "crash_loop",
+				FirstDetectedLabel: "2d ago", ReopenCountVal: 1, TrendVal: "accelerating",
+				MemoryLine: "First detected 2d ago · reopened once · accelerating",
 			},
 			{
 				Rank: 2, Title: "2 namespaces missing NetworkPolicy", Subtitle: "Including checkout, payments",
 				Severity: "high", SeverityLbl: "HIGH", CountText: "2 ns", URL: "/warroom",
+				Namespace: "checkout", Resource: "namespace", IssueType: "unprotected_namespace",
+				FirstDetectedLabel: "5d ago",
+				MemoryLine:         "First detected 5d ago",
 			},
 		},
+
+		HasTopIssue:    true,
+		TopIssueName:   "payments-api-7d8f9c6b5-abc12",
+		TopIssueNS:     "payments",
+		TopIssueTrend:  "accelerating",
+		TopIssueReopen: 1,
 
 		CostDeltaText:          "+$45",
 		IncidentScoreDeltaText: "-10",
@@ -408,7 +421,7 @@ func fullyPopulatedOverviewData() overviewPageData {
 		IncidentScore: 62, IncidentScoreColor: "orange", IncidentScoreLabel: "Needs attention",
 		SecurityScore: 78, WasteCount: 6, MonthlyCost: 1234.56,
 
-		CostsHref: "/costs", WasteHref: "/waste", WrURL: "/warroom", IncidentsHref: "/incidents",
+		CostsHref: "/costs", WasteHref: "/waste", WrURL: "/warroom", IncidentsHref: "/incidents", NSsURL: "/namespaces",
 
 		ActivePage: "dashboard",
 		Version:    "test",
@@ -445,6 +458,8 @@ func TestOverviewTemplate_RendersFullyPopulatedData(t *testing.T) {
 		"&#43;$45 from last scan",
 		"-10 from last scan",
 		"&#43;5 from last scan",
+		"First detected 2d ago · reopened once · accelerating", // MemoryLine
+		"payments", // TopIssueNS in the "Highest Priority" bf-item
 	}
 	for _, want := range wantSubstrings {
 		if !strings.Contains(out, want) {
@@ -580,5 +595,273 @@ func TestBuildOverviewVerdict_IdleNamespaceUsesNamespaceNotLiteralResource(t *te
 	}
 	if !strings.Contains(line1, "batch-jobs reoccurred") {
 		t.Fatalf("expected verdict to mention namespace %q, got: %q", "batch-jobs", line1)
+	}
+}
+
+func TestBuildMemoryLine(t *testing.T) {
+	tests := []struct {
+		name               string
+		firstDetectedLabel string
+		reopenCount        int
+		trend              string
+		issueType          string
+		want               string
+	}{
+		{
+			name: "no reopens, no trend", firstDetectedLabel: "3d ago", reopenCount: 0, trend: "stable", issueType: "crash_loop",
+			want: "First detected 3d ago",
+		},
+		{
+			name: "one reopen", firstDetectedLabel: "3d ago", reopenCount: 1, trend: "stable", issueType: "crash_loop",
+			want: "First detected 3d ago · reopened once",
+		},
+		{
+			name: "multiple reopens use ×N", firstDetectedLabel: "3d ago", reopenCount: 4, trend: "stable", issueType: "crash_loop",
+			want: "First detected 3d ago · reopened ×4",
+		},
+		{
+			name: "accelerating trend included for restart-based issue type", firstDetectedLabel: "3d ago", reopenCount: 0, trend: "accelerating", issueType: "crash_loop",
+			want: "First detected 3d ago · accelerating",
+		},
+		{
+			name: "non-accelerating trend never shown", firstDetectedLabel: "3d ago", reopenCount: 0, trend: "stable", issueType: "crash_loop",
+			want: "First detected 3d ago",
+		},
+		{
+			name: "accelerating omitted for privileged_container (posture-only)", firstDetectedLabel: "3d ago", reopenCount: 0, trend: "accelerating", issueType: "privileged_container",
+			want: "First detected 3d ago",
+		},
+		{
+			name: "accelerating omitted for unprotected_namespace (posture-only)", firstDetectedLabel: "3d ago", reopenCount: 0, trend: "accelerating", issueType: "unprotected_namespace",
+			want: "First detected 3d ago",
+		},
+		{
+			name: "accelerating omitted for idle_namespace (posture-only)", firstDetectedLabel: "3d ago", reopenCount: 0, trend: "accelerating", issueType: "idle_namespace",
+			want: "First detected 3d ago",
+		},
+		{
+			name: "reopen and trend both present, joined with middle dot", firstDetectedLabel: "7d ago", reopenCount: 1, trend: "accelerating", issueType: "crash_loop",
+			want: "First detected 7d ago · reopened once · accelerating",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildMemoryLine(tt.firstDetectedLabel, tt.reopenCount, tt.trend, tt.issueType)
+			if got != tt.want {
+				t.Errorf("buildMemoryLine(%q, %d, %q, %q) = %q, want %q", tt.firstDetectedLabel, tt.reopenCount, tt.trend, tt.issueType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTopIssueResourceLabel(t *testing.T) {
+	tests := []struct {
+		name, resource, namespace, issueType, want string
+	}{
+		{"crash_loop uses resource", "payments-api-abc123", "payments", "crash_loop", "payments-api-abc123"},
+		{"unprotected_namespace uses namespace", "namespace", "payments", "unprotected_namespace", "payments"},
+		{"idle_namespace uses namespace", "namespace", "batch-jobs", "idle_namespace", "batch-jobs"},
+		{"privileged_container uses resource", "web-abc123", "default", "privileged_container", "web-abc123"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := topIssueResourceLabel(tt.resource, tt.namespace, tt.issueType); got != tt.want {
+				t.Errorf("topIssueResourceLabel(%q, %q, %q) = %q, want %q", tt.resource, tt.namespace, tt.issueType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeriveTopIssueSummary(t *testing.T) {
+	t.Run("empty issues yields all zero values", func(t *testing.T) {
+		has, name, ns, trend, reopen := deriveTopIssueSummary(nil)
+		if has || name != "" || ns != "" || trend != "" || reopen != 0 {
+			t.Fatalf("expected all zero values for empty issues, got has=%v name=%q ns=%q trend=%q reopen=%d", has, name, ns, trend, reopen)
+		}
+	})
+
+	t.Run("mirrors TopIssues[0]", func(t *testing.T) {
+		issues := []topIssue{
+			{
+				Namespace: "payments", Resource: "payments-api-abc123", IssueType: "crash_loop",
+				TrendVal: "accelerating", ReopenCountVal: 2,
+			},
+			{Namespace: "checkout", Resource: "checkout-api-xyz789", IssueType: "oom_killed"},
+		}
+		has, name, ns, trend, reopen := deriveTopIssueSummary(issues)
+		if !has {
+			t.Fatalf("expected has=true")
+		}
+		if name != "payments-api-abc123" {
+			t.Errorf("name = %q, want %q", name, "payments-api-abc123")
+		}
+		if ns != "payments" {
+			t.Errorf("ns = %q, want %q", ns, "payments")
+		}
+		if trend != "accelerating" {
+			t.Errorf("trend = %q, want %q", trend, "accelerating")
+		}
+		if reopen != 2 {
+			t.Errorf("reopen = %d, want %d", reopen, 2)
+		}
+	})
+
+	t.Run("unprotected_namespace/idle_namespace use Namespace for name too", func(t *testing.T) {
+		issues := []topIssue{
+			{Namespace: "checkout", Resource: "namespace", IssueType: "unprotected_namespace"},
+		}
+		_, name, ns, _, _ := deriveTopIssueSummary(issues)
+		if name != "checkout" {
+			t.Errorf("name = %q, want %q (should use Namespace, not the literal placeholder %q)", name, "checkout", "namespace")
+		}
+		if ns != "checkout" {
+			t.Errorf("ns = %q, want %q", ns, "checkout")
+		}
+	})
+}
+
+func TestEnrichTopIssues(t *testing.T) {
+	stub := &queryIncidentsStubStore{
+		items: []store.IncidentSummary{
+			{
+				Namespace: "payments", Resource: "payments-api-abc123", IssueType: "crash_loop",
+				FirstSeen: time.Now().Add(-2 * 24 * time.Hour), ReopenCount: 1, Trend: "accelerating",
+			},
+		},
+		total: 1,
+	}
+
+	issues := []topIssue{
+		{Namespace: "payments", Resource: "payments-api-abc123", IssueType: "crash_loop"}, // matches
+		{Namespace: "", Resource: "", IssueType: ""},                                      // aggregate row, no matching key
+		{Namespace: "checkout", Resource: "checkout-api-xyz", IssueType: "oom_killed"},    // matching key, but no incident
+	}
+
+	got := enrichTopIssues(issues, stub, "test-cluster")
+
+	if got[0].MemoryLine == "" {
+		t.Fatalf("expected matched row to be enriched, got %+v", got[0])
+	}
+	if !strings.Contains(got[0].MemoryLine, "reopened once") || !strings.Contains(got[0].MemoryLine, "accelerating") {
+		t.Errorf("unexpected MemoryLine: %q", got[0].MemoryLine)
+	}
+	if got[0].ReopenCountVal != 1 || got[0].TrendVal != "accelerating" {
+		t.Errorf("unexpected enrichment fields: %+v", got[0])
+	}
+
+	if got[1].MemoryLine != "" {
+		t.Errorf("expected row with no matching key to stay unenriched, got %+v", got[1])
+	}
+	if got[2].MemoryLine != "" {
+		t.Errorf("expected row with a matching key but no incident to stay unenriched, got %+v", got[2])
+	}
+}
+
+func TestEnrichTopIssues_NilDBOrEmptyIssues(t *testing.T) {
+	issues := []topIssue{{Namespace: "payments", Resource: "payments-api", IssueType: "crash_loop"}}
+	if got := enrichTopIssues(issues, nil, "test-cluster"); len(got) != 1 || got[0].MemoryLine != "" {
+		t.Fatalf("expected passthrough with nil db, got %+v", got)
+	}
+	stub := &queryIncidentsStubStore{}
+	if got := enrichTopIssues(nil, stub, "test-cluster"); len(got) != 0 {
+		t.Fatalf("expected empty passthrough, got %+v", got)
+	}
+}
+
+// TestOverviewTemplate_BriefingClassByCriticalCount covers Fix 3: the
+// Situation Briefing card is danger-tinted ("briefing") when there's an
+// active critical issue, success-tinted ("briefing-ok") otherwise.
+func TestOverviewTemplate_BriefingClassByCriticalCount(t *testing.T) {
+	t.Run("critical issues present uses briefing (danger tint)", func(t *testing.T) {
+		data := fullyPopulatedOverviewData()
+		data.CriticalCount = 2
+
+		var buf strings.Builder
+		if err := getOverviewTmpl().Execute(&buf, data); err != nil {
+			t.Fatalf("template execution failed: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, `class="section-card briefing"`) {
+			t.Errorf("expected briefing class when CriticalCount>0")
+		}
+		if strings.Contains(out, `class="section-card briefing-ok"`) {
+			t.Errorf("did not expect briefing-ok class when CriticalCount>0")
+		}
+	})
+
+	t.Run("no critical issues uses briefing-ok (success tint)", func(t *testing.T) {
+		data := fullyPopulatedOverviewData()
+		data.CriticalCount = 0
+
+		var buf strings.Builder
+		if err := getOverviewTmpl().Execute(&buf, data); err != nil {
+			t.Fatalf("template execution failed: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, `class="section-card briefing-ok"`) {
+			t.Errorf("expected briefing-ok class when CriticalCount==0")
+		}
+		if strings.Contains(out, `class="section-card briefing"`) {
+			t.Errorf("did not expect plain briefing class when CriticalCount==0")
+		}
+	})
+}
+
+// TestOverviewTemplate_HealthCardsCapAndShowViewAll covers Fix 5: the
+// Namespace Health list and Cluster Health's Workload Health dot strip are
+// capped, with a "View all" link appearing once content exceeds the cap.
+func TestOverviewTemplate_HealthCardsCapAndShowViewAll(t *testing.T) {
+	data := fullyPopulatedOverviewData()
+
+	nsList := make([]namespaceHealth, 9)
+	for i := range nsList {
+		nsList[i] = namespaceHealth{Name: fmt.Sprintf("ns-%d", i), Ready: i, Total: i + 1}
+	}
+	data.NamespaceHealthList = nsList
+
+	whList := make([]workloadHealthCell, 45)
+	for i := range whList {
+		whList[i] = workloadHealthCell{Name: fmt.Sprintf("wl-%d", i)}
+	}
+	data.WorkloadHealthGrid = whList
+
+	var buf strings.Builder
+	if err := getOverviewTmpl().Execute(&buf, data); err != nil {
+		t.Fatalf("template execution failed: %v", err)
+	}
+	out := buf.String()
+
+	if got := strings.Count(out, `class="ns-health-row"`); got != 6 {
+		t.Errorf("expected 6 namespace health rows (capped from 9), got %d", got)
+	}
+	if !strings.Contains(out, "View all 9 namespaces") {
+		t.Errorf("expected a 'View all 9 namespaces' link")
+	}
+
+	if got := strings.Count(out, `class="wh-dot`); got != 40 {
+		t.Errorf("expected 40 workload health dots (capped from 45), got %d", got)
+	}
+	if !strings.Contains(out, "View all 45 workloads") {
+		t.Errorf("expected a 'View all 45 workloads' link")
+	}
+}
+
+// TestOverviewTemplate_HealthCardsNoViewAllUnderCap proves the "View all"
+// links only appear once content actually exceeds the cap — fullyPopulated
+// OverviewData's fixture has 3 namespaces and 4 workloads, both under it.
+func TestOverviewTemplate_HealthCardsNoViewAllUnderCap(t *testing.T) {
+	data := fullyPopulatedOverviewData()
+
+	var buf strings.Builder
+	if err := getOverviewTmpl().Execute(&buf, data); err != nil {
+		t.Fatalf("template execution failed: %v", err)
+	}
+	out := buf.String()
+
+	if strings.Contains(out, "View all 3 namespaces") {
+		t.Errorf("did not expect a namespaces View all link under the cap")
+	}
+	if strings.Contains(out, "View all 4 workloads") {
+		t.Errorf("did not expect a workloads View all link under the cap")
 	}
 }

--- a/cmd/opscart-dashboard/main_test.go
+++ b/cmd/opscart-dashboard/main_test.go
@@ -477,3 +477,108 @@ func TestOverviewTemplate_RendersEmptyData(t *testing.T) {
 		t.Errorf("expected Operational Memory empty state when Scoreboard is nil")
 	}
 }
+
+// TestOverviewTemplate_FeedsCapAtFive drives getOverviewTmpl with more than
+// five ChangesSinceLastView/RecentEvents rows and asserts the rendered
+// output shows exactly five rows per feed — the display cap the limitSlice
+// FuncMap helper enforces, independent of how many rows were fetched.
+func TestOverviewTemplate_FeedsCapAtFive(t *testing.T) {
+	data := fullyPopulatedOverviewData()
+
+	makeEvents := func(n int) []store.RecentEvent {
+		out := make([]store.RecentEvent, n)
+		for i := 0; i < n; i++ {
+			out[i] = store.RecentEvent{
+				Resource:    "svc-" + strconv.Itoa(i),
+				EventReason: "Detected",
+				OccurredAt:  time.Now().Add(-time.Duration(i) * time.Minute),
+			}
+		}
+		return out
+	}
+	data.ChangesSinceLastView = makeEvents(9)
+	data.RecentEvents = makeEvents(7)
+
+	var buf strings.Builder
+	if err := getOverviewTmpl().Execute(&buf, data); err != nil {
+		t.Fatalf("template execution failed: %v", err)
+	}
+
+	out := buf.String()
+	// `class="change-row"` (the literal HTML attribute) rather than just
+	// "change-row" — the latter also matches the CSS selector rules
+	// earlier in the same document and would inflate the count.
+	if got := strings.Count(out, `class="change-row"`); got != 10 {
+		t.Fatalf("expected 5 change-row entries per feed (10 total) regardless of 9/7 fetched, got %d", got)
+	}
+}
+
+// queryIncidentsStubStore returns a fixed QueryIncidents result, embedding
+// store.Store so only the one method buildOverviewVerdict actually calls
+// needs a real implementation.
+type queryIncidentsStubStore struct {
+	store.Store
+	items []store.IncidentSummary
+	total int
+}
+
+func (s *queryIncidentsStubStore) QueryIncidents(f store.IncidentFilter) ([]store.IncidentSummary, int, error) {
+	return s.items, s.total, nil
+}
+
+// TestBuildOverviewVerdict_UnprotectedNamespaceUsesNamespaceNotLiteralResource
+// covers the unprotected_namespace/idle_namespace case, where
+// IncidentSummary.Resource is literally the string "namespace" (there's no
+// pod/deployment involved) — the sentence must use Namespace instead, not
+// that placeholder.
+func TestBuildOverviewVerdict_UnprotectedNamespaceUsesNamespaceNotLiteralResource(t *testing.T) {
+	stub := &queryIncidentsStubStore{
+		items: []store.IncidentSummary{
+			{
+				Namespace: "payments-prod",
+				Resource:  "namespace",
+				IssueType: "unprotected_namespace",
+				Severity:  "high",
+				FirstSeen: time.Now().Add(-3 * 24 * time.Hour),
+			},
+		},
+		total: 1,
+	}
+
+	line1, _ := buildOverviewVerdict(stub, "test-cluster")
+
+	if strings.Contains(line1, "namespace has been") {
+		t.Fatalf("expected verdict to use the real namespace, not the literal placeholder %q: got %q", "namespace", line1)
+	}
+	if !strings.Contains(line1, "payments-prod has been") {
+		t.Fatalf("expected verdict to mention namespace %q, got: %q", "payments-prod", line1)
+	}
+}
+
+// TestBuildOverviewVerdict_IdleNamespaceUsesNamespaceNotLiteralResource
+// covers the same substitution for idle_namespace, and the ReopenCount
+// branch rather than the default one.
+func TestBuildOverviewVerdict_IdleNamespaceUsesNamespaceNotLiteralResource(t *testing.T) {
+	stub := &queryIncidentsStubStore{
+		items: []store.IncidentSummary{
+			{
+				Namespace:   "batch-jobs",
+				Resource:    "namespace",
+				IssueType:   "idle_namespace",
+				Severity:    "medium",
+				FirstSeen:   time.Now().Add(-5 * 24 * time.Hour),
+				ReopenCount: 2,
+			},
+		},
+		total: 1,
+	}
+
+	line1, _ := buildOverviewVerdict(stub, "test-cluster")
+
+	if strings.Contains(line1, "namespace reoccurred") {
+		t.Fatalf("expected verdict to use the real namespace, not the literal placeholder %q: got %q", "namespace", line1)
+	}
+	if !strings.Contains(line1, "batch-jobs reoccurred") {
+		t.Fatalf("expected verdict to mention namespace %q, got: %q", "batch-jobs", line1)
+	}
+}

--- a/cmd/opscart-dashboard/main_test.go
+++ b/cmd/opscart-dashboard/main_test.go
@@ -5,7 +5,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/opscart/opscart-k8s-watcher/pkg/store"
 )
@@ -83,6 +85,114 @@ func TestFormatIntDelta(t *testing.T) {
 				t.Errorf("formatIntDelta(%d, %d, %v) = %q, want %q", tt.current, tt.previous, tt.hasHistory, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestReadLastViewedCursor(t *testing.T) {
+	t.Run("missing cookie defaults to 24h ago", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		got := readLastViewedCursor(req)
+		want := time.Now().Add(-24 * time.Hour)
+		if diff := got.Sub(want); diff < -time.Minute || diff > time.Minute {
+			t.Fatalf("expected ~24h ago, got %v (want ~%v)", got, want)
+		}
+	})
+
+	t.Run("unparseable cookie defaults to 24h ago", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.AddCookie(&http.Cookie{Name: lastViewedCookieName, Value: "not-a-timestamp"})
+		got := readLastViewedCursor(req)
+		want := time.Now().Add(-24 * time.Hour)
+		if diff := got.Sub(want); diff < -time.Minute || diff > time.Minute {
+			t.Fatalf("expected ~24h ago, got %v (want ~%v)", got, want)
+		}
+	})
+
+	t.Run("valid cookie is parsed exactly", func(t *testing.T) {
+		want := time.Now().Add(-3 * time.Hour).Truncate(time.Second)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.AddCookie(&http.Cookie{Name: lastViewedCookieName, Value: strconv.FormatInt(want.Unix(), 10)})
+		got := readLastViewedCursor(req)
+		if !got.Equal(want) {
+			t.Fatalf("readLastViewedCursor = %v, want %v", got, want)
+		}
+	})
+}
+
+// sinceCapturingStore wraps a real Store and records the `since` argument
+// passed to GetChangesSince, so tests can verify the query used the cursor
+// from the incoming request rather than one already advanced to "now".
+type sinceCapturingStore struct {
+	store.Store
+	capturedSince time.Time
+}
+
+func (s *sinceCapturingStore) GetChangesSince(cluster string, since time.Time, limit int) ([]store.RecentEvent, error) {
+	s.capturedSince = since
+	return s.Store.GetChangesSince(cluster, since, limit)
+}
+
+// TestHandleOverviewPage_CursorSetAfterQuery drives the real handler
+// end-to-end (not just the query function in isolation) to verify that the
+// cursor cookie is refreshed to "now" only after it has been used to query
+// GetChangesSince — otherwise this request's own changes would never be
+// visible as "new" on the very next page load.
+func TestHandleOverviewPage_CursorSetAfterQuery(t *testing.T) {
+	sqlDB, err := store.OpenSQLite(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	defer sqlDB.Close()
+	wrapped := &sinceCapturingStore{Store: sqlDB}
+
+	srv := newServer([]string{"test-ctx"}, wrapped, 90, true)
+
+	// Seed a scan directly so the handler doesn't attempt a real cluster
+	// scan (unavailable in this test environment).
+	state := srv.getState("test-ctx")
+	state.mu.Lock()
+	state.scan = &clusterScan{}
+	state.mu.Unlock()
+
+	oldCursor := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+	req := httptest.NewRequest(http.MethodGet, "/?cluster=test-ctx", nil)
+	req.AddCookie(&http.Cookie{Name: lastViewedCookieName, Value: strconv.FormatInt(oldCursor.Unix(), 10)})
+	rec := httptest.NewRecorder()
+
+	srv.handleOverviewPage(rec, req)
+
+	resp := rec.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, rec.Body.String())
+	}
+
+	// The query must have used the cursor from the incoming cookie, proving
+	// it wasn't already overwritten before being read.
+	if !wrapped.capturedSince.Equal(oldCursor) {
+		t.Fatalf("GetChangesSince called with since=%v, want incoming cookie value %v", wrapped.capturedSince, oldCursor)
+	}
+
+	var newCookie *http.Cookie
+	for _, c := range resp.Cookies() {
+		if c.Name == lastViewedCookieName {
+			newCookie = c
+		}
+	}
+	if newCookie == nil {
+		t.Fatalf("expected Set-Cookie %s in response", lastViewedCookieName)
+	}
+	newSec, err := strconv.ParseInt(newCookie.Value, 10, 64)
+	if err != nil {
+		t.Fatalf("parse new cookie value %q: %v", newCookie.Value, err)
+	}
+	if newSec <= oldCursor.Unix() {
+		t.Fatalf("expected refreshed cookie newer than the cursor used for the query: new=%d old=%d", newSec, oldCursor.Unix())
+	}
+	if newCookie.Path != "/" {
+		t.Fatalf("expected cookie Path=/, got %q", newCookie.Path)
+	}
+	if newCookie.MaxAge != int(lastViewedMaxAge.Seconds()) {
+		t.Fatalf("expected MaxAge=%d, got %d", int(lastViewedMaxAge.Seconds()), newCookie.MaxAge)
 	}
 }
 

--- a/cmd/opscart-dashboard/main_test.go
+++ b/cmd/opscart-dashboard/main_test.go
@@ -64,3 +64,45 @@ func TestHandleHealth(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatIntDelta(t *testing.T) {
+	tests := []struct {
+		name              string
+		current, previous int
+		hasHistory        bool
+		want              string
+	}{
+		{name: "no history", current: 50, previous: 40, hasHistory: false, want: ""},
+		{name: "increase", current: 55, previous: 40, hasHistory: true, want: "+15"},
+		{name: "decrease", current: 30, previous: 40, hasHistory: true, want: "-10"},
+		{name: "unchanged", current: 40, previous: 40, hasHistory: true, want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatIntDelta(tt.current, tt.previous, tt.hasHistory); got != tt.want {
+				t.Errorf("formatIntDelta(%d, %d, %v) = %q, want %q", tt.current, tt.previous, tt.hasHistory, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatCostDelta(t *testing.T) {
+	tests := []struct {
+		name       string
+		delta      float64
+		hasHistory bool
+		want       string
+	}{
+		{name: "no history", delta: 45, hasHistory: false, want: ""},
+		{name: "increase", delta: 45, hasHistory: true, want: "+$45"},
+		{name: "decrease", delta: -12, hasHistory: true, want: "-$12"},
+		{name: "unchanged", delta: 0, hasHistory: true, want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatCostDelta(tt.delta, tt.hasHistory); got != tt.want {
+				t.Errorf("formatCostDelta(%v, %v) = %q, want %q", tt.delta, tt.hasHistory, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/opscart-dashboard/scan.go
+++ b/cmd/opscart-dashboard/scan.go
@@ -22,6 +22,12 @@ type clusterScan struct {
 	cisResult  *analyzer.CISResult
 	wasteAudit *analyzer.WasteAudit
 	netAudit   *analyzer.NetworkPolicyAudit
+
+	// AllWorkloads is every Deployment/StatefulSet/DaemonSet the scan
+	// observed, regardless of the --breakdown flag — retained from the pod
+	// enumeration ResourceAnalyzer.AnalyzeClusterResources already performs
+	// for cost allocation, not a second cluster fetch.
+	AllWorkloads []models.WorkloadRef
 }
 
 // ── Per-cluster state ─────────────────────────────────────────────────────────

--- a/cmd/opscart-dashboard/server.go
+++ b/cmd/opscart-dashboard/server.go
@@ -600,6 +600,10 @@ type overviewPageData struct {
 	ChangesSinceLastView []store.RecentEvent
 	LastViewedLabel      string
 
+	// Namespace Health + Workload Health grid
+	NamespaceHealthList []namespaceHealth
+	WorkloadHealthGrid  []workloadHealthCell
+
 	// War Room featured issue
 	FeaturedIssues []warRoomIssue
 	HasFeatured    bool
@@ -816,6 +820,9 @@ func buildOverviewData(scan *clusterScan, activeCtx string, clusterList []string
 
 		ChangesSinceLastView: changesSinceLastView,
 		LastViewedLabel:      lastViewedLabel,
+
+		NamespaceHealthList: buildNamespaceHealth(scan),
+		WorkloadHealthGrid:  buildWorkloadHealthGrid(scan),
 	}
 }
 
@@ -916,6 +923,142 @@ func humanizeIssueType(issueType string) string {
 	default:
 		return "failing"
 	}
+}
+
+// ── Namespace Health + Workload Health grid ────────────────────────────────
+
+// namespaceHealth is one row of the Namespace Health panel: how many pods
+// in a namespace are healthy vs. total.
+type namespaceHealth struct {
+	Name  string
+	Ready int
+	Total int
+}
+
+// workloadHealthCell is one cell of the Workload Health grid: a
+// Deployment/StatefulSet/DaemonSet colored by whether it currently has an
+// active incident (per collectWarRoomIssues) and at what severity.
+type workloadHealthCell struct {
+	Name     string
+	Severity string // "critical" | "high" | "medium" | "" (empty = healthy)
+}
+
+// workloadSeverityRank orders workloadHealthCell.Severity values from most
+// to least urgent; "" (healthy) always ranks last.
+var workloadSeverityRank = map[string]int{"critical": 3, "high": 2, "medium": 1}
+
+// buildNamespaceHealth groups pods by namespace using the same per-namespace
+// pod counts already computed for cost allocation (scan.report.NamespaceCosts
+// — populated on every scan, no new clientset call), and treats pods the
+// waste auditor already flagged as crash-looping/OOMKilled zombies
+// (scan.wasteAudit.StalePods) as not-ready. Sorted worst-health first,
+// matching the risk-first / pod-count-descending convention used for
+// NetworkPolicyAudit.UnprotectedNamespaces.
+func buildNamespaceHealth(scan *clusterScan) []namespaceHealth {
+	if scan == nil || scan.report == nil {
+		return nil
+	}
+
+	unhealthyByNS := map[string]int{}
+	if scan.wasteAudit != nil {
+		for _, pod := range scan.wasteAudit.StalePods {
+			if pod.Kind == analyzer.StalePodZombie {
+				unhealthyByNS[pod.Namespace]++
+			}
+		}
+	}
+
+	list := make([]namespaceHealth, 0, len(scan.report.NamespaceCosts))
+	for _, ns := range scan.report.NamespaceCosts {
+		total := ns.PodCount
+		unhealthy := unhealthyByNS[ns.Name]
+		if unhealthy > total {
+			unhealthy = total
+		}
+		list = append(list, namespaceHealth{Name: ns.Name, Ready: total - unhealthy, Total: total})
+	}
+
+	sort.SliceStable(list, func(i, j int) bool {
+		ri, rj := namespaceHealthRatio(list[i]), namespaceHealthRatio(list[j])
+		if ri != rj {
+			return ri < rj // worst health (lowest ready/total) first
+		}
+		return list[i].Total > list[j].Total
+	})
+	return list
+}
+
+// namespaceHealthRatio returns Ready/Total, treating an empty namespace
+// (Total == 0) as perfectly healthy so it sorts after any namespace with
+// at least one unhealthy pod.
+func namespaceHealthRatio(n namespaceHealth) float64 {
+	if n.Total == 0 {
+		return 1
+	}
+	return float64(n.Ready) / float64(n.Total)
+}
+
+// buildWorkloadHealthGrid maps every workload the scan currently knows
+// about to a severity, by reusing collectWarRoomIssues' output — never a
+// second incident query. Workload identity for a pod-level issue is
+// resolved with store.OwnerNameFromPod (pure string parsing, matching the
+// same owner-name convention used for incident fingerprints, not a new
+// clientset call). When the scan's deployment-level cost breakdown is
+// available (scan.report.NamespaceCosts[].Deployments) it's used to also
+// list healthy workloads with no active issue; otherwise the grid only
+// contains workloads an issue has actually implicated.
+func buildWorkloadHealthGrid(scan *clusterScan) []workloadHealthCell {
+	if scan == nil {
+		return nil
+	}
+
+	type workloadKey struct{ namespace, name string }
+	severityOf := map[workloadKey]string{}
+
+	for _, issue := range collectWarRoomIssues(scan, 0) {
+		if issue.Namespace == "" || issue.Resource == "" || issue.Resource == "namespace" {
+			continue // namespace-level issues (e.g. unprotected_namespace) aren't workloads
+		}
+		key := workloadKey{namespace: issue.Namespace, name: store.OwnerNameFromPod(issue.Resource)}
+		if existing, ok := severityOf[key]; !ok || workloadSeverityRank[issue.Severity] > workloadSeverityRank[existing] {
+			severityOf[key] = issue.Severity
+		}
+	}
+
+	seen := map[workloadKey]bool{}
+	var grid []workloadHealthCell
+
+	if scan.report != nil {
+		for _, ns := range scan.report.NamespaceCosts {
+			for _, d := range ns.Deployments {
+				key := workloadKey{namespace: d.Namespace, name: d.Name}
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				grid = append(grid, workloadHealthCell{Name: d.Name, Severity: severityOf[key]})
+			}
+		}
+	}
+
+	// Always include workloads implied by an active issue, even when the
+	// deployment-level breakdown above isn't available.
+	for key, sev := range severityOf {
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		grid = append(grid, workloadHealthCell{Name: key.name, Severity: sev})
+	}
+
+	sort.SliceStable(grid, func(i, j int) bool {
+		si, sj := workloadSeverityRank[grid[i].Severity], workloadSeverityRank[grid[j].Severity]
+		if si != sj {
+			return si > sj // most severe first
+		}
+		return grid[i].Name < grid[j].Name
+	})
+	return grid
 }
 
 func buildTopIssues(scan *clusterScan, wrIssues []warRoomIssue) []topIssue {

--- a/cmd/opscart-dashboard/server.go
+++ b/cmd/opscart-dashboard/server.go
@@ -500,17 +500,19 @@ var getSidebarTmpl = sync.OnceValue(func() *template.Template {
 // ── Overview page (executive summary) ─────────────────────────────────────────
 
 type overviewPageData struct {
-	ClusterName string
-	ActiveCtx   string
-	ClusterList []costClusterLink
-	DashURL     string
-	InfraURL    string
-	NSsURL      string
-	OptURL      string
-	WrURL       string
-	CostsURL    string
-	ScannedAtMS int64
-	CostsHref   string
+	ClusterName  string
+	ActiveCtx    string
+	ClusterList  []costClusterLink
+	DashURL      string
+	InfraURL     string
+	NSsURL       string
+	OptURL       string
+	WrURL        string
+	CostsURL     string
+	ScannedAtMS  int64
+	CostsHref    string
+	VerdictLine1 string
+	VerdictLine2 string
 
 	// Sidebar aliases (matches sidebar.html template)
 	DashHref      string
@@ -540,6 +542,16 @@ type overviewPageData struct {
 	// Top 5 Things to Fix
 	TopIssues []topIssue
 	Trend     *store.OverviewTrend
+
+	// Trend deltas formatted for template display: "+N"/"-N", or "" when
+	// there's no history or no change.
+	CostDeltaText          string
+	IncidentScoreDeltaText string
+	SecurityScoreDeltaText string
+
+	// Memory scoreboard + cluster-wide recent activity
+	Scoreboard   *store.MemoryScoreboard
+	RecentEvents []store.RecentEvent
 
 	// War Room featured issue
 	FeaturedIssues []warRoomIssue
@@ -657,10 +669,27 @@ func buildOverviewData(scan *clusterScan, activeCtx string, clusterList []string
 	_ = secFailed // reserved for future use
 
 	var trend *store.OverviewTrend
+	var scoreboard *store.MemoryScoreboard
+	var recentEvents []store.RecentEvent
+	var verdictLine1, verdictLine2 string
 	if db != nil {
 		if t, err := db.GetOverviewTrend(activeCtx); err == nil {
 			trend = t
 		}
+		if sb, err := db.GetMemoryScoreboard(activeCtx); err == nil {
+			scoreboard = sb
+		}
+		if events, err := db.GetRecentEvents(activeCtx, overviewRecentEventsLimit); err == nil {
+			recentEvents = events
+		}
+		verdictLine1, verdictLine2 = buildOverviewVerdict(db, activeCtx)
+	}
+
+	var costDeltaText, incidentScoreDeltaText, securityScoreDeltaText string
+	if trend != nil {
+		costDeltaText = formatCostDelta(trend.CostDelta, trend.HasHistory)
+		incidentScoreDeltaText = formatIntDelta(trend.IncidentScore.Current, trend.IncidentScore.Previous, trend.HasHistory)
+		securityScoreDeltaText = formatIntDelta(trend.SecurityScore.Current, trend.SecurityScore.Previous, trend.HasHistory)
 	}
 
 	q := ""
@@ -723,6 +752,114 @@ func buildOverviewData(scan *clusterScan, activeCtx string, clusterList []string
 		IncidentScoreColor: incidentScoreColor,
 		IncidentScoreLabel: incidentScoreLabel,
 		Trend:              trend,
+
+		CostDeltaText:          costDeltaText,
+		IncidentScoreDeltaText: incidentScoreDeltaText,
+		SecurityScoreDeltaText: securityScoreDeltaText,
+
+		Scoreboard:   scoreboard,
+		RecentEvents: recentEvents,
+		VerdictLine1: verdictLine1,
+		VerdictLine2: verdictLine2,
+	}
+}
+
+// overviewRecentEventsLimit caps the cluster-wide recent-activity feed shown
+// on the overview page.
+const overviewRecentEventsLimit = 15
+
+// formatIntDelta renders the change between two integer metric readings as
+// "+N"/"-N" for template display. Returns "" when there's no history to
+// compare against or the value hasn't changed, so the template never claims
+// a change that didn't happen.
+func formatIntDelta(current, previous int, hasHistory bool) string {
+	if !hasHistory || current == previous {
+		return ""
+	}
+	if current > previous {
+		return fmt.Sprintf("+%d", current-previous)
+	}
+	return fmt.Sprintf("-%d", previous-current)
+}
+
+// formatCostDelta renders a monthly-cost delta as "+$45"/"-$12" for template
+// display. Returns "" when there's no history to compare against or the
+// cost hasn't changed.
+func formatCostDelta(delta float64, hasHistory bool) string {
+	if !hasHistory || delta == 0 {
+		return ""
+	}
+	if delta > 0 {
+		return fmt.Sprintf("+$%.0f", delta)
+	}
+	return fmt.Sprintf("-$%.0f", -delta)
+}
+
+// buildOverviewVerdict produces the two-sentence cluster assessment shown
+// at the top of the Overview page. Priority: accelerating > reopened >
+// stable-but-critical > all-clear. line2 (resolved-since-yesterday) is
+// filled in separately once the memory scoreboard data is available.
+func buildOverviewVerdict(db store.Store, cluster string) (line1, line2 string) {
+	items, total, err := db.QueryIncidents(store.IncidentFilter{
+		Cluster:  cluster,
+		Status:   "active",
+		SortBy:   "severity",
+		SortDesc: true,
+		PerPage:  20,
+	})
+	if err != nil || len(items) == 0 {
+		return "No active incidents detected.", ""
+	}
+
+	worst := &items[0]
+	for i := range items {
+		if items[i].Trend == "accelerating" {
+			worst = &items[i]
+			break
+		}
+	}
+
+	ageDays := int(time.Since(worst.FirstSeen).Hours() / 24)
+	issueLabel := humanizeIssueType(worst.IssueType)
+	workloadWord := "workload needs"
+	if total > 1 {
+		workloadWord = "workloads need"
+	}
+
+	switch {
+	case worst.Trend == "accelerating":
+		line1 = fmt.Sprintf(
+			"%d %s attention. %s has been %s for %d day(s) and its restart rate is accelerating.",
+			total, workloadWord, worst.Resource, issueLabel, ageDays)
+	case worst.ReopenCount > 0:
+		line1 = fmt.Sprintf(
+			"%d %s attention. %s reoccurred after a recovery — reopened %d time(s).",
+			total, workloadWord, worst.Resource, worst.ReopenCount)
+	default:
+		line1 = fmt.Sprintf(
+			"%d %s attention. %s has been %s for %d day(s).",
+			total, workloadWord, worst.Resource, issueLabel, ageDays)
+	}
+
+	return line1, line2
+}
+
+func humanizeIssueType(issueType string) string {
+	switch issueType {
+	case "crash_loop":
+		return "crash-looping"
+	case "probe_failure":
+		return "failing its startup/liveness probe"
+	case "image_pull_backoff":
+		return "unable to pull its image"
+	case "oomkilled":
+		return "being OOM-killed"
+	case "privileged_container":
+		return "running privileged"
+	case "unprotected_namespace", "idle_namespace":
+		return "flagged"
+	default:
+		return "failing"
 	}
 }
 

--- a/cmd/opscart-dashboard/server.go
+++ b/cmd/opscart-dashboard/server.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -102,6 +103,41 @@ func (srv *server) activeCtx(r *http.Request) string {
 	return srv.clusterList[0]
 }
 
+// lastViewedCookieName holds the Unix-seconds timestamp of the last time
+// this browser loaded the Overview page, used as the cursor for the
+// "what's changed since last scan" feed.
+const lastViewedCookieName = "opscart_last_viewed"
+
+// lastViewedMaxAge is how long the cursor cookie persists — long enough to
+// survive a browser restart, since it's a "last visit" marker, not a
+// session token.
+const lastViewedMaxAge = 30 * 24 * time.Hour
+
+// readLastViewedCursor reads the lastViewedCookieName cookie and returns the
+// time it encodes. A missing or unparseable cookie (first-ever visit, or a
+// tampered/stale value) defaults to 24h ago so first-time visitors see a
+// day of history instead of nothing.
+func readLastViewedCursor(r *http.Request) time.Time {
+	c, err := r.Cookie(lastViewedCookieName)
+	if err != nil {
+		return time.Now().Add(-24 * time.Hour)
+	}
+	sec, err := strconv.ParseInt(c.Value, 10, 64)
+	if err != nil {
+		return time.Now().Add(-24 * time.Hour)
+	}
+	return time.Unix(sec, 0)
+}
+
+func setLastViewedCursor(w http.ResponseWriter, at time.Time) {
+	http.SetCookie(w, &http.Cookie{
+		Name:   lastViewedCookieName,
+		Value:  strconv.FormatInt(at.Unix(), 10),
+		Path:   "/",
+		MaxAge: int(lastViewedMaxAge.Seconds()),
+	})
+}
+
 func (srv *server) handleOverviewPage(w http.ResponseWriter, r *http.Request) {
 	ctx := srv.activeCtx(r)
 	state := srv.getState(ctx)
@@ -120,7 +156,8 @@ func (srv *server) handleOverviewPage(w http.ResponseWriter, r *http.Request) {
 		state.mu.RUnlock()
 	}
 
-	data := buildOverviewData(scan, ctx, srv.clusterList, srv.db)
+	since := readLastViewedCursor(r)
+	data := buildOverviewData(scan, ctx, srv.clusterList, srv.db, since)
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
@@ -131,6 +168,12 @@ func (srv *server) handleOverviewPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "template error", http.StatusInternalServerError)
 		return
 	}
+
+	// Set the cursor to now only after using the previous value to query
+	// changes above — otherwise this request's own changes would never be
+	// visible as "new".
+	setLastViewedCursor(w, time.Now())
+
 	w.Write([]byte(buf.String()))
 }
 
@@ -553,6 +596,10 @@ type overviewPageData struct {
 	Scoreboard   *store.MemoryScoreboard
 	RecentEvents []store.RecentEvent
 
+	// What's changed since this browser last loaded the Overview page
+	ChangesSinceLastView []store.RecentEvent
+	LastViewedLabel      string
+
 	// War Room featured issue
 	FeaturedIssues []warRoomIssue
 	HasFeatured    bool
@@ -598,7 +645,7 @@ func convertToSidebarClusters(clusterList []string, activeCtx, basePath string) 
 	return out
 }
 
-func buildOverviewData(scan *clusterScan, activeCtx string, clusterList []string, db store.Store) overviewPageData {
+func buildOverviewData(scan *clusterScan, activeCtx string, clusterList []string, db store.Store, since time.Time) overviewPageData {
 
 	clusterName := displayName(activeCtx)
 	var monthlyCost, savings float64
@@ -671,6 +718,7 @@ func buildOverviewData(scan *clusterScan, activeCtx string, clusterList []string
 	var trend *store.OverviewTrend
 	var scoreboard *store.MemoryScoreboard
 	var recentEvents []store.RecentEvent
+	var changesSinceLastView []store.RecentEvent
 	var verdictLine1, verdictLine2 string
 	if db != nil {
 		if t, err := db.GetOverviewTrend(activeCtx); err == nil {
@@ -682,8 +730,12 @@ func buildOverviewData(scan *clusterScan, activeCtx string, clusterList []string
 		if events, err := db.GetRecentEvents(activeCtx, overviewRecentEventsLimit); err == nil {
 			recentEvents = events
 		}
+		if changes, err := db.GetChangesSince(activeCtx, since, overviewRecentEventsLimit); err == nil {
+			changesSinceLastView = changes
+		}
 		verdictLine1, verdictLine2 = buildOverviewVerdict(db, activeCtx)
 	}
+	lastViewedLabel := humanAge(time.Since(since)) + " ago"
 
 	var costDeltaText, incidentScoreDeltaText, securityScoreDeltaText string
 	if trend != nil {
@@ -761,6 +813,9 @@ func buildOverviewData(scan *clusterScan, activeCtx string, clusterList []string
 		RecentEvents: recentEvents,
 		VerdictLine1: verdictLine1,
 		VerdictLine2: verdictLine2,
+
+		ChangesSinceLastView: changesSinceLastView,
+		LastViewedLabel:      lastViewedLabel,
 	}
 }
 

--- a/cmd/opscart-dashboard/server.go
+++ b/cmd/opscart-dashboard/server.go
@@ -888,19 +888,27 @@ func buildOverviewVerdict(db store.Store, cluster string) (line1, line2 string) 
 		workloadWord = "workloads need"
 	}
 
+	// unprotected_namespace/idle_namespace incidents store the literal
+	// string "namespace" as Resource (there's no pod/deployment involved);
+	// the incident's real identifying context is its Namespace.
+	resourceLabel := worst.Resource
+	if worst.IssueType == "unprotected_namespace" || worst.IssueType == "idle_namespace" {
+		resourceLabel = worst.Namespace
+	}
+
 	switch {
 	case worst.Trend == "accelerating":
 		line1 = fmt.Sprintf(
 			"%d %s attention. %s has been %s for %d day(s) and its restart rate is accelerating.",
-			total, workloadWord, worst.Resource, issueLabel, ageDays)
+			total, workloadWord, resourceLabel, issueLabel, ageDays)
 	case worst.ReopenCount > 0:
 		line1 = fmt.Sprintf(
 			"%d %s attention. %s reoccurred after a recovery — reopened %d time(s).",
-			total, workloadWord, worst.Resource, worst.ReopenCount)
+			total, workloadWord, resourceLabel, worst.ReopenCount)
 	default:
 		line1 = fmt.Sprintf(
 			"%d %s attention. %s has been %s for %d day(s).",
-			total, workloadWord, worst.Resource, issueLabel, ageDays)
+			total, workloadWord, resourceLabel, issueLabel, ageDays)
 	}
 
 	return line1, line2
@@ -1303,6 +1311,16 @@ var getOverviewTmpl = sync.OnceValue(func() *template.Template {
 					default:
 						return "danger"
 					}
+				},
+				// limitSlice caps a RecentEvent feed's DISPLAY length —
+				// GetRecentEvents/GetChangesSince already cap what's
+				// fetched (overviewRecentEventsLimit); this only trims how
+				// many of those rows the page renders.
+				"limitSlice": func(items []store.RecentEvent, n int) []store.RecentEvent {
+					if len(items) <= n {
+						return items
+					}
+					return items[:n]
 				},
 			}).
 			ParseFS(templateFS, "templates/base.html", "templates/sidebar.html", "templates/overview.html"),

--- a/cmd/opscart-dashboard/server.go
+++ b/cmd/opscart-dashboard/server.go
@@ -586,6 +586,14 @@ type overviewPageData struct {
 	TopIssues []topIssue
 	Trend     *store.OverviewTrend
 
+	// "If you only fix one thing today" banner + Situation Briefing
+	// "Highest Priority" fact — mirrors TopIssues[0] after enrichment.
+	HasTopIssue    bool
+	TopIssueName   string // resource name, or Namespace for unprotected_namespace/idle_namespace
+	TopIssueNS     string
+	TopIssueTrend  string
+	TopIssueReopen int
+
 	// Trend deltas formatted for template display: "+N"/"-N", or "" when
 	// there's no history or no change.
 	CostDeltaText          string
@@ -628,6 +636,22 @@ type topIssue struct {
 	SeverityLbl string // "CRITICAL" | "HIGH" | "MEDIUM" | "LOW"
 	CountText   string // "8 pods", "~$40/mo", "14 checks"
 	URL         string
+
+	// Matching key for cross-referencing this row against the incident
+	// registry (db.QueryIncidents) in enrichTopIssues. Empty for rows with
+	// no single corresponding incident — the aggregated orphaned-PVCs/
+	// security-score/zero-replica rows below aren't tied to one resource.
+	Namespace string
+	Resource  string
+	IssueType string
+
+	// Enriched from the incident registry by enrichTopIssues, matched via
+	// Namespace+Resource+IssueType above. Zero-valued when no match was
+	// found (including for rows with no matching key at all).
+	FirstDetectedLabel string
+	ReopenCountVal     int // named _Val to read distinctly from store.IncidentSummary.ReopenCount
+	TrendVal           string
+	MemoryLine         string // "First detected 7d ago · reopened once · accelerating"
 }
 
 func convertToSidebarClusters(clusterList []string, activeCtx, basePath string) []sidebarCluster {
@@ -741,6 +765,10 @@ func buildOverviewData(scan *clusterScan, activeCtx string, clusterList []string
 	}
 	lastViewedLabel := humanAge(time.Since(since)) + " ago"
 
+	topIssues := buildTopIssues(scan, wrIssues)
+	topIssues = enrichTopIssues(topIssues, db, activeCtx)
+	hasTopIssue, topIssueName, topIssueNS, topIssueTrend, topIssueReopen := deriveTopIssueSummary(topIssues)
+
 	var costDeltaText, incidentScoreDeltaText, securityScoreDeltaText string
 	if trend != nil {
 		costDeltaText = formatCostDelta(trend.CostDelta, trend.HasHistory)
@@ -784,7 +812,12 @@ func buildOverviewData(scan *clusterScan, activeCtx string, clusterList []string
 		SecurityScore:      securityScore,
 		WasteCount:         wasteCount,
 		MonthlyCost:        monthlyCost,
-		TopIssues:          buildTopIssues(scan, wrIssues),
+		TopIssues:          topIssues,
+		HasTopIssue:        hasTopIssue,
+		TopIssueName:       topIssueName,
+		TopIssueNS:         topIssueNS,
+		TopIssueTrend:      topIssueTrend,
+		TopIssueReopen:     topIssueReopen,
 		FeaturedIssues:     featuredIssues,
 		HasFeatured:        len(featuredIssues) > 0,
 		NodePoolCount:      nodePoolCount,
@@ -1106,6 +1139,9 @@ func buildTopIssues(scan *clusterScan, wrIssues []warRoomIssue) []topIssue {
 
 		title, subtitle, countText, action := formatGroupedIssue(k.issueTyp, k.severity, grp)
 
+		// grp preserves collectWarRoomIssues' severity/restart-sorted
+		// order, so grp[0] is this group's highest-priority representative
+		// — the natural incident to cross-reference in enrichTopIssues.
 		issues = append(issues, topIssue{
 			Title:       title,
 			Subtitle:    subtitle,
@@ -1114,6 +1150,9 @@ func buildTopIssues(scan *clusterScan, wrIssues []warRoomIssue) []topIssue {
 			SeverityLbl: sevLbl,
 			CountText:   countText,
 			URL:         "/warroom",
+			Namespace:   grp[0].Namespace,
+			Resource:    grp[0].Resource,
+			IssueType:   k.issueTyp,
 		})
 		_ = count
 	}
@@ -1254,6 +1293,98 @@ func pluralS(n int) string {
 	return "s"
 }
 
+// postureOnlyIssueTypes are issue types with no restart-based trajectory —
+// static findings rather than something that "accelerates" — so
+// buildMemoryLine omits the trend clause for them.
+var postureOnlyIssueTypes = map[string]bool{
+	"privileged_container":  true,
+	"unprotected_namespace": true,
+	"idle_namespace":        true,
+}
+
+// enrichTopIssues cross-references each topIssue's matching key
+// (Namespace+Resource+IssueType, set in buildTopIssues) against the active
+// incident registry, filling in FirstDetectedLabel/ReopenCountVal/TrendVal/
+// MemoryLine for rows with a match. Rows with no matching key (the
+// aggregated orphaned-PVCs/security-score/zero-replica rows) or no
+// corresponding active incident are left at their zero values.
+func enrichTopIssues(issues []topIssue, db store.Store, cluster string) []topIssue {
+	if db == nil || len(issues) == 0 {
+		return issues
+	}
+	items, _, err := db.QueryIncidents(store.IncidentFilter{
+		Cluster: cluster,
+		Status:  "active",
+		PerPage: 200,
+	})
+	if err != nil || len(items) == 0 {
+		return issues
+	}
+
+	type matchKey struct{ namespace, resource, issueType string }
+	byKey := make(map[matchKey]store.IncidentSummary, len(items))
+	for _, it := range items {
+		byKey[matchKey{it.Namespace, it.Resource, it.IssueType}] = it
+	}
+
+	for i := range issues {
+		if issues[i].Namespace == "" || issues[i].Resource == "" || issues[i].IssueType == "" {
+			continue
+		}
+		match, ok := byKey[matchKey{issues[i].Namespace, issues[i].Resource, issues[i].IssueType}]
+		if !ok {
+			continue
+		}
+		issues[i].FirstDetectedLabel = humanAge(time.Since(match.FirstSeen)) + " ago"
+		issues[i].ReopenCountVal = match.ReopenCount
+		issues[i].TrendVal = match.Trend
+		issues[i].MemoryLine = buildMemoryLine(issues[i].FirstDetectedLabel, match.ReopenCount, match.Trend, issues[i].IssueType)
+	}
+	return issues
+}
+
+// buildMemoryLine composes the small muted "First detected 7d ago ·
+// reopened once · accelerating" line shown below a Top 5 row's subtitle.
+// The trend clause is omitted for postureOnlyIssueTypes, where a
+// restart-based trend doesn't apply.
+func buildMemoryLine(firstDetectedLabel string, reopenCount int, trend string, issueType string) string {
+	parts := []string{"First detected " + firstDetectedLabel}
+	switch {
+	case reopenCount == 1:
+		parts = append(parts, "reopened once")
+	case reopenCount > 1:
+		parts = append(parts, fmt.Sprintf("reopened ×%d", reopenCount))
+	}
+	if trend == "accelerating" && !postureOnlyIssueTypes[issueType] {
+		parts = append(parts, "accelerating")
+	}
+	return strings.Join(parts, " · ")
+}
+
+// topIssueResourceLabel mirrors buildOverviewVerdict's resourceLabel
+// substitution: unprotected_namespace/idle_namespace incidents store the
+// literal string "namespace" as Resource, so the real identifying context
+// is the incident's Namespace instead.
+func topIssueResourceLabel(resource, namespace, issueType string) string {
+	if issueType == "unprotected_namespace" || issueType == "idle_namespace" {
+		return namespace
+	}
+	return resource
+}
+
+// deriveTopIssueSummary promotes TopIssues[0] (after enrichTopIssues) into
+// the overviewPageData fields the "if you only fix one thing today" banner
+// and the Situation Briefing's "Highest Priority" fact use — same data,
+// rendered a second time, not a separate computation. Returns the zero
+// value for every field when issues is empty.
+func deriveTopIssueSummary(issues []topIssue) (has bool, name, namespace, trend string, reopenCount int) {
+	if len(issues) == 0 {
+		return false, "", "", "", 0
+	}
+	top := issues[0]
+	return true, topIssueResourceLabel(top.Resource, top.Namespace, top.IssueType), top.Namespace, top.TrendVal, top.ReopenCountVal
+}
+
 type costClusterLink struct {
 	Ctx      string
 	Label    string
@@ -1317,6 +1448,25 @@ var getOverviewTmpl = sync.OnceValue(func() *template.Template {
 				// fetched (overviewRecentEventsLimit); this only trims how
 				// many of those rows the page renders.
 				"limitSlice": func(items []store.RecentEvent, n int) []store.RecentEvent {
+					if len(items) <= n {
+						return items
+					}
+					return items[:n]
+				},
+				// limitNamespaceHealth/limitWorkloadHealth cap the two
+				// list-based cards in the Cluster/Namespace Health row the
+				// same way limitSlice caps the feed cards above. Go's
+				// text/template FuncMap dispatches by exact reflected
+				// argument type, so limitSlice's []store.RecentEvent
+				// signature can't be reused for these — same pattern,
+				// separate typed helpers.
+				"limitNamespaceHealth": func(items []namespaceHealth, n int) []namespaceHealth {
+					if len(items) <= n {
+						return items
+					}
+					return items[:n]
+				},
+				"limitWorkloadHealth": func(items []workloadHealthCell, n int) []workloadHealthCell {
 					if len(items) <= n {
 						return items
 					}

--- a/cmd/opscart-dashboard/server.go
+++ b/cmd/opscart-dashboard/server.go
@@ -1003,10 +1003,11 @@ func namespaceHealthRatio(n namespaceHealth) float64 {
 // second incident query. Workload identity for a pod-level issue is
 // resolved with store.OwnerNameFromPod (pure string parsing, matching the
 // same owner-name convention used for incident fingerprints, not a new
-// clientset call). When the scan's deployment-level cost breakdown is
-// available (scan.report.NamespaceCosts[].Deployments) it's used to also
-// list healthy workloads with no active issue; otherwise the grid only
-// contains workloads an issue has actually implicated.
+// clientset call). The workload universe itself comes from scan.AllWorkloads
+// — every Deployment/StatefulSet/DaemonSet the scan observed while
+// enumerating pods for cost allocation, retained regardless of the
+// --breakdown flag — so healthy workloads with no active issue are always
+// represented, not just the ones an issue happens to name.
 func buildWorkloadHealthGrid(scan *clusterScan) []workloadHealthCell {
 	if scan == nil {
 		return nil
@@ -1028,21 +1029,18 @@ func buildWorkloadHealthGrid(scan *clusterScan) []workloadHealthCell {
 	seen := map[workloadKey]bool{}
 	var grid []workloadHealthCell
 
-	if scan.report != nil {
-		for _, ns := range scan.report.NamespaceCosts {
-			for _, d := range ns.Deployments {
-				key := workloadKey{namespace: d.Namespace, name: d.Name}
-				if seen[key] {
-					continue
-				}
-				seen[key] = true
-				grid = append(grid, workloadHealthCell{Name: d.Name, Severity: severityOf[key]})
-			}
+	for _, w := range scan.AllWorkloads {
+		key := workloadKey{namespace: w.Namespace, name: w.Name}
+		if seen[key] {
+			continue
 		}
+		seen[key] = true
+		grid = append(grid, workloadHealthCell{Name: w.Name, Severity: severityOf[key]})
 	}
 
-	// Always include workloads implied by an active issue, even when the
-	// deployment-level breakdown above isn't available.
+	// Always include workloads implied by an active issue, even when
+	// AllWorkloads didn't independently observe them (e.g. a test fixture
+	// or a partial scan).
 	for key, sev := range severityOf {
 		if seen[key] {
 			continue
@@ -1368,6 +1366,9 @@ func runFullScan(ctx string) (*clusterScan, error) {
 	if err != nil {
 		return nil, fmt.Errorf("resource analysis: %w", err)
 	}
+	// Retained regardless of --breakdown — this is the same pod enumeration
+	// already fetched above, not a second cluster call.
+	scan.AllWorkloads = resourceAnalysis.Workloads
 
 	nsCosts := npCostAnalyzer.AllocateNamespaceCosts(
 		poolCosts, resourceAnalysis.Namespaces,

--- a/cmd/opscart-dashboard/server.go
+++ b/cmd/opscart-dashboard/server.go
@@ -602,10 +602,10 @@ type overviewPageData struct {
 
 	// Memory scoreboard + cluster-wide recent activity
 	Scoreboard   *store.MemoryScoreboard
-	RecentEvents []store.RecentEvent
+	RecentEvents []changeLine
 
 	// What's changed since this browser last loaded the Overview page
-	ChangesSinceLastView []store.RecentEvent
+	ChangesSinceLastView []changeLine
 	LastViewedLabel      string
 
 	// Namespace Health + Workload Health grid
@@ -636,6 +636,8 @@ type topIssue struct {
 	SeverityLbl string // "CRITICAL" | "HIGH" | "MEDIUM" | "LOW"
 	CountText   string // "8 pods", "~$40/mo", "14 checks"
 	URL         string
+	ButtonLabel string // "Fix now →" | "View all N →" | "View →" (aggregated rows)
+	GroupSize   int    // number of underlying pods/incidents this row represents; 0 for aggregated rows
 
 	// Matching key for cross-referencing this row against the incident
 	// registry (db.QueryIncidents) in enrichTopIssues. Empty for rows with
@@ -743,11 +745,12 @@ func buildOverviewData(scan *clusterScan, activeCtx string, clusterList []string
 	incidentScore, incidentScoreColor, incidentScoreLabel := calcIncidentScore(scan)
 	_ = secFailed // reserved for future use
 
+	topIssues := buildTopIssues(scan, wrIssues, activeCtx)
+
 	var trend *store.OverviewTrend
 	var scoreboard *store.MemoryScoreboard
-	var recentEvents []store.RecentEvent
-	var changesSinceLastView []store.RecentEvent
-	var verdictLine1, verdictLine2 string
+	var recentEvents []changeLine
+	var changesSinceLastView []changeLine
 	if db != nil {
 		if t, err := db.GetOverviewTrend(activeCtx); err == nil {
 			trend = t
@@ -755,18 +758,22 @@ func buildOverviewData(scan *clusterScan, activeCtx string, clusterList []string
 		if sb, err := db.GetMemoryScoreboard(activeCtx); err == nil {
 			scoreboard = sb
 		}
-		if events, err := db.GetRecentEvents(activeCtx, overviewRecentEventsLimit); err == nil {
-			recentEvents = events
+		if events, err := db.GetRecentEvents(activeCtx, time.Now().Add(-recentEventsWindow), recentEventsLimit); err == nil {
+			recentEvents = formatChangeLines(events)
 		}
 		if changes, err := db.GetChangesSince(activeCtx, since, overviewRecentEventsLimit); err == nil {
-			changesSinceLastView = changes
+			changesSinceLastView = formatChangeLines(changes)
 		}
-		verdictLine1, verdictLine2 = buildOverviewVerdict(db, activeCtx)
+		topIssues = enrichTopIssues(topIssues, db, activeCtx)
 	}
+	// Same topIssues slice Top 5 and the fix-one-thing banner render — one
+	// source of truth for "the worst issue" (see buildOverviewVerdict).
+	// resolvedSinceCursor reuses changesSinceLastView (already fetched via
+	// GetChangesSince above) rather than issuing a second query.
+	resolvedSinceCursor := countResolvedSince(changesSinceLastView)
+	verdictLine1, verdictLine2 := buildOverviewVerdict(topIssues, resolvedSinceCursor, since)
 	lastViewedLabel := humanAge(time.Since(since)) + " ago"
 
-	topIssues := buildTopIssues(scan, wrIssues, activeCtx)
-	topIssues = enrichTopIssues(topIssues, db, activeCtx)
 	hasTopIssue, topIssueName, topIssueNS, topIssueTrend, topIssueReopen := deriveTopIssueSummary(topIssues)
 
 	var costDeltaText, incidentScoreDeltaText, securityScoreDeltaText string
@@ -859,9 +866,18 @@ func buildOverviewData(scan *clusterScan, activeCtx string, clusterList []string
 	}
 }
 
-// overviewRecentEventsLimit caps the cluster-wide recent-activity feed shown
-// on the overview page.
+// overviewRecentEventsLimit caps the cursor-scoped "what's changed since
+// last visit" feed (GetChangesSince).
 const overviewRecentEventsLimit = 15
+
+// recentEventsWindow/recentEventsLimit govern the cluster-wide Recent
+// Events feed (GetRecentEvents) — a fixed 7-day lookback independent of
+// the opscart_last_viewed cursor, so it reliably shows more/older activity
+// than the cursor-scoped ChangesSinceLastView even on a quiet day. Capped
+// higher than overviewRecentEventsLimit since a real week of activity
+// needs more rows to feel substantive than a single visit's worth of change.
+const recentEventsWindow = 7 * 24 * time.Hour
+const recentEventsLimit = 20
 
 // formatIntDelta renders the change between two integer metric readings as
 // "+N"/"-N" for template display. Returns "" when there's no history to
@@ -890,58 +906,96 @@ func formatCostDelta(delta float64, hasHistory bool) string {
 	return fmt.Sprintf("-$%.0f", -delta)
 }
 
-// buildOverviewVerdict produces the two-sentence cluster assessment shown
-// at the top of the Overview page. Priority: accelerating > reopened >
-// stable-but-critical > all-clear. line2 (resolved-since-yesterday) is
-// filled in separately once the memory scoreboard data is available.
-func buildOverviewVerdict(db store.Store, cluster string) (line1, line2 string) {
-	items, total, err := db.QueryIncidents(store.IncidentFilter{
-		Cluster:  cluster,
-		Status:   "active",
-		SortBy:   "severity",
-		SortDesc: true,
-		PerPage:  20,
-	})
-	if err != nil || len(items) == 0 {
-		return "No active incidents detected.", ""
-	}
-
-	worst := &items[0]
-	for i := range items {
-		if items[i].Trend == "accelerating" {
-			worst = &items[i]
-			break
+// countResolvedSince counts changesSinceLastView entries representing a
+// Resolved event, for the verdict's "N incidents resolved ..." clause.
+// Reuses the changeLine slice buildOverviewData already fetched via
+// GetChangesSince — never a second query.
+func countResolvedSince(changes []changeLine) int {
+	count := 0
+	for _, c := range changes {
+		if c.EventReason == "Resolved" {
+			count++
 		}
 	}
+	return count
+}
 
-	ageDays := int(time.Since(worst.FirstSeen).Hours() / 24)
-	issueLabel := humanizeIssueType(worst.IssueType)
+// sinceCursorPhrase anchors the verdict's resolved-since clause to how old
+// the visitor's opscart_last_viewed cursor actually is. "since yesterday"
+// only reads honestly when the cursor is roughly a day old — the default
+// for a first-time visitor (readLastViewedCursor: now-24h) and for anyone
+// who checks back about once a day. A cursor meaningfully more recent
+// (checking every few minutes) or older (checking every few weeks) uses
+// the always-accurate "since your last visit" instead.
+func sinceCursorPhrase(elapsed time.Duration) string {
+	if elapsed >= 18*time.Hour && elapsed <= 36*time.Hour {
+		return "since yesterday"
+	}
+	return "since your last visit"
+}
+
+// buildOverviewVerdict produces the two-sentence cluster assessment shown
+// at the top of the Overview page. line1's priority: accelerating >
+// reopened > stable-but-critical > all-clear, built from topIssues[0] —
+// the SAME row the "if you only fix one thing today" banner and the Top 5
+// list's first entry already show, so there's exactly one source of truth
+// for "the worst issue" (previously this ran its own independent
+// db.QueryIncidents call and could disagree with what Top 5 displayed).
+// line2 is the resolved-since-cursor clause, or "" if nothing resolved.
+func buildOverviewVerdict(topIssues []topIssue, resolvedSinceCursor int, cursorSince time.Time) (line1, line2 string) {
+	if resolvedSinceCursor > 0 {
+		line2 = fmt.Sprintf("%d incident%s resolved %s.",
+			resolvedSinceCursor, pluralS(resolvedSinceCursor), sinceCursorPhrase(time.Since(cursorSince)))
+	}
+
+	if len(topIssues) == 0 {
+		return "No active incidents detected.", line2
+	}
+
+	worst := topIssues[0]
+
+	// Aggregated rows (orphaned PVCs, security score, zero-replica
+	// workloads) have no single Namespace/Resource/IssueType to build a
+	// resource/trend sentence from — fall back to the row's own title,
+	// which is always meaningful on its own.
+	if worst.Namespace == "" || worst.Resource == "" || worst.IssueType == "" {
+		return fmt.Sprintf("Cluster needs attention: %s.", worst.Title), line2
+	}
+
+	total := worst.GroupSize
+	if total < 1 {
+		total = 1
+	}
 	workloadWord := "workload needs"
 	if total > 1 {
 		workloadWord = "workloads need"
 	}
 
+	issueLabel := humanizeIssueType(worst.IssueType)
+
 	// unprotected_namespace/idle_namespace incidents store the literal
 	// string "namespace" as Resource (there's no pod/deployment involved);
 	// the incident's real identifying context is its Namespace.
-	resourceLabel := worst.Resource
-	if worst.IssueType == "unprotected_namespace" || worst.IssueType == "idle_namespace" {
-		resourceLabel = worst.Namespace
+	resourceLabel := topIssueResourceLabel(worst.Resource, worst.Namespace, worst.IssueType)
+
+	firstDetected := worst.FirstDetectedLabel
+	if firstDetected == "" {
+		firstDetected = "recently"
 	}
 
 	switch {
-	case worst.Trend == "accelerating":
+	case worst.TrendVal == "accelerating":
 		line1 = fmt.Sprintf(
-			"%d %s attention. %s has been %s for %d day(s) and its restart rate is accelerating.",
-			total, workloadWord, resourceLabel, issueLabel, ageDays)
-	case worst.ReopenCount > 0:
+			"%d %s attention. %s has been %s, first detected %s, and its restart rate is accelerating.",
+			total, workloadWord, resourceLabel, issueLabel, firstDetected)
+	case worst.ReopenCountVal > 0:
 		line1 = fmt.Sprintf(
 			"%d %s attention. %s reoccurred after a recovery — reopened %d time(s).",
-			total, workloadWord, resourceLabel, worst.ReopenCount)
+			total, workloadWord, resourceLabel, worst.ReopenCountVal)
 	default:
 		line1 = fmt.Sprintf(
-			"%d %s attention. %s has been %s for %d day(s).",
-			total, workloadWord, resourceLabel, issueLabel, ageDays)
+			"%d %s attention. %s has been %s, first detected %s.",
+			total, workloadWord, resourceLabel, issueLabel, firstDetected)
 	}
 
 	return line1, line2
@@ -964,6 +1018,58 @@ func humanizeIssueType(issueType string) string {
 	default:
 		return "failing"
 	}
+}
+
+// changeLine is one formatted row of the What's Changed Since Last Scan /
+// Recent Events feeds: a short human phrase plus the EventReason driving
+// its colored dot (reusing the exact Detected/Resolved/Reopened/
+// RestartMilestone/SeverityChanged categories and casing the CSS already
+// defines for .change-dot — see overview.html).
+type changeLine struct {
+	Phrase      string
+	EventReason string
+	OccurredAt  time.Time
+}
+
+// formatChangeLine turns a raw store.RecentEvent — which carries only
+// Resource/EventReason/OccurredAt, nothing else — into a short readable
+// phrase. Some illustrative designs for this feed show extra detail (a
+// restart-rate percentage, an incident's total active duration, a trend
+// judgment); none of that is available on RecentEvent without an extra
+// per-event query, which would be an N+1 pattern this function
+// deliberately avoids — so those clauses are omitted rather than
+// fabricated.
+func formatChangeLine(e store.RecentEvent) changeLine {
+	var phrase string
+	switch e.EventReason {
+	case "Detected":
+		phrase = fmt.Sprintf("New: %s", e.Resource)
+	case "Resolved":
+		phrase = fmt.Sprintf("%s recovered", e.Resource)
+	case "Reopened":
+		phrase = fmt.Sprintf("%s reopened", e.Resource)
+	case "RestartMilestone":
+		// Not "...restart rate accelerating" — RecentEvent carries no
+		// restart count or trend, so there's nothing to justify a trend
+		// judgment. "Milestone reached" is the honest description of what
+		// this event actually records (see insertIncidentEvent's
+		// RestartMilestone case in pkg/store/sqlite.go).
+		phrase = fmt.Sprintf("%s restart milestone reached", e.Resource)
+	case "SeverityChanged":
+		phrase = fmt.Sprintf("%s severity changed", e.Resource)
+	default:
+		phrase = e.Resource
+	}
+	return changeLine{Phrase: phrase, EventReason: e.EventReason, OccurredAt: e.OccurredAt}
+}
+
+// formatChangeLines maps formatChangeLine over a whole feed.
+func formatChangeLines(events []store.RecentEvent) []changeLine {
+	out := make([]changeLine, len(events))
+	for i, e := range events {
+		out[i] = formatChangeLine(e)
+	}
+	return out
 }
 
 // ── Namespace Health + Workload Health grid ────────────────────────────────
@@ -1156,8 +1262,19 @@ func buildTopIssues(scan *clusterScan, wrIssues []warRoomIssue, activeCtx string
 
 		// grp preserves collectWarRoomIssues' severity/restart-sorted
 		// order, so grp[0] is this group's highest-priority representative
-		// — the natural incident to cross-reference in enrichTopIssues, and
-		// the row this deep-link points at.
+		// — the natural incident to cross-reference in enrichTopIssues. A
+		// group of exactly one pod deep-links straight to that pod's
+		// Investigation page; a group of several pods deep-links to the
+		// Incidents registry filtered to this issue type instead of
+		// arbitrarily picking grp[0]'s pod as "the" incident.
+		issueURL := investigateURL(grp[0].Namespace, grp[0].Resource, k.issueTyp, activeCtx)
+		buttonLabel := "Fix now →"
+		if count > 1 {
+			issueURL = fmt.Sprintf("/incidents?cluster=%s&type=%s&status=active",
+				url.QueryEscape(activeCtx), url.QueryEscape(k.issueTyp))
+			buttonLabel = fmt.Sprintf("View all %d →", count)
+		}
+
 		issues = append(issues, topIssue{
 			Title:       title,
 			Subtitle:    subtitle,
@@ -1165,12 +1282,13 @@ func buildTopIssues(scan *clusterScan, wrIssues []warRoomIssue, activeCtx string
 			Severity:    k.severity,
 			SeverityLbl: sevLbl,
 			CountText:   countText,
-			URL:         investigateURL(grp[0].Namespace, grp[0].Resource, k.issueTyp, activeCtx),
+			URL:         issueURL,
+			ButtonLabel: buttonLabel,
+			GroupSize:   count,
 			Namespace:   grp[0].Namespace,
 			Resource:    grp[0].Resource,
 			IssueType:   k.issueTyp,
 		})
-		_ = count
 	}
 
 	// Waste: orphaned PVCs (single aggregated row)
@@ -1190,6 +1308,7 @@ func buildTopIssues(scan *clusterScan, wrIssues []warRoomIssue, activeCtx string
 				SeverityLbl: "MEDIUM",
 				CountText:   cost,
 				URL:         "/optimizations",
+				ButtonLabel: "View →",
 			})
 		}
 	}
@@ -1203,6 +1322,7 @@ func buildTopIssues(scan *clusterScan, wrIssues []warRoomIssue, activeCtx string
 			SeverityLbl: "MEDIUM",
 			CountText:   fmt.Sprintf("%d/%d failed", scan.cisResult.FailedChecks, scan.cisResult.TotalChecks),
 			URL:         "/warroom",
+			ButtonLabel: "View →",
 		})
 	}
 
@@ -1216,6 +1336,7 @@ func buildTopIssues(scan *clusterScan, wrIssues []warRoomIssue, activeCtx string
 			SeverityLbl: "LOW",
 			CountText:   fmt.Sprintf("%d workload%s", count, pluralS(count)),
 			URL:         "/optimizations",
+			ButtonLabel: "View →",
 		})
 	}
 
@@ -1459,11 +1580,11 @@ var getOverviewTmpl = sync.OnceValue(func() *template.Template {
 						return "danger"
 					}
 				},
-				// limitSlice caps a RecentEvent feed's DISPLAY length —
+				// limitSlice caps a changeLine feed's DISPLAY length —
 				// GetRecentEvents/GetChangesSince already cap what's
 				// fetched (overviewRecentEventsLimit); this only trims how
 				// many of those rows the page renders.
-				"limitSlice": func(items []store.RecentEvent, n int) []store.RecentEvent {
+				"limitSlice": func(items []changeLine, n int) []changeLine {
 					if len(items) <= n {
 						return items
 					}

--- a/cmd/opscart-dashboard/server.go
+++ b/cmd/opscart-dashboard/server.go
@@ -1267,6 +1267,43 @@ var getOverviewTmpl = sync.OnceValue(func() *template.Template {
 					}
 					return 3 + (score * 28 / 100)
 				},
+				// eventAge renders a RecentEvent/ChangesSinceLastView
+				// timestamp the same way incidents.html's firstDetected/
+				// lastSeen render IncidentSummary timestamps.
+				"eventAge": func(t time.Time) string {
+					if t.IsZero() {
+						return "—"
+					}
+					d := time.Since(t)
+					switch {
+					case d < time.Minute:
+						return "just now"
+					case d < time.Hour:
+						return fmt.Sprintf("%dm ago", int(d.Minutes()))
+					case d < 24*time.Hour:
+						return fmt.Sprintf("%dh ago", int(d.Hours()))
+					case d < 48*time.Hour:
+						return "yesterday"
+					default:
+						return fmt.Sprintf("%d days ago", int(d.Hours()/24))
+					}
+				},
+				// healthColor classifies a namespaceHealth ready/total pair
+				// into "ok"/"warn"/"danger" for badge coloring.
+				"healthColor": func(ready, total int) string {
+					if total == 0 {
+						return "ok"
+					}
+					ratio := float64(ready) / float64(total)
+					switch {
+					case ratio >= 1:
+						return "ok"
+					case ratio >= 0.5:
+						return "warn"
+					default:
+						return "danger"
+					}
+				},
 			}).
 			ParseFS(templateFS, "templates/base.html", "templates/sidebar.html", "templates/overview.html"),
 	)

--- a/cmd/opscart-dashboard/server.go
+++ b/cmd/opscart-dashboard/server.go
@@ -765,7 +765,7 @@ func buildOverviewData(scan *clusterScan, activeCtx string, clusterList []string
 	}
 	lastViewedLabel := humanAge(time.Since(since)) + " ago"
 
-	topIssues := buildTopIssues(scan, wrIssues)
+	topIssues := buildTopIssues(scan, wrIssues, activeCtx)
 	topIssues = enrichTopIssues(topIssues, db, activeCtx)
 	hasTopIssue, topIssueName, topIssueNS, topIssueTrend, topIssueReopen := deriveTopIssueSummary(topIssues)
 
@@ -1100,7 +1100,22 @@ func buildWorkloadHealthGrid(scan *clusterScan) []workloadHealthCell {
 	return grid
 }
 
-func buildTopIssues(scan *clusterScan, wrIssues []warRoomIssue) []topIssue {
+// investigateURL builds a deep link to the Investigation page for a single
+// incident, matching the exact query params handleInvestigationPage reads
+// (pod, ns, type, cluster, from). Falls back to "/warroom" when namespace/
+// resource/issueType aren't all known — the aggregated rows built later in
+// buildTopIssues (orphaned PVCs, security score, zero-replica workloads)
+// have no single corresponding incident to deep-link to.
+func investigateURL(namespace, resource, issueType, activeCtx string) string {
+	if namespace == "" || resource == "" || issueType == "" {
+		return "/warroom"
+	}
+	return fmt.Sprintf("/investigate?pod=%s&ns=%s&type=%s&cluster=%s&from=warroom",
+		url.QueryEscape(resource), url.QueryEscape(namespace),
+		url.QueryEscape(issueType), url.QueryEscape(activeCtx))
+}
+
+func buildTopIssues(scan *clusterScan, wrIssues []warRoomIssue, activeCtx string) []topIssue {
 	var issues []topIssue
 
 	// Group war room issues by Severity + Type
@@ -1141,7 +1156,8 @@ func buildTopIssues(scan *clusterScan, wrIssues []warRoomIssue) []topIssue {
 
 		// grp preserves collectWarRoomIssues' severity/restart-sorted
 		// order, so grp[0] is this group's highest-priority representative
-		// — the natural incident to cross-reference in enrichTopIssues.
+		// — the natural incident to cross-reference in enrichTopIssues, and
+		// the row this deep-link points at.
 		issues = append(issues, topIssue{
 			Title:       title,
 			Subtitle:    subtitle,
@@ -1149,7 +1165,7 @@ func buildTopIssues(scan *clusterScan, wrIssues []warRoomIssue) []topIssue {
 			Severity:    k.severity,
 			SeverityLbl: sevLbl,
 			CountText:   countText,
-			URL:         "/warroom",
+			URL:         investigateURL(grp[0].Namespace, grp[0].Resource, k.issueTyp, activeCtx),
 			Namespace:   grp[0].Namespace,
 			Resource:    grp[0].Resource,
 			IssueType:   k.issueTyp,

--- a/cmd/opscart-dashboard/templates/overview.html
+++ b/cmd/opscart-dashboard/templates/overview.html
@@ -7,115 +7,112 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 {{template "base" .}}
 <style>
-.overview-grid{display:grid;grid-template-columns:2fr 1fr;gap:1.5rem;align-items:start}
-@media(max-width:1280px){.overview-grid{grid-template-columns:1fr}}
+/* ── Page header ── */
+.ov-hdr{display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:1.5rem;flex-wrap:wrap;gap:1rem}
+.ov-hdr h1{font-size:1.75rem;font-weight:800}
+.ov-hdr-sub{color:var(--text-muted);font-size:0.85rem;margin-top:0.25rem}
+.ov-badges{display:flex;gap:0.5rem;margin-top:0.75rem;flex-wrap:wrap}
+.badge-ok{background:rgba(16,185,129,0.12);color:#34d399;border:1px solid rgba(16,185,129,0.2)}
+.badge-warn{background:rgba(245,158,11,0.12);color:#fbbf24;border:1px solid rgba(245,158,11,0.2)}
+.badge-danger{background:rgba(239,68,68,0.12);color:#f87171;border:1px solid rgba(239,68,68,0.2)}
 
-.page-meta-bar{display:flex;justify-content:space-between;align-items:center;margin-bottom:2rem;flex-wrap:wrap;gap:1rem}
-.cluster-selector{display:flex;align-items:center;gap:0.75rem;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);padding:0.5rem 1rem;font-size:0.85rem}
-.cluster-selector strong{color:var(--text)}
-.refresh-badge{display:flex;align-items:center;gap:0.5rem;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);padding:0.5rem 1rem;font-size:0.8rem;color:var(--text-muted)}
-.refresh-badge::before{content:'';width:6px;height:6px;border-radius:50%;background:var(--success);box-shadow:0 0 8px var(--success)}
+/* ── Fix-one-thing banner ── */
+.fix-one-banner{display:flex;align-items:center;gap:1rem;background:linear-gradient(180deg,rgba(239,68,68,0.06) 0%,var(--surface) 100%);border:1px solid rgba(239,68,68,0.3);border-radius:var(--radius);padding:1.1rem 1.4rem;margin-bottom:1.5rem;animation:fadeIn 0.3s ease both}
+.fix-one-icon{font-size:1.5rem;flex-shrink:0}
+.fix-one-body{flex:1;min-width:0}
+.fix-one-lbl{font-size:0.68rem;text-transform:uppercase;letter-spacing:0.6px;color:#f87171;font-weight:700;margin-bottom:0.25rem}
+.fix-one-title{font-size:1.02rem;font-weight:700;margin-bottom:0.2rem}
+.fix-one-sub{font-size:0.8rem;color:var(--text-muted)}
+.fix-one-btn{background:var(--danger);color:#fff;font-size:0.82rem;font-weight:600;padding:0.55rem 1.1rem;border-radius:6px;text-decoration:none;white-space:nowrap;transition:background .15s}
+.fix-one-btn:hover{background:#dc2626}
 
-.kpi-row{display:grid;grid-template-columns:repeat(5,1fr);gap:1rem;margin-bottom:1.5rem}
-@media(max-width:1100px){.kpi-row{grid-template-columns:repeat(2,1fr)}}
-.kpi-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:1.25rem;animation:fadeIn 0.3s ease both}
-.kpi-card.critical{border-color:rgba(239,68,68,0.35)}
-.kpi-icon{width:32px;height:32px;border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:1rem;margin-bottom:0.75rem}
-.kpi-icon.red{background:rgba(239,68,68,0.15);color:var(--danger)}
-.kpi-icon.green{background:rgba(16,185,129,0.15);color:var(--success)}
-.kpi-icon.purple{background:rgba(139,92,246,0.15);color:#a78bfa}
-.kpi-icon.orange{background:rgba(245,158,11,0.15);color:var(--warning)}
-.kpi-icon.gold{background:rgba(234,179,8,0.15);color:#facc15}
-.kpi-label{font-size:0.7rem;text-transform:uppercase;letter-spacing:0.5px;color:var(--text-muted);margin-bottom:0.4rem;display:flex;align-items:center;gap:0.4rem}
-.kpi-value{font-size:1.85rem;font-weight:800;line-height:1;margin-bottom:0.5rem;font-variant-numeric:tabular-nums}
-.kpi-value.red{color:var(--danger)}
-.kpi-value.green{color:var(--success)}
-.kpi-value.orange{color:var(--warning)}
-.kpi-value.yellow{color:#eab308}
-.kpi-sub.red{color:var(--danger)}
-.kpi-sub.orange{color:var(--warning)}
-.kpi-sub.yellow{color:#eab308}
-.kpi-sub.green{color:var(--success)}
-.kpi-card-score{border-width:2px}
-.kpi-sub{font-size:0.7rem;color:var(--text-muted);min-height:1rem}
-.kpi-sub.red{color:var(--danger)}
-.kpi-trend{font-size:0.72rem;font-weight:600;margin-top:0.35rem;display:flex;align-items:center;gap:0.3rem}
-.kpi-trend.up-good{color:#4ade80}
-.kpi-trend.up-bad{color:#f87171}
-.kpi-trend.down-good{color:#4ade80}
-.kpi-trend.down-bad{color:#f87171}
-.kpi-trend.flat{color:#94a3b8}
-.trend-arrow{font-size:0.8rem;font-weight:700}
-.sparkline{display:flex;align-items:flex-end;gap:2px;height:36px;margin-top:0.5rem}
-.spark-bar{width:7px;border-radius:2px 2px 0 0;background:var(--primary-light);opacity:0.6;min-height:4px;transition:opacity .2s}
-.spark-bar:last-child{opacity:1}
-.spark-bar.spark-low{background:var(--danger)}
-.spark-bar.spark-mid{background:var(--warning)}
-.spark-bar.spark-high{background:var(--success)}
-
+/* ── Section card (shared) ── */
 .section-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:1.5rem;margin-bottom:1.5rem;animation:fadeIn 0.3s ease both}
-.section-hdr{margin-bottom:1.25rem}
 .section-title{font-size:1.05rem;font-weight:700;margin-bottom:0.25rem}
-.section-sub{font-size:0.78rem;color:var(--text-muted)}
-
-.top-issue{display:grid;grid-template-columns:36px 1fr auto auto auto;gap:1rem;align-items:center;padding:1rem;background:rgba(0,0,0,0.2);border:1px solid var(--border);border-radius:var(--radius-sm);margin-bottom:0.65rem;transition:border-color 0.15s}
-.top-issue:hover{border-color:rgba(99,102,241,0.4)}
-.top-issue-rank{width:32px;height:32px;border-radius:50%;background:rgba(99,102,241,0.15);color:var(--primary-light);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:0.9rem}
-.top-issue-title{font-weight:600;font-size:0.92rem;margin-bottom:0.2rem}
-.top-issue-sub{font-size:0.75rem;color:var(--text-muted);line-height:1.4}
-.top-issue-action{font-size:0.72rem;color:var(--primary-light);margin-top:0.3rem;font-family:'Consolas','Monaco',monospace}
+.section-sub{font-size:0.78rem;color:var(--text-muted);margin-bottom:1rem}
+.empty-state-small{padding:2rem 1rem;text-align:center;color:var(--text-muted);font-size:0.85rem}
+.empty-state-small .icon{font-size:1.8rem;margin-bottom:0.5rem;display:block}
+.view-all-link{display:inline-flex;align-items:center;gap:0.4rem;color:var(--primary-light);font-size:0.85rem;margin-top:0.5rem;text-decoration:none}
+.view-all-link:hover{text-decoration:underline}
 .sev-badge{padding:3px 9px;border-radius:12px;font-size:0.66rem;font-weight:700;letter-spacing:0.5px;white-space:nowrap}
 .sev-badge.critical{background:rgba(239,68,68,0.18);color:#f87171}
 .sev-badge.high{background:rgba(245,158,11,0.18);color:#fbbf24}
 .sev-badge.medium{background:rgba(234,179,8,0.18);color:#facc15}
 .sev-badge.low{background:rgba(100,116,139,0.18);color:#94a3b8}
-.top-issue-count{font-size:0.75rem;color:var(--text-muted);white-space:nowrap}
-.top-issue-btn{background:transparent;border:1px solid var(--border);color:var(--text-secondary);font-size:0.78rem;padding:0.4rem 0.9rem;border-radius:6px;cursor:pointer;text-decoration:none;display:inline-flex;align-items:center;gap:0.3rem;transition:all 0.15s}
+
+/* ── Row 1: Situation Briefing (62%) + Operational Memory (38%) ── */
+.ov-row-briefing{display:grid;grid-template-columns:1.6fr 1fr;gap:1.5rem;align-items:stretch}
+@media(max-width:1100px){.ov-row-briefing{grid-template-columns:1fr}}
+.briefing-text{font-size:0.92rem;line-height:1.6;color:var(--text-secondary);margin-bottom:0.75rem}
+.briefing-text:last-child{margin-bottom:0}
+.mem-grid{display:grid;grid-template-columns:1fr 1fr;gap:0.75rem;margin-bottom:1rem}
+.mem-cell{background:rgba(0,0,0,0.2);border:1px solid var(--border);border-radius:var(--radius-sm);padding:0.85rem;text-align:center}
+.mem-num{font-size:1.5rem;font-weight:800;line-height:1;margin-bottom:0.25rem;font-variant-numeric:tabular-nums}
+.mem-lbl{font-size:0.66rem;text-transform:uppercase;letter-spacing:0.5px;color:var(--text-muted)}
+.mem-line{font-size:0.8rem;color:var(--text-secondary);padding-top:0.6rem;border-top:1px solid var(--border);margin-top:0.2rem}
+.mem-line strong{color:var(--text)}
+.mem-line+.mem-line{border-top:none;padding-top:0.3rem;margin-top:0}
+
+/* ── Row 2: Top 5 (65%) + Changes/Recent stacked (35%) ── */
+.ov-row-top5{display:grid;grid-template-columns:1.85fr 1fr;gap:1.5rem;align-items:start}
+@media(max-width:1100px){.ov-row-top5{grid-template-columns:1fr}}
+.top-issue{display:grid;grid-template-columns:36px 1fr auto auto;gap:1rem;align-items:center;padding:1rem;background:rgba(0,0,0,0.2);border:1px solid var(--border);border-radius:var(--radius-sm);margin-bottom:0.65rem;transition:border-color 0.15s}
+.top-issue:hover{border-color:rgba(99,102,241,0.4)}
+.top-issue-rank{width:32px;height:32px;border-radius:50%;background:rgba(99,102,241,0.15);color:var(--primary-light);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:0.9rem}
+.top-issue-title{font-weight:600;font-size:0.92rem;margin-bottom:0.2rem}
+.top-issue-sub{font-size:0.75rem;color:var(--text-muted);line-height:1.4}
+.top-issue-action{font-size:0.72rem;color:var(--primary-light);margin-top:0.3rem;font-family:'Consolas','Monaco',monospace}
+.top-issue-btn{background:transparent;border:1px solid var(--border);color:var(--text-secondary);font-size:0.78rem;padding:0.4rem 0.9rem;border-radius:6px;cursor:pointer;text-decoration:none;display:inline-flex;align-items:center;gap:0.3rem;transition:all 0.15s;white-space:nowrap}
 .top-issue-btn:hover{background:var(--surface-hover);border-color:var(--primary);color:var(--text)}
-.view-all-link{display:inline-flex;align-items:center;gap:0.4rem;color:var(--primary-light);font-size:0.85rem;margin-top:0.75rem;text-decoration:none}
-.view-all-link:hover{text-decoration:underline}
 
-.empty-state-small{padding:2rem 1rem;text-align:center;color:var(--text-muted);font-size:0.85rem}
-.empty-state-small .icon{font-size:1.8rem;margin-bottom:0.5rem;display:block}
+.feed-card .section-card{margin-bottom:1.5rem}
+.feed-card:last-child .section-card{margin-bottom:0}
+.change-row{display:flex;align-items:center;gap:0.6rem;padding:0.6rem 0;border-bottom:1px solid rgba(51,65,85,0.5);font-size:0.8rem}
+.change-row:last-child{border-bottom:none}
+.change-reason{font-size:0.64rem;font-weight:700;text-transform:uppercase;letter-spacing:0.4px;padding:2px 7px;border-radius:10px;white-space:nowrap;flex-shrink:0}
+.change-reason.Detected{background:rgba(245,158,11,0.15);color:#fbbf24}
+.change-reason.Resolved{background:rgba(16,185,129,0.15);color:#4ade80}
+.change-reason.Reopened{background:rgba(239,68,68,0.15);color:#f87171}
+.change-reason.RestartMilestone{background:rgba(239,68,68,0.12);color:#f87171}
+.change-reason.SeverityChanged{background:rgba(99,102,241,0.15);color:var(--primary-light)}
+.change-resource{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--text-secondary)}
+.change-age{color:var(--text-muted);font-size:0.72rem;white-space:nowrap;flex-shrink:0}
 
-/* War Room featured panel */
-.wr-featured-hdr{display:flex;justify-content:space-between;align-items:center;margin-bottom:0.5rem}
-.wr-featured-title{font-size:1.05rem;font-weight:700;display:flex;align-items:center;gap:0.5rem}
-.wr-featured-count{background:rgba(239,68,68,0.18);color:#f87171;padding:3px 10px;border-radius:20px;font-size:0.7rem;font-weight:700}
-.wr-featured-sub{font-size:0.78rem;color:var(--text-muted);margin-bottom:1.25rem}
-.wr-issue-card{background:rgba(0,0,0,0.25);border:1px solid rgba(239,68,68,0.25);border-radius:var(--radius-sm);padding:1rem;margin-bottom:1rem}
-.wr-featured .wr-issue-card:first-of-type{border-color:rgba(239,68,68,0.5);box-shadow:0 0 24px rgba(239,68,68,0.08)}
-.wr-featured{background:var(--surface);border:1px solid rgba(239,68,68,0.35);border-radius:var(--radius);padding:1.5rem;margin-bottom:1.5rem;background:linear-gradient(180deg,rgba(239,68,68,0.03) 0%,var(--surface) 100%)}
-.wr-cards-body{max-height:520px;overflow-y:auto;margin:0 -1.5rem -1.5rem -1.5rem;padding:0 1.5rem 1.5rem 1.5rem}
-.wr-issue-top{display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:0.75rem}
-.wr-issue-name{font-size:0.95rem;font-weight:700;margin-bottom:0.3rem}
-.wr-issue-ns{font-size:0.75rem;color:var(--text-muted)}
-.wr-issue-section{margin-top:0.85rem;padding-top:0.85rem;border-top:1px solid rgba(255,255,255,0.05)}
-.wr-issue-label{font-size:0.7rem;text-transform:uppercase;letter-spacing:0.5px;color:var(--text-muted);margin-bottom:0.3rem}
-.wr-issue-text{font-size:0.83rem;line-height:1.5;color:var(--text-secondary)}
-.wr-issue-card{transition:border-color .2s,transform .2s}
-.wr-issue-card:hover{border-color:rgba(239,68,68,0.5);transform:translateX(3px)}
-.wr-issue-card:first-of-type{border-color:rgba(239,68,68,0.5);box-shadow:0 0 20px rgba(239,68,68,0.08)}
-.wr-quick-fix code{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1;min-width:0}
-.wr-quick-fix{background:rgba(0,0,0,0.4);border:1px solid var(--border);border-radius:6px;padding:0.55rem 0.75rem;margin-top:0.4rem;display:flex;align-items:center;gap:0.5rem;font-family:'Consolas','Monaco',monospace;font-size:0.72rem;color:var(--primary-light)}
-.wr-copy-btn{background:transparent;border:1px solid var(--border);color:var(--text-muted);font-size:0.65rem;padding:2px 8px;border-radius:4px;cursor:pointer;white-space:nowrap}
-.wr-copy-btn:hover{background:var(--surface-hover);color:var(--text)}
-.wr-view-details{display:inline-flex;align-items:center;gap:0.4rem;background:var(--danger);color:white;font-size:0.78rem;padding:0.5rem 1.25rem;border-radius:6px;text-decoration:none;font-weight:600;margin-top:0.75rem;transition:background .15s}
-.wr-view-details:hover{background:#dc2626}
-/* Cluster summary */
-.summary-grid{display:grid;grid-template-columns:repeat(5,1fr);gap:1rem}
-@media(max-width:900px){.summary-grid{grid-template-columns:repeat(2,1fr)}}
-.summary-card{background:rgba(0,0,0,0.15);border:1px solid var(--border);border-radius:var(--radius-sm);padding:1.1rem;text-align:left}
-.summary-icon{width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;font-size:0.85rem;background:rgba(99,102,241,0.12);color:var(--primary-light);margin-bottom:0.6rem}
-.summary-num{font-size:1.5rem;font-weight:800;line-height:1;margin-bottom:0.25rem;font-variant-numeric:tabular-nums}
-.summary-lbl{font-size:0.7rem;text-transform:uppercase;letter-spacing:0.5px;color:var(--text-muted);margin-bottom:0.25rem}
-.summary-sub{font-size:0.7rem;color:var(--text-muted)}
+/* ── Row 3: Cluster Health / Namespace Health / Security Status ── */
+.ov-3col{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem}
+@media(max-width:1100px){.ov-3col{grid-template-columns:1fr}}
+.ch-grid{display:grid;grid-template-columns:1fr 1fr;gap:0.75rem;margin-bottom:1rem}
+.ch-cell{background:rgba(0,0,0,0.15);border:1px solid var(--border);border-radius:var(--radius-sm);padding:0.85rem;text-align:center}
+.ch-num{font-size:1.3rem;font-weight:800;line-height:1;margin-bottom:0.2rem;font-variant-numeric:tabular-nums}
+.ch-lbl{font-size:0.64rem;text-transform:uppercase;letter-spacing:0.5px;color:var(--text-muted)}
+.ch-summary{font-size:0.78rem;padding:0.6rem 0.75rem;border-radius:var(--radius-sm);border:1px solid var(--border);display:flex;align-items:center;gap:0.5rem}
+.ch-summary.ok{color:#4ade80;border-color:rgba(16,185,129,0.25);background:rgba(16,185,129,0.06)}
+.ch-summary.warn{color:#fbbf24;border-color:rgba(245,158,11,0.25);background:rgba(245,158,11,0.06)}
+.wh-strip{display:flex;flex-wrap:wrap;gap:5px;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)}
+.wh-strip-lbl{width:100%;font-size:0.64rem;text-transform:uppercase;letter-spacing:0.5px;color:var(--text-muted);margin-bottom:0.4rem}
+.wh-dot{width:9px;height:9px;border-radius:50%;flex-shrink:0}
+.wh-dot.critical{background:#f87171;box-shadow:0 0 5px rgba(248,113,113,0.5)}
+.wh-dot.high{background:#fbbf24}
+.wh-dot.medium{background:#facc15}
+.wh-dot.ok{background:#334155}
 
-/* Footer trust badges */
-.trust-footer{margin-top:2rem;padding:1.5rem 0;border-top:1px solid var(--border);text-align:center;color:var(--text-muted);font-size:0.78rem}
-.trust-footer strong{color:var(--text-secondary);font-weight:600}
-.trust-badge{display:inline-flex;align-items:center;gap:0.35rem;margin:0 0.75rem;color:var(--text-muted)}
-.trust-badge::before{content:'✓';color:var(--success);font-weight:700}
+.ns-health-row{display:flex;justify-content:space-between;align-items:center;padding:0.55rem 0;border-bottom:1px solid rgba(51,65,85,0.5);font-size:0.85rem}
+.ns-health-row:last-child{border-bottom:none}
+.ns-health-name{color:var(--text-secondary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.ns-health-ratio{font-variant-numeric:tabular-nums;font-weight:700}
+
+.sec-checklist{list-style:none;font-size:0.83rem;color:var(--text-secondary);line-height:2.1}
+.sec-checklist li::before{content:'✓';color:var(--success);font-weight:700;margin-right:0.6rem}
+
+/* ── Row 4: Bottom strip (demoted) ── */
+.bottom-strip{display:flex;align-items:center;gap:2rem;flex-wrap:wrap;background:rgba(0,0,0,0.15);border:1px solid var(--border);border-radius:var(--radius);padding:1.1rem 1.5rem;margin-top:0.5rem}
+.bottom-metric{min-width:110px}
+.bottom-lbl{font-size:0.66rem;text-transform:uppercase;letter-spacing:0.5px;color:var(--text-muted);margin-bottom:0.2rem}
+.bottom-val{font-size:1.15rem;font-weight:700;font-variant-numeric:tabular-nums;color:var(--text-secondary)}
+.bottom-delta{font-size:0.7rem;color:var(--text-muted);margin-top:0.1rem}
+.bottom-actions{margin-left:auto;display:flex;gap:0.75rem;flex-wrap:wrap}
+.bottom-btn{border:1px solid var(--border);color:var(--text-secondary);font-size:0.8rem;font-weight:600;padding:0.5rem 1.1rem;border-radius:var(--radius-sm);text-decoration:none;transition:all 0.15s;white-space:nowrap}
+.bottom-btn:hover{background:var(--surface-hover);border-color:var(--primary);color:var(--text)}
 </style>
 </head>
 <body>
@@ -123,229 +120,263 @@
 {{template "sidebar.html" .}}
 <main class="main">
 
-<div class="page-meta-bar">
-  <div class="cluster-selector">
-    <span style="color:var(--text-muted)">Cluster:</span>
-    <strong>{{.ClusterName}}</strong>
-  </div>
-  <div class="refresh-badge">Auto refresh: 60s</div>
-</div>
-
-<div class="page-hdr">
+<!-- 1. Page header -->
+<div class="ov-hdr">
   <div>
     <h1>Overview</h1>
-    <p>Find what deserves attention first</p>
+    <div class="ov-hdr-sub">{{.ClusterName}} · {{.NamespaceCount}} namespace(s)</div>
+    <div class="ov-badges">
+      <span class="badge badge-ok">Read-only</span>
+      <span class="badge badge-ok">Operational memory</span>
+      <span class="badge badge-ok">Auth enabled</span>
+    </div>
+  </div>
+  <div class="page-meta">
+    <div>Last scanned: <strong id="ov-age">just now</strong></div>
   </div>
 </div>
 
-<!-- KPI Row -->
-<div class="kpi-row">
+<!-- 2. If you only fix one thing today -->
+{{if .TopIssues}}
+{{with index .TopIssues 0}}
+<div class="fix-one-banner">
+  <div class="fix-one-icon">⚡</div>
+  <div class="fix-one-body">
+    <div class="fix-one-lbl">If you only fix one thing today</div>
+    <div class="fix-one-title">{{.Title}}</div>
+    <div class="fix-one-sub">{{.Subtitle}}</div>
+  </div>
+  <span class="sev-badge {{.Severity}}">{{.SeverityLbl}}</span>
+  <a class="fix-one-btn" href="{{.URL}}">Fix now →</a>
+</div>
+{{end}}
+{{end}}
 
-  <div class="kpi-card kpi-card-score{{if eq .IncidentScoreColor "red"}} critical{{end}}">
-    <div class="kpi-icon {{.IncidentScoreColor}}"><span class="kpi-icon-svg"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg></span></div>
-    <div class="kpi-label">Incident Score</div>
-    <div class="kpi-value {{.IncidentScoreColor}}">{{.IncidentScore}}<span style="font-size:0.9rem;font-weight:600;color:var(--text-muted)">/100</span></div>
-    <div class="kpi-sub {{.IncidentScoreColor}}">{{.IncidentScoreLabel}}</div>
-    {{if and .Trend .Trend.HasHistory}}
-    <div class="kpi-trend {{if eq .Trend.IncidentScore.Direction "up"}}up-good{{else if eq .Trend.IncidentScore.Direction "down"}}down-bad{{else}}flat{{end}}">
-      <span class="trend-arrow">{{if eq .Trend.IncidentScore.Direction "up"}}↑{{else if eq .Trend.IncidentScore.Direction "down"}}↓{{else}}→{{end}}</span>
-      <span>{{if gt .Trend.IncidentScore.Delta 0}}+{{end}}{{.Trend.IncidentScore.Delta}} from last scan</span>
+<!-- 3. Situation Briefing + Operational Memory -->
+<div class="ov-row-briefing">
+  <div class="section-card">
+    <div class="section-title">Situation Briefing</div>
+    <p class="briefing-text">{{.VerdictLine1}}</p>
+    {{if .VerdictLine2}}<p class="briefing-text">{{.VerdictLine2}}</p>{{end}}
+  </div>
+
+  <div class="section-card">
+    <div class="section-title">Operational Memory</div>
+    <div class="section-sub">What this cluster's history shows</div>
+    {{if .Scoreboard}}
+    <div class="mem-grid">
+      <div class="mem-cell">
+        <div class="mem-num">{{.Scoreboard.TotalSeen}}</div>
+        <div class="mem-lbl">Total Seen</div>
+      </div>
+      <div class="mem-cell">
+        <div class="mem-num">{{.Scoreboard.Resolved}}</div>
+        <div class="mem-lbl">Resolved</div>
+      </div>
+      <div class="mem-cell">
+        <div class="mem-num">{{.Scoreboard.Reopened}}</div>
+        <div class="mem-lbl">Reopened</div>
+      </div>
+      <div class="mem-cell">
+        <div class="mem-num">{{.Scoreboard.Accelerating}}</div>
+        <div class="mem-lbl">Accelerating</div>
+      </div>
     </div>
-    {{if .Trend.ScoreHistory}}
-    <div class="sparkline">
-      {{range .Trend.ScoreHistory}}
-      <div class="spark-bar {{if lt . 40}}spark-low{{else if lt . 70}}spark-mid{{else}}spark-high{{end}}"
-           style="height:{{sparkHeight .}}px"
-           title="Score: {{.}}"></div>
+    {{if .Scoreboard.LongestActiveName}}
+    <div class="mem-line">Longest active: <strong>{{.Scoreboard.LongestActiveName}}</strong> — {{.Scoreboard.LongestActiveDays}}d</div>
+    {{end}}
+    {{if .Scoreboard.MostUnstableNamespace}}
+    <div class="mem-line">Most unstable namespace: <strong>{{.Scoreboard.MostUnstableNamespace}}</strong> ({{.Scoreboard.MostUnstableCount}} incidents)</div>
+    {{end}}
+    {{else}}
+    <div class="empty-state-small">
+      <span class="icon">🧠</span>
+      <div>No operational memory yet</div>
+    </div>
+    {{end}}
+  </div>
+</div>
+
+<!-- 4. Top 5 Things To Fix + What's Changed / Recent Events -->
+<div class="ov-row-top5">
+  <div class="section-card">
+    <div class="section-title">Top 5 Things To Fix</div>
+    <div class="section-sub">Prioritized by impact</div>
+
+    {{if not .TopIssues}}
+    <div class="empty-state-small">
+      <span class="icon">✅</span>
+      <div>No issues detected. Cluster looks healthy.</div>
+    </div>
+    {{else}}
+    {{range .TopIssues}}
+    <div class="top-issue">
+      <div class="top-issue-rank">{{.Rank}}</div>
+      <div>
+        <div class="top-issue-title">{{.Title}}</div>
+        <div class="top-issue-sub">{{.Subtitle}}</div>
+        {{if .Action}}<div class="top-issue-action">▸ {{.Action}}</div>{{end}}
+      </div>
+      <span class="sev-badge {{.Severity}}">{{.SeverityLbl}}</span>
+      <a class="top-issue-btn" href="{{.URL}}">View →</a>
+    </div>
+    {{end}}
+    <a class="view-all-link" href="{{.WrURL}}">View all issues in War Room →</a>
+    {{end}}
+  </div>
+
+  <div class="feed-card">
+    <div class="section-card">
+      <div class="section-title">What's Changed Since Last Scan</div>
+      <div class="section-sub">Since {{.LastViewedLabel}}</div>
+      {{if not .ChangesSinceLastView}}
+      <div class="empty-state-small">
+        <span class="icon">🕓</span>
+        <div>Nothing's changed since your last visit</div>
+      </div>
+      {{else}}
+      {{range .ChangesSinceLastView}}
+      <div class="change-row">
+        <span class="change-reason {{.EventReason}}">{{.EventReason}}</span>
+        <span class="change-resource">{{.Resource}}</span>
+        <span class="change-age">{{eventAge .OccurredAt}}</span>
+      </div>
+      {{end}}
+      {{end}}
+      <a class="view-all-link" href="{{.IncidentsHref}}">View all →</a>
+    </div>
+
+    <div class="section-card">
+      <div class="section-title">Recent Events</div>
+      <div class="section-sub">Cluster-wide activity feed</div>
+      {{if not .RecentEvents}}
+      <div class="empty-state-small">
+        <span class="icon">🕓</span>
+        <div>No activity recorded yet</div>
+      </div>
+      {{else}}
+      {{range .RecentEvents}}
+      <div class="change-row">
+        <span class="change-reason {{.EventReason}}">{{.EventReason}}</span>
+        <span class="change-resource">{{.Resource}}</span>
+        <span class="change-age">{{eventAge .OccurredAt}}</span>
+      </div>
+      {{end}}
+      {{end}}
+    </div>
+  </div>
+</div>
+
+<!-- 5. Cluster Health / Namespace Health / Security Status -->
+<div class="ov-3col">
+
+  <div class="section-card">
+    <div class="section-title">Cluster Health</div>
+    <div class="ch-grid">
+      <div class="ch-cell">
+        <div class="ch-num">{{.NodePoolCount}}</div>
+        <div class="ch-lbl">Node Pools</div>
+      </div>
+      <div class="ch-cell">
+        <div class="ch-num">{{.PodCount}}</div>
+        <div class="ch-lbl">Running Pods</div>
+      </div>
+      <div class="ch-cell">
+        <div class="ch-num">{{.CPUUtilization}}%</div>
+        <div class="ch-lbl">CPU Utilization</div>
+      </div>
+      <div class="ch-cell">
+        <div class="ch-num">{{.MemUtilization}}%</div>
+        <div class="ch-lbl">Memory Utilization</div>
+      </div>
+    </div>
+    {{if or (gt .CPUUtilization 85) (gt .MemUtilization 85)}}
+    <div class="ch-summary warn">⚠ Utilization running high</div>
+    {{else}}
+    <div class="ch-summary ok">✓ Utilization nominal</div>
+    {{end}}
+    {{if .WorkloadHealthGrid}}
+    <div class="wh-strip">
+      <div class="wh-strip-lbl">Workload Health ({{len .WorkloadHealthGrid}})</div>
+      {{range .WorkloadHealthGrid}}
+      <span class="wh-dot {{if .Severity}}{{.Severity}}{{else}}ok{{end}}" title="{{.Name}}{{if .Severity}} — {{.Severity}}{{end}}"></span>
       {{end}}
     </div>
     {{end}}
-    {{else if .Trend}}
-    <div class="kpi-trend flat"><span>Trend data building...</span></div>
-    {{end}}
   </div>
 
-  <div class="kpi-card{{if .CriticalCount}} critical{{end}}">
-    <div class="kpi-icon red"><span class="kpi-icon-svg"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg></span></div>
-    <div class="kpi-label">Critical Issues</div>
-    <div class="kpi-value{{if .CriticalCount}} red{{else}} green{{end}}">{{.CriticalCount}}</div>
-    <div class="kpi-sub{{if .CriticalCount}} red{{end}}">{{if .CriticalCount}}Needs immediate attention{{else}}All clear{{end}}</div>
-    {{if and .Trend .Trend.HasHistory}}
-    <div class="kpi-trend {{if eq .Trend.CriticalCount.Direction "up"}}up-bad{{else if eq .Trend.CriticalCount.Direction "down"}}down-good{{else}}flat{{end}}">
-      <span class="trend-arrow">{{if eq .Trend.CriticalCount.Direction "up"}}↑{{else if eq .Trend.CriticalCount.Direction "down"}}↓{{else}}→{{end}}</span>
-      <span>{{if gt .Trend.CriticalCount.Delta 0}}+{{end}}{{.Trend.CriticalCount.Delta}} from last scan</span>
+  <div class="section-card">
+    <div class="section-title">Namespace Health</div>
+    <div class="section-sub">Ready pods per namespace</div>
+    {{if not .NamespaceHealthList}}
+    <div class="empty-state-small">
+      <span class="icon">📁</span>
+      <div>No namespace data available</div>
+    </div>
+    {{else}}
+    {{range .NamespaceHealthList}}
+    <div class="ns-health-row">
+      <span class="ns-health-name">{{.Name}}</span>
+      <span class="badge badge-{{healthColor .Ready .Total}} ns-health-ratio">{{.Ready}}/{{.Total}}</span>
     </div>
     {{end}}
-  </div>
-
-  <div class="kpi-card">
-    <div class="kpi-icon purple"><span class="kpi-icon-svg"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg></span></div>
-    <div class="kpi-label">Security Score</div>
-    <div class="kpi-value">{{.SecurityScore}}<span style="font-size:0.7rem;color:var(--text-muted);font-weight:600">/100</span></div>
-    <div class="kpi-sub">{{if lt .SecurityScore 40}}High Risk{{else if lt .SecurityScore 70}}Medium Risk{{else}}Good{{end}}</div>
-    {{if and .Trend .Trend.HasHistory}}
-    <div class="kpi-trend {{if eq .Trend.SecurityScore.Direction "up"}}up-good{{else if eq .Trend.SecurityScore.Direction "down"}}down-bad{{else}}flat{{end}}">
-      <span class="trend-arrow">{{if eq .Trend.SecurityScore.Direction "up"}}↑{{else if eq .Trend.SecurityScore.Direction "down"}}↓{{else}}→{{end}}</span>
-      <span>{{if gt .Trend.SecurityScore.Delta 0}}+{{end}}{{.Trend.SecurityScore.Delta}} from last scan</span>
-    </div>
     {{end}}
   </div>
 
-  <div class="kpi-card">
-    <div class="kpi-icon orange"><span class="kpi-icon-svg"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/></svg></span></div>
-    <div class="kpi-label">Waste Resources</div>
-    <div class="kpi-value orange">{{.WasteCount}}</div>
-    <div class="kpi-sub">Resources found</div>
-    {{if and .Trend .Trend.HasHistory}}
-    <div class="kpi-trend {{if eq .Trend.WasteCount.Direction "up"}}up-bad{{else if eq .Trend.WasteCount.Direction "down"}}down-good{{else}}flat{{end}}">
-      <span class="trend-arrow">{{if eq .Trend.WasteCount.Direction "up"}}↑{{else if eq .Trend.WasteCount.Direction "down"}}↓{{else}}→{{end}}</span>
-      <span>{{if gt .Trend.WasteCount.Delta 0}}+{{end}}{{.Trend.WasteCount.Delta}} from last scan</span>
-    </div>
-    {{end}}
-  </div>
-
-  <div class="kpi-card">
-    <div class="kpi-icon gold"><span class="kpi-icon-svg"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="2" x2="12" y2="22"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg></span></div>
-    <div class="kpi-label">Monthly Cost</div>
-    <div class="kpi-value">${{.MonthlyCost | printf "%.0f"}}</div>
-    <div class="kpi-sub">Estimated</div>
+  <div class="section-card">
+    <div class="section-title">Security Status</div>
+    <div class="section-sub">How OpsCart operates in this cluster</div>
+    <ul class="sec-checklist">
+      <li>Read-only access</li>
+      <li>RBAC enforced</li>
+      <li>No agents installed</li>
+      <li>No outbound network calls</li>
+      <li>No secrets stored</li>
+    </ul>
   </div>
 
 </div>
 
-<!-- Two-column layout -->
-<div class="overview-grid">
-
-  <!-- LEFT: Top 5 + Cluster Summary -->
-  <div>
-    <div class="section-card">
-      <div class="section-hdr">
-        <div class="section-title">Top 5 Things To Fix</div>
-        <div class="section-sub">Prioritized by impact</div>
-      </div>
-
-      {{if not .TopIssues}}
-      <div class="empty-state-small">
-        <span class="icon">✅</span>
-        <div>No issues detected. Cluster looks healthy.</div>
-      </div>
-      {{else}}
-      {{range .TopIssues}}
-      <div class="top-issue">
-        <div class="top-issue-rank">{{.Rank}}</div>
-        <div>
-          <div class="top-issue-title">{{.Title}}</div>
-          <div class="top-issue-sub">{{.Subtitle}}</div>
-          {{if .Action}}<div class="top-issue-action">▸ {{.Action}}</div>{{end}}
-        </div>
-        <span class="sev-badge {{.Severity}}">{{.SeverityLbl}}</span>
-        <span class="top-issue-count">{{.CountText}}</span>
-        <a class="top-issue-btn" href="{{.URL}}">View →</a>
-      </div>
-      {{end}}
-      <a class="view-all-link" href="{{.WrURL}}">View all issues in War Room →</a>
-      {{end}}
-    </div>
-
-    <div class="section-card">
-      <div class="section-hdr">
-        <div style="display:flex;justify-content:space-between;align-items:center">
-          <div class="section-title">Cluster Summary</div>
-          <a class="view-all-link" href="{{.InfraURL}}">View infrastructure →</a>
-        </div>
-      </div>
-      <div class="summary-grid">
-        <div class="summary-card">
-          <div class="summary-icon">🖥</div>
-          <div class="summary-lbl">Node Pools</div>
-          <div class="summary-num">{{.NodePoolCount}}</div>
-          <div class="summary-sub">Pools</div>
-        </div>
-        <div class="summary-card">
-          <div class="summary-icon">📦</div>
-          <div class="summary-lbl">Running Pods</div>
-          <div class="summary-num">{{.PodCount}}</div>
-          <div class="summary-sub">Pods</div>
-        </div>
-        <div class="summary-card">
-          <div class="summary-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg></div>
-          <div class="summary-lbl">CPU Utilization</div>
-          <div class="summary-num">{{.CPUUtilization}}%</div>
-          <div class="summary-sub">Average</div>
-        </div>
-        <div class="summary-card">
-          <div class="summary-icon">🧠</div>
-          <div class="summary-lbl">Memory Utilization</div>
-          <div class="summary-num">{{.MemUtilization}}%</div>
-          <div class="summary-sub">Average</div>
-        </div>
-        <div class="summary-card">
-          <div class="summary-icon">📁</div>
-          <div class="summary-lbl">Namespaces</div>
-          <div class="summary-num">{{.NamespaceCount}}</div>
-          <div class="summary-sub">Namespaces</div>
-        </div>
-      </div>
-    </div>
+<!-- 6. Bottom strip (demoted) -->
+<div class="bottom-strip">
+  <div class="bottom-metric">
+    <div class="bottom-lbl">Incident Score</div>
+    <div class="bottom-val">{{.IncidentScore}}/100</div>
+    {{if .IncidentScoreDeltaText}}<div class="bottom-delta">{{.IncidentScoreDeltaText}} from last scan</div>{{end}}
   </div>
-
-<!-- RIGHT: War Room featured -->
-  <div>
-    <div class="wr-featured">
-
-      <!-- Sticky header -->
-      <div class="wr-featured-hdr">
-        <div class="wr-featured-title">War Room
-          {{if .HasFeatured}}<span class="wr-featured-count">{{.CriticalCount}} {{if eq .CriticalCount 1}}Critical{{else}}Issues{{end}}</span>{{end}}
-        </div>
-        <a class="view-all-link" href="{{.WrURL}}" style="margin-top:0">View all →</a>
-      </div>
-      <div class="wr-featured-sub">Issues that need your immediate attention</div>
-
-      {{if .HasFeatured}}
-      <!-- Scrollable cards body -->
-      <div class="wr-cards-body">
-        {{range .FeaturedIssues}}
-        <div class="wr-issue-card">
-          <div class="wr-issue-top">
-            <span class="sev-badge {{.Severity}}">{{if eq .Severity "critical"}}CRITICAL{{else if eq .Severity "high"}}HIGH{{else}}{{.Severity}}{{end}}</span>
-            <span class="top-issue-count">{{.Namespace}}</span>
-          </div>
-          <div class="wr-issue-name">{{.Message}}</div>
-          <div class="wr-issue-ns">{{.Namespace}} · {{.Resource}}</div>
-          {{if .KubectlCmd}}
-          <div class="wr-issue-section">
-            <div class="wr-issue-label">Quick Fix</div>
-            <div class="wr-quick-fix">
-              <code>{{.KubectlCmd}}</code>
-              <button class="wr-copy-btn" onclick="navigator.clipboard.writeText('{{.KubectlCmd}}')">Copy</button>
-            </div>
-          </div>
-          {{end}}
-        </div>
-        {{end}}
-        <a class="wr-view-details" href="{{$.WrURL}}">View All in War Room →</a>
-      </div>
-
-      {{else}}
-      <div class="empty-state-small">
-        <span class="icon">✅</span>
-        <div>No critical issues detected</div>
-      </div>
-      {{end}}
-
-    </div>
+  <div class="bottom-metric">
+    <div class="bottom-lbl">Security Score</div>
+    <div class="bottom-val">{{.SecurityScore}}/100</div>
+    {{if .SecurityScoreDeltaText}}<div class="bottom-delta">{{.SecurityScoreDeltaText}} from last scan</div>{{end}}
   </div>
-
-<!-- Footer trust badges -->
-<div class="trust-footer">
-  <strong>OpsCart {{.Version}}</strong>
-  <span class="trust-badge">Read-only</span>
-  <span class="trust-badge">No agents</span>
-  <span class="trust-badge">No cloud credentials</span>
+  <div class="bottom-metric">
+    <div class="bottom-lbl">Monthly Cost</div>
+    <div class="bottom-val">${{money .MonthlyCost}}</div>
+    {{if .CostDeltaText}}<div class="bottom-delta">{{.CostDeltaText}} from last scan</div>{{end}}
+  </div>
+  <div class="bottom-metric">
+    <div class="bottom-lbl">Reclaimable Waste</div>
+    <div class="bottom-val">{{.WasteCount}}</div>
+  </div>
+  <div class="bottom-actions">
+    <a class="bottom-btn" href="{{.CostsHref}}">Cost Intelligence →</a>
+    <a class="bottom-btn" href="{{.WasteHref}}">Waste &amp; Drift →</a>
+  </div>
 </div>
 
 </main>
 </div>
+<script>
+(function(){
+  var el = document.getElementById('ov-age');
+  var TS = {{.ScannedAtMS}};
+  function upd(){
+    var s = Math.floor((Date.now()-TS)/1000);
+    var t = s<5?'just now':s<60?s+'s ago':Math.floor(s/60)+'m ago';
+    if(el) el.textContent = t;
+  }
+  setInterval(upd,1000); upd();
+})();
+</script>
 </body>
 </html>

--- a/cmd/opscart-dashboard/templates/overview.html
+++ b/cmd/opscart-dashboard/templates/overview.html
@@ -44,6 +44,14 @@
 /* ── Row 1: Situation Briefing (62%) + Operational Memory (38%) ── */
 .ov-row-briefing{display:grid;grid-template-columns:1.6fr 1fr;gap:1.5rem;align-items:stretch}
 @media(max-width:1100px){.ov-row-briefing{grid-template-columns:1fr}}
+/* align-items:stretch above makes both cards match height — intentional,
+   matches the target look. Each card is its own flex column so content
+   still reads top-to-bottom normally; only Briefing's trailing CTA button
+   is pinned to the bottom via margin-top:auto (see .briefing-cta) so a
+   taller Memory card doesn't leave dead space below an early-ending
+   button. This rule is scoped to .ov-row-briefing specifically — it must
+   not affect the Cluster Health/Namespace Health/Security Status row. */
+.ov-row-briefing .section-card{display:flex;flex-direction:column}
 .briefing-text{font-size:0.92rem;line-height:1.6;color:var(--text-secondary);margin-bottom:0.75rem}
 .briefing-text:last-child{margin-bottom:0}
 .briefing{border-color:rgba(239,68,68,.35);background:rgba(239,68,68,.03)}
@@ -51,7 +59,7 @@
 .briefing-facts{display:flex;gap:1.5rem;flex-wrap:wrap;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)}
 .bf-label{font-size:0.66rem;text-transform:uppercase;letter-spacing:0.5px;color:var(--text-muted);margin-bottom:0.25rem}
 .bf-val{font-size:1.05rem;font-weight:700;color:var(--text);max-width:320px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.briefing-cta{margin-top:1.1rem}
+.briefing-cta{margin-top:auto;padding-top:1.1rem}
 .btn-primary{display:inline-block;background:var(--primary-light);border:none;border-radius:var(--radius-sm);color:#fff;font-size:0.82rem;font-weight:600;padding:0.55rem 1.1rem;text-decoration:none;white-space:nowrap;transition:opacity .15s}
 .btn-primary:hover{opacity:.85}
 .mem-grid{display:grid;grid-template-columns:1fr 1fr;gap:0.75rem;margin-bottom:1rem}
@@ -79,13 +87,13 @@
 .feed-card .section-card:last-child{margin-bottom:0}
 .change-row{display:flex;align-items:center;gap:0.6rem;padding:0.6rem 0;border-bottom:1px solid rgba(51,65,85,0.5);font-size:0.8rem}
 .change-row:last-child{border-bottom:none}
-.change-reason{font-size:0.64rem;font-weight:700;text-transform:uppercase;letter-spacing:0.4px;padding:2px 7px;border-radius:10px;white-space:nowrap;flex-shrink:0}
-.change-reason.Detected{background:rgba(245,158,11,0.15);color:#fbbf24}
-.change-reason.Resolved{background:rgba(16,185,129,0.15);color:#4ade80}
-.change-reason.Reopened{background:rgba(239,68,68,0.15);color:#f87171}
-.change-reason.RestartMilestone{background:rgba(239,68,68,0.12);color:#f87171}
-.change-reason.SeverityChanged{background:rgba(99,102,241,0.15);color:var(--primary-light)}
-.change-resource{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--text-secondary)}
+.change-dot{width:8px;height:8px;border-radius:50%;flex-shrink:0}
+.change-dot.Detected{background:#fbbf24}
+.change-dot.Resolved{background:#4ade80}
+.change-dot.Reopened{background:#f87171;box-shadow:0 0 5px rgba(248,113,113,.5)}
+.change-dot.RestartMilestone{background:#f87171;box-shadow:0 0 5px rgba(248,113,113,.5)}
+.change-dot.SeverityChanged{background:var(--primary-light)}
+.change-phrase{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--text-secondary)}
 .change-age{color:var(--text-muted);font-size:0.72rem;white-space:nowrap;flex-shrink:0}
 
 /* ── Row 3: Cluster Health / Namespace Health / Security Status ── */
@@ -165,7 +173,7 @@
     <div class="fix-one-sub">{{.Subtitle}}{{if $.TopIssueNS}} · {{$.TopIssueNS}}{{end}}</div>
   </div>
   <span class="sev-badge {{.Severity}}">{{.SeverityLbl}}</span>
-  <a class="fix-one-btn" href="{{.URL}}">Fix now →</a>
+  <a class="fix-one-btn" href="{{.URL}}">{{.ButtonLabel}}</a>
 </div>
 {{end}}
 {{end}}
@@ -244,7 +252,7 @@
         {{if .Action}}<div class="top-issue-action">▸ {{.Action}}</div>{{end}}
       </div>
       <span class="sev-badge {{.Severity}}">{{.SeverityLbl}}</span>
-      <a class="top-issue-btn" href="{{.URL}}">View →</a>
+      <a class="top-issue-btn" href="{{.URL}}">{{.ButtonLabel}}</a>
     </div>
     {{end}}
     <a class="view-all-link" href="{{.WrURL}}">View all issues in War Room →</a>
@@ -263,8 +271,8 @@
       {{else}}
       {{range limitSlice .ChangesSinceLastView 5}}
       <div class="change-row">
-        <span class="change-reason {{.EventReason}}">{{.EventReason}}</span>
-        <span class="change-resource">{{.Resource}}</span>
+        <span class="change-dot {{.EventReason}}"></span>
+        <span class="change-phrase">{{.Phrase}}</span>
         <span class="change-age">{{eventAge .OccurredAt}}</span>
       </div>
       {{end}}
@@ -283,8 +291,8 @@
       {{else}}
       {{range limitSlice .RecentEvents 5}}
       <div class="change-row">
-        <span class="change-reason {{.EventReason}}">{{.EventReason}}</span>
-        <span class="change-resource">{{.Resource}}</span>
+        <span class="change-dot {{.EventReason}}"></span>
+        <span class="change-phrase">{{.Phrase}}</span>
         <span class="change-age">{{eventAge .OccurredAt}}</span>
       </div>
       {{end}}

--- a/cmd/opscart-dashboard/templates/overview.html
+++ b/cmd/opscart-dashboard/templates/overview.html
@@ -46,6 +46,8 @@
 @media(max-width:1100px){.ov-row-briefing{grid-template-columns:1fr}}
 .briefing-text{font-size:0.92rem;line-height:1.6;color:var(--text-secondary);margin-bottom:0.75rem}
 .briefing-text:last-child{margin-bottom:0}
+.briefing{border-color:rgba(239,68,68,.35);background:rgba(239,68,68,.03)}
+.briefing-ok{border-color:rgba(74,222,128,.3)}
 .briefing-facts{display:flex;gap:1.5rem;flex-wrap:wrap;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)}
 .bf-label{font-size:0.66rem;text-transform:uppercase;letter-spacing:0.5px;color:var(--text-muted);margin-bottom:0.25rem}
 .bf-val{font-size:1.05rem;font-weight:700;color:var(--text);max-width:320px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
@@ -69,6 +71,7 @@
 .top-issue-title{font-weight:600;font-size:0.92rem;margin-bottom:0.2rem}
 .top-issue-sub{font-size:0.75rem;color:var(--text-muted);line-height:1.4}
 .top-issue-action{font-size:0.72rem;color:var(--primary-light);margin-top:0.3rem;font-family:'Consolas','Monaco',monospace}
+.top-issue-memory{font-size:0.7rem;color:var(--text-muted);margin-top:0.2rem}
 .top-issue-btn{background:transparent;border:1px solid var(--border);color:var(--text-secondary);font-size:0.78rem;padding:0.4rem 0.9rem;border-radius:6px;cursor:pointer;text-decoration:none;display:inline-flex;align-items:center;gap:0.3rem;transition:all 0.15s;white-space:nowrap}
 .top-issue-btn:hover{background:var(--surface-hover);border-color:var(--primary);color:var(--text)}
 
@@ -122,6 +125,12 @@
 .bottom-actions{margin-left:auto;display:flex;gap:0.75rem;flex-wrap:wrap}
 .bottom-btn{border:1px solid var(--border);color:var(--text-secondary);font-size:0.8rem;font-weight:600;padding:0.5rem 1.1rem;border-radius:var(--radius-sm);text-decoration:none;transition:all 0.15s;white-space:nowrap}
 .bottom-btn:hover{background:var(--surface-hover);border-color:var(--primary);color:var(--text)}
+.bs-item{display:flex;flex-direction:column;gap:2px;padding-right:1.5rem;border-right:1px solid var(--border)}
+.bs-item:last-of-type{border-right:none}
+.bs-item .n{font-size:1.1rem;font-weight:700}
+.bs-item .l{font-size:.68rem;text-transform:uppercase;letter-spacing:.5px;color:var(--text-muted)}
+.bs-btn{margin-left:auto;font-size:.8rem;color:var(--primary-light);font-weight:600;text-decoration:none;border:1px solid rgba(129,140,248,.4);border-radius:8px;padding:.5rem 1rem;white-space:nowrap}
+.bs-btn:hover{background:rgba(129,140,248,.1)}
 </style>
 </head>
 <body>
@@ -146,14 +155,14 @@
 </div>
 
 <!-- 2. If you only fix one thing today -->
-{{if .TopIssues}}
+{{if .HasTopIssue}}
 {{with index .TopIssues 0}}
 <div class="fix-one-banner">
   <div class="fix-one-icon"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg></div>
   <div class="fix-one-body">
     <div class="fix-one-lbl">If you only fix one thing today</div>
     <div class="fix-one-title">{{.Title}}</div>
-    <div class="fix-one-sub">{{.Subtitle}}</div>
+    <div class="fix-one-sub">{{.Subtitle}}{{if $.TopIssueNS}} · {{$.TopIssueNS}}{{end}}</div>
   </div>
   <span class="sev-badge {{.Severity}}">{{.SeverityLbl}}</span>
   <a class="fix-one-btn" href="{{.URL}}">Fix now →</a>
@@ -163,14 +172,14 @@
 
 <!-- 3. Situation Briefing + Operational Memory -->
 <div class="ov-row-briefing">
-  <div class="section-card">
+  <div class="section-card{{if gt .CriticalCount 0}} briefing{{else}} briefing-ok{{end}}">
     <div class="section-title">Situation Briefing</div>
     <p class="briefing-text">{{.VerdictLine1}}</p>
     {{if .VerdictLine2}}<p class="briefing-text">{{.VerdictLine2}}</p>{{end}}
     <div class="briefing-facts">
       <div class="bf-item"><div class="bf-label">Active Critical</div><div class="bf-val">{{.CriticalCount}}</div></div>
-      {{if .TopIssues}}
-      <div class="bf-item"><div class="bf-label">Highest Priority</div><div class="bf-val">{{with index .TopIssues 0}}{{.Title}}{{end}}</div></div>
+      {{if .HasTopIssue}}
+      <div class="bf-item"><div class="bf-label">Highest Priority</div><div class="bf-val">{{.TopIssueNS}}</div></div>
       {{end}}
     </div>
     <div class="briefing-cta"><a href="{{.WrURL}}" class="btn-primary">Open War Room →</a></div>
@@ -231,6 +240,7 @@
       <div>
         <div class="top-issue-title">{{.Title}}</div>
         <div class="top-issue-sub">{{.Subtitle}}</div>
+        {{if .MemoryLine}}<div class="top-issue-memory">{{.MemoryLine}}</div>{{end}}
         {{if .Action}}<div class="top-issue-action">▸ {{.Action}}</div>{{end}}
       </div>
       <span class="sev-badge {{.Severity}}">{{.SeverityLbl}}</span>
@@ -315,8 +325,11 @@
     {{if .WorkloadHealthGrid}}
     <div class="wh-strip">
       <div class="wh-strip-lbl">Workload Health ({{len .WorkloadHealthGrid}})</div>
-      {{range .WorkloadHealthGrid}}
+      {{range limitWorkloadHealth .WorkloadHealthGrid 40}}
       <span class="wh-dot {{if .Severity}}{{.Severity}}{{else}}ok{{end}}" title="{{.Name}}{{if .Severity}} — {{.Severity}}{{end}}"></span>
+      {{end}}
+      {{if gt (len .WorkloadHealthGrid) 40}}
+      <a class="view-all-link" href="{{$.WrURL}}">View all {{len .WorkloadHealthGrid}} workloads →</a>
       {{end}}
     </div>
     {{end}}
@@ -331,11 +344,14 @@
       <div>No namespace data available</div>
     </div>
     {{else}}
-    {{range .NamespaceHealthList}}
+    {{range limitNamespaceHealth .NamespaceHealthList 6}}
     <div class="ns-health-row">
       <span class="ns-health-name">{{.Name}}</span>
       <span class="badge badge-{{healthColor .Ready .Total}} ns-health-ratio">{{.Ready}}/{{.Total}}</span>
     </div>
+    {{end}}
+    {{if gt (len .NamespaceHealthList) 6}}
+    <a class="view-all-link" href="{{.NSsURL}}">View all {{len .NamespaceHealthList}} namespaces →</a>
     {{end}}
     {{end}}
   </div>
@@ -356,28 +372,28 @@
 
 <!-- 6. Bottom strip (demoted) -->
 <div class="bottom-strip">
-  <div class="bottom-metric">
-    <div class="bottom-lbl">Incident Score</div>
-    <div class="bottom-val">{{.IncidentScore}}/100</div>
+  <div class="bottom-metric bs-item">
+    <div class="bottom-lbl l">Incident Score</div>
+    <div class="bottom-val n">{{.IncidentScore}}/100</div>
     {{if .IncidentScoreDeltaText}}<div class="bottom-delta">{{.IncidentScoreDeltaText}} from last scan</div>{{end}}
   </div>
-  <div class="bottom-metric">
-    <div class="bottom-lbl">Security Score</div>
-    <div class="bottom-val">{{.SecurityScore}}/100</div>
+  <div class="bottom-metric bs-item">
+    <div class="bottom-lbl l">Security Score</div>
+    <div class="bottom-val n">{{.SecurityScore}}/100</div>
     {{if .SecurityScoreDeltaText}}<div class="bottom-delta">{{.SecurityScoreDeltaText}} from last scan</div>{{end}}
   </div>
-  <div class="bottom-metric">
-    <div class="bottom-lbl">Monthly Cost</div>
-    <div class="bottom-val">${{money .MonthlyCost}}</div>
+  <div class="bottom-metric bs-item">
+    <div class="bottom-lbl l">Monthly Cost</div>
+    <div class="bottom-val n">${{money .MonthlyCost}}</div>
     {{if .CostDeltaText}}<div class="bottom-delta">{{.CostDeltaText}} from last scan</div>{{end}}
   </div>
-  <div class="bottom-metric">
-    <div class="bottom-lbl">Reclaimable Waste</div>
-    <div class="bottom-val">{{.WasteCount}}</div>
+  <div class="bottom-metric bs-item">
+    <div class="bottom-lbl l">Reclaimable Waste</div>
+    <div class="bottom-val n">{{.WasteCount}}</div>
   </div>
   <div class="bottom-actions">
-    <a class="bottom-btn" href="{{.CostsHref}}">Cost Intelligence →</a>
-    <a class="bottom-btn" href="{{.WasteHref}}">Waste &amp; Drift →</a>
+    <a class="bottom-btn bs-btn" href="{{.CostsHref}}">Cost Intelligence →</a>
+    <a class="bottom-btn bs-btn" href="{{.WasteHref}}">Waste &amp; Drift →</a>
   </div>
 </div>
 

--- a/cmd/opscart-dashboard/templates/overview.html
+++ b/cmd/opscart-dashboard/templates/overview.html
@@ -18,7 +18,7 @@
 
 /* ── Fix-one-thing banner ── */
 .fix-one-banner{display:flex;align-items:center;gap:1rem;background:linear-gradient(180deg,rgba(239,68,68,0.06) 0%,var(--surface) 100%);border:1px solid rgba(239,68,68,0.3);border-radius:var(--radius);padding:1.1rem 1.4rem;margin-bottom:1.5rem;animation:fadeIn 0.3s ease both}
-.fix-one-icon{font-size:1.5rem;flex-shrink:0}
+.fix-one-icon{flex-shrink:0;color:#f87171;display:flex}
 .fix-one-body{flex:1;min-width:0}
 .fix-one-lbl{font-size:0.68rem;text-transform:uppercase;letter-spacing:0.6px;color:#f87171;font-weight:700;margin-bottom:0.25rem}
 .fix-one-title{font-size:1.02rem;font-weight:700;margin-bottom:0.2rem}
@@ -31,7 +31,8 @@
 .section-title{font-size:1.05rem;font-weight:700;margin-bottom:0.25rem}
 .section-sub{font-size:0.78rem;color:var(--text-muted);margin-bottom:1rem}
 .empty-state-small{padding:2rem 1rem;text-align:center;color:var(--text-muted);font-size:0.85rem}
-.empty-state-small .icon{font-size:1.8rem;margin-bottom:0.5rem;display:block}
+.empty-state-small .icon{display:flex;justify-content:center;margin-bottom:0.5rem}
+.empty-state-small .icon svg{width:28px;height:28px}
 .view-all-link{display:inline-flex;align-items:center;gap:0.4rem;color:var(--primary-light);font-size:0.85rem;margin-top:0.5rem;text-decoration:none}
 .view-all-link:hover{text-decoration:underline}
 .sev-badge{padding:3px 9px;border-radius:12px;font-size:0.66rem;font-weight:700;letter-spacing:0.5px;white-space:nowrap}
@@ -45,6 +46,12 @@
 @media(max-width:1100px){.ov-row-briefing{grid-template-columns:1fr}}
 .briefing-text{font-size:0.92rem;line-height:1.6;color:var(--text-secondary);margin-bottom:0.75rem}
 .briefing-text:last-child{margin-bottom:0}
+.briefing-facts{display:flex;gap:1.5rem;flex-wrap:wrap;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)}
+.bf-label{font-size:0.66rem;text-transform:uppercase;letter-spacing:0.5px;color:var(--text-muted);margin-bottom:0.25rem}
+.bf-val{font-size:1.05rem;font-weight:700;color:var(--text);max-width:320px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.briefing-cta{margin-top:1.1rem}
+.btn-primary{display:inline-block;background:var(--primary-light);border:none;border-radius:var(--radius-sm);color:#fff;font-size:0.82rem;font-weight:600;padding:0.55rem 1.1rem;text-decoration:none;white-space:nowrap;transition:opacity .15s}
+.btn-primary:hover{opacity:.85}
 .mem-grid{display:grid;grid-template-columns:1fr 1fr;gap:0.75rem;margin-bottom:1rem}
 .mem-cell{background:rgba(0,0,0,0.2);border:1px solid var(--border);border-radius:var(--radius-sm);padding:0.85rem;text-align:center}
 .mem-num{font-size:1.5rem;font-weight:800;line-height:1;margin-bottom:0.25rem;font-variant-numeric:tabular-nums}
@@ -66,7 +73,7 @@
 .top-issue-btn:hover{background:var(--surface-hover);border-color:var(--primary);color:var(--text)}
 
 .feed-card .section-card{margin-bottom:1.5rem}
-.feed-card:last-child .section-card{margin-bottom:0}
+.feed-card .section-card:last-child{margin-bottom:0}
 .change-row{display:flex;align-items:center;gap:0.6rem;padding:0.6rem 0;border-bottom:1px solid rgba(51,65,85,0.5);font-size:0.8rem}
 .change-row:last-child{border-bottom:none}
 .change-reason{font-size:0.64rem;font-weight:700;text-transform:uppercase;letter-spacing:0.4px;padding:2px 7px;border-radius:10px;white-space:nowrap;flex-shrink:0}
@@ -86,6 +93,7 @@
 .ch-num{font-size:1.3rem;font-weight:800;line-height:1;margin-bottom:0.2rem;font-variant-numeric:tabular-nums}
 .ch-lbl{font-size:0.64rem;text-transform:uppercase;letter-spacing:0.5px;color:var(--text-muted)}
 .ch-summary{font-size:0.78rem;padding:0.6rem 0.75rem;border-radius:var(--radius-sm);border:1px solid var(--border);display:flex;align-items:center;gap:0.5rem}
+.ch-summary svg{flex-shrink:0}
 .ch-summary.ok{color:#4ade80;border-color:rgba(16,185,129,0.25);background:rgba(16,185,129,0.06)}
 .ch-summary.warn{color:#fbbf24;border-color:rgba(245,158,11,0.25);background:rgba(245,158,11,0.06)}
 .wh-strip{display:flex;flex-wrap:wrap;gap:5px;margin-top:1rem;padding-top:1rem;border-top:1px solid var(--border)}
@@ -101,8 +109,9 @@
 .ns-health-name{color:var(--text-secondary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .ns-health-ratio{font-variant-numeric:tabular-nums;font-weight:700}
 
-.sec-checklist{list-style:none;font-size:0.83rem;color:var(--text-secondary);line-height:2.1}
-.sec-checklist li::before{content:'✓';color:var(--success);font-weight:700;margin-right:0.6rem}
+.sec-checklist{list-style:none;font-size:0.83rem;color:var(--text-secondary)}
+.sec-checklist li{display:flex;align-items:center;gap:0.6rem;padding:0.35rem 0}
+.sec-checklist svg{color:var(--success);flex-shrink:0}
 
 /* ── Row 4: Bottom strip (demoted) ── */
 .bottom-strip{display:flex;align-items:center;gap:2rem;flex-wrap:wrap;background:rgba(0,0,0,0.15);border:1px solid var(--border);border-radius:var(--radius);padding:1.1rem 1.5rem;margin-top:0.5rem}
@@ -140,7 +149,7 @@
 {{if .TopIssues}}
 {{with index .TopIssues 0}}
 <div class="fix-one-banner">
-  <div class="fix-one-icon">⚡</div>
+  <div class="fix-one-icon"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg></div>
   <div class="fix-one-body">
     <div class="fix-one-lbl">If you only fix one thing today</div>
     <div class="fix-one-title">{{.Title}}</div>
@@ -158,6 +167,13 @@
     <div class="section-title">Situation Briefing</div>
     <p class="briefing-text">{{.VerdictLine1}}</p>
     {{if .VerdictLine2}}<p class="briefing-text">{{.VerdictLine2}}</p>{{end}}
+    <div class="briefing-facts">
+      <div class="bf-item"><div class="bf-label">Active Critical</div><div class="bf-val">{{.CriticalCount}}</div></div>
+      {{if .TopIssues}}
+      <div class="bf-item"><div class="bf-label">Highest Priority</div><div class="bf-val">{{with index .TopIssues 0}}{{.Title}}{{end}}</div></div>
+      {{end}}
+    </div>
+    <div class="briefing-cta"><a href="{{.WrURL}}" class="btn-primary">Open War Room →</a></div>
   </div>
 
   <div class="section-card">
@@ -190,7 +206,7 @@
     {{end}}
     {{else}}
     <div class="empty-state-small">
-      <span class="icon">🧠</span>
+      <span class="icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.5 2A2.5 2.5 0 0 0 7 4.5v.5A2.5 2.5 0 0 0 4.5 7.5v1A2.5 2.5 0 0 0 2 11v1a2.5 2.5 0 0 0 2.5 2.5h1"/><path d="M14.5 2A2.5 2.5 0 0 1 17 4.5v.5a2.5 2.5 0 0 1 2.5 2.5v1A2.5 2.5 0 0 1 22 11v1a2.5 2.5 0 0 1-2.5 2.5h-1"/><path d="M6 18a4 4 0 0 0 4 4h4a4 4 0 0 0 4-4"/><path d="M12 2v20"/></svg></span>
       <div>No operational memory yet</div>
     </div>
     {{end}}
@@ -205,7 +221,7 @@
 
     {{if not .TopIssues}}
     <div class="empty-state-small">
-      <span class="icon">✅</span>
+      <span class="icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg></span>
       <div>No issues detected. Cluster looks healthy.</div>
     </div>
     {{else}}
@@ -231,11 +247,11 @@
       <div class="section-sub">Since {{.LastViewedLabel}}</div>
       {{if not .ChangesSinceLastView}}
       <div class="empty-state-small">
-        <span class="icon">🕓</span>
+        <span class="icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg></span>
         <div>Nothing's changed since your last visit</div>
       </div>
       {{else}}
-      {{range .ChangesSinceLastView}}
+      {{range limitSlice .ChangesSinceLastView 5}}
       <div class="change-row">
         <span class="change-reason {{.EventReason}}">{{.EventReason}}</span>
         <span class="change-resource">{{.Resource}}</span>
@@ -251,11 +267,11 @@
       <div class="section-sub">Cluster-wide activity feed</div>
       {{if not .RecentEvents}}
       <div class="empty-state-small">
-        <span class="icon">🕓</span>
+        <span class="icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg></span>
         <div>No activity recorded yet</div>
       </div>
       {{else}}
-      {{range .RecentEvents}}
+      {{range limitSlice .RecentEvents 5}}
       <div class="change-row">
         <span class="change-reason {{.EventReason}}">{{.EventReason}}</span>
         <span class="change-resource">{{.Resource}}</span>
@@ -263,6 +279,7 @@
       </div>
       {{end}}
       {{end}}
+      <a class="view-all-link" href="{{.IncidentsHref}}">View all →</a>
     </div>
   </div>
 </div>
@@ -291,9 +308,9 @@
       </div>
     </div>
     {{if or (gt .CPUUtilization 85) (gt .MemUtilization 85)}}
-    <div class="ch-summary warn">⚠ Utilization running high</div>
+    <div class="ch-summary warn"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg> Utilization running high</div>
     {{else}}
-    <div class="ch-summary ok">✓ Utilization nominal</div>
+    <div class="ch-summary ok"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg> Utilization nominal</div>
     {{end}}
     {{if .WorkloadHealthGrid}}
     <div class="wh-strip">
@@ -310,7 +327,7 @@
     <div class="section-sub">Ready pods per namespace</div>
     {{if not .NamespaceHealthList}}
     <div class="empty-state-small">
-      <span class="icon">📁</span>
+      <span class="icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg></span>
       <div>No namespace data available</div>
     </div>
     {{else}}
@@ -327,11 +344,11 @@
     <div class="section-title">Security Status</div>
     <div class="section-sub">How OpsCart operates in this cluster</div>
     <ul class="sec-checklist">
-      <li>Read-only access</li>
-      <li>RBAC enforced</li>
-      <li>No agents installed</li>
-      <li>No outbound network calls</li>
-      <li>No secrets stored</li>
+      <li><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg> Read-only access</li>
+      <li><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg> RBAC enforced</li>
+      <li><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg> No agents installed</li>
+      <li><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg> No outbound network calls</li>
+      <li><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg> No secrets stored</li>
     </ul>
   </div>
 

--- a/pkg/analyzer/resources.go
+++ b/pkg/analyzer/resources.go
@@ -3,6 +3,8 @@ package analyzer
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/opscart/opscart-k8s-watcher/pkg/models"
@@ -44,6 +46,10 @@ func (ra *ResourceAnalyzer) AnalyzeClusterResources(namespace string) (*models.C
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pods: %w", err)
 	}
+
+	// Roll the same pod list up to one entry per owning workload — no
+	// second cluster fetch, just a different view of data already in hand.
+	analysis.Workloads = workloadsFromPods(podList.Items)
 
 	// Analyze by namespace
 	namespaceMap := make(map[string]*models.NamespaceResourceUsage)
@@ -132,6 +138,84 @@ func (ra *ResourceAnalyzer) getClusterCapacity() (models.ResourceCapacity, error
 	}
 
 	return capacity, nil
+}
+
+// workloadsFromPods rolls a pod list up to one entry per owning
+// Deployment/StatefulSet/DaemonSet, deduplicating replicas. Pods with no
+// matching owner kind (bare pods, Jobs, CronJobs) are excluded — this
+// mirrors the Deployment/StatefulSet/DaemonSet scope callers expect.
+func workloadsFromPods(pods []corev1.Pod) []models.WorkloadRef {
+	seen := map[models.WorkloadRef]bool{}
+	var out []models.WorkloadRef
+	for _, pod := range pods {
+		ref, ok := workloadRefForPod(pod)
+		if !ok || seen[ref] {
+			continue
+		}
+		seen[ref] = true
+		out = append(out, ref)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Namespace != out[j].Namespace {
+			return out[i].Namespace < out[j].Namespace
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+// workloadRefForPod resolves a pod's owning Deployment/StatefulSet/DaemonSet
+// from its OwnerReferences. ReplicaSet-owned pods (the common Deployment
+// case) roll up to the Deployment name by stripping the ReplicaSet's own
+// hash suffix — the ReplicaSet object itself is not fetched, avoiding a
+// second API call. StatefulSet/DaemonSet owner names are used verbatim;
+// those controllers name pods deterministically, no suffix to strip.
+func workloadRefForPod(pod corev1.Pod) (models.WorkloadRef, bool) {
+	for _, owner := range pod.OwnerReferences {
+		switch owner.Kind {
+		case "ReplicaSet":
+			return models.WorkloadRef{Name: stripHashSuffix(owner.Name), Kind: "Deployment", Namespace: pod.Namespace}, true
+		case "StatefulSet":
+			return models.WorkloadRef{Name: owner.Name, Kind: "StatefulSet", Namespace: pod.Namespace}, true
+		case "DaemonSet":
+			return models.WorkloadRef{Name: owner.Name, Kind: "DaemonSet", Namespace: pod.Namespace}, true
+		}
+	}
+	return models.WorkloadRef{}, false
+}
+
+// stripHashSuffix removes a trailing ReplicaSet hash segment, e.g.
+// "payments-api-7d8f9c6b5" -> "payments-api".
+func stripHashSuffix(name string) string {
+	idx := strings.LastIndex(name, "-")
+	if idx < 0 {
+		return name
+	}
+	suffix := name[idx+1:]
+	if !looksLikeHash(suffix) {
+		return name
+	}
+	return name[:idx]
+}
+
+// looksLikeHash reports whether s looks like a ReplicaSet hash suffix:
+// 5-10 lowercase alphanumeric characters containing at least one digit.
+func looksLikeHash(s string) bool {
+	if len(s) < 5 || len(s) > 10 {
+		return false
+	}
+	hasDigit := false
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9':
+			hasDigit = true
+		case r >= 'a' && r <= 'z':
+			// ok
+		default:
+			return false
+		}
+	}
+	return hasDigit
 }
 
 // getPodResourceRequests calculates total resource requests for a pod

--- a/pkg/analyzer/resources_test.go
+++ b/pkg/analyzer/resources_test.go
@@ -1,0 +1,81 @@
+package analyzer
+
+import (
+	"testing"
+
+	"github.com/opscart/opscart-k8s-watcher/pkg/models"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ownedPod(namespace, name, ownerKind, ownerName string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: ownerKind, Name: ownerName},
+			},
+		},
+	}
+}
+
+func TestWorkloadsFromPods(t *testing.T) {
+	pods := []corev1.Pod{
+		// Two replicas of the same Deployment — must dedupe to one entry,
+		// with the ReplicaSet's own hash suffix stripped.
+		ownedPod("payments", "payments-api-7d8f9c6b5-abc12", "ReplicaSet", "payments-api-7d8f9c6b5"),
+		ownedPod("payments", "payments-api-7d8f9c6b5-def34", "ReplicaSet", "payments-api-7d8f9c6b5"),
+		// StatefulSet-owned pods use the owner name verbatim (no suffix to strip).
+		ownedPod("payments", "redis-0", "StatefulSet", "redis"),
+		ownedPod("payments", "redis-1", "StatefulSet", "redis"),
+		// DaemonSet-owned pod, different namespace.
+		ownedPod("kube-system", "node-exporter-xz9kq", "DaemonSet", "node-exporter"),
+		// Job-owned pod — not a Deployment/StatefulSet/DaemonSet, excluded.
+		ownedPod("payments", "migrate-abc12", "Job", "migrate"),
+		// Bare pod, no owner at all — excluded.
+		{ObjectMeta: metav1.ObjectMeta{Name: "debug-shell", Namespace: "payments"}},
+		// Same Deployment name in a different namespace — must stay distinct.
+		ownedPod("checkout", "payments-api-9f1a2b3c4-zzz99", "ReplicaSet", "payments-api-9f1a2b3c4"),
+	}
+
+	got := workloadsFromPods(pods)
+
+	want := []models.WorkloadRef{
+		{Name: "payments-api", Kind: "Deployment", Namespace: "checkout"},
+		{Name: "node-exporter", Kind: "DaemonSet", Namespace: "kube-system"},
+		{Name: "payments-api", Kind: "Deployment", Namespace: "payments"},
+		{Name: "redis", Kind: "StatefulSet", Namespace: "payments"},
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("expected %d workloads, got %d: %+v", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got[%d] = %+v, want %+v (full: %+v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestWorkloadsFromPods_EmptyInput(t *testing.T) {
+	if got := workloadsFromPods(nil); len(got) != 0 {
+		t.Fatalf("expected empty, got %+v", got)
+	}
+}
+
+func TestStripHashSuffix(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"payments-api-7d8f9c6b5", "payments-api"},
+		{"redis", "redis"},               // no hyphen at all
+		{"payments-api", "payments-api"}, // "api" too short to look like a hash
+		{"checkout-worker-9f1a2", "checkout-worker"},
+	}
+	for _, tc := range tests {
+		if got := stripHashSuffix(tc.in); got != tc.want {
+			t.Errorf("stripHashSuffix(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/pkg/models/resources.go
+++ b/pkg/models/resources.go
@@ -19,6 +19,19 @@ type ClusterResourceAnalysis struct {
 
 	// Optimization opportunities
 	Optimizations []Optimization `json:"optimizations"`
+
+	// Workloads is every Deployment/StatefulSet/DaemonSet observed while
+	// enumerating pods for the namespace breakdown above — a rollup of the
+	// same pod list, not a second cluster fetch.
+	Workloads []WorkloadRef `json:"workloads,omitempty"`
+}
+
+// WorkloadRef identifies a single Deployment/StatefulSet/DaemonSet, derived
+// from pod OwnerReferences during resource analysis.
+type WorkloadRef struct {
+	Name      string `json:"name"`
+	Kind      string `json:"kind"` // "Deployment" | "StatefulSet" | "DaemonSet"
+	Namespace string `json:"namespace"`
 }
 
 // NamespaceResourceUsage represents resource usage for a single namespace

--- a/pkg/store/null.go
+++ b/pkg/store/null.go
@@ -48,7 +48,7 @@ func (NullStore) GetMemoryScoreboard(cluster string) (*MemoryScoreboard, error) 
 	return &MemoryScoreboard{}, nil
 }
 
-func (NullStore) GetRecentEvents(cluster string, limit int) ([]RecentEvent, error) {
+func (NullStore) GetRecentEvents(cluster string, since time.Time, limit int) ([]RecentEvent, error) {
 	return nil, nil
 }
 

--- a/pkg/store/null.go
+++ b/pkg/store/null.go
@@ -44,6 +44,14 @@ func (NullStore) QueryIncidents(f IncidentFilter) ([]IncidentSummary, int, error
 	return nil, 0, nil
 }
 
+func (NullStore) GetMemoryScoreboard(cluster string) (*MemoryScoreboard, error) {
+	return &MemoryScoreboard{}, nil
+}
+
+func (NullStore) GetRecentEvents(cluster string, limit int) ([]RecentEvent, error) {
+	return nil, nil
+}
+
 func (NullStore) PruneOlderThan(cluster string, cutoff time.Time) (int, error) {
 	return 0, nil
 }

--- a/pkg/store/null.go
+++ b/pkg/store/null.go
@@ -52,6 +52,10 @@ func (NullStore) GetRecentEvents(cluster string, limit int) ([]RecentEvent, erro
 	return nil, nil
 }
 
+func (NullStore) GetChangesSince(cluster string, since time.Time, limit int) ([]RecentEvent, error) {
+	return nil, nil
+}
+
 func (NullStore) PruneOlderThan(cluster string, cutoff time.Time) (int, error) {
 	return 0, nil
 }

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -1203,6 +1203,59 @@ func (s *SQLiteStore) GetRecentEvents(cluster string, limit int) ([]RecentEvent,
 	return out, rows.Err()
 }
 
+// meaningfulEventReasons are the event_reason values worth surfacing in a
+// "what changed" diff — every reason insertIncidentEvent ever writes (see
+// UpsertIncidents/ResolveMissing/emitDriftEvents). There is currently no
+// internal/housekeeping event_reason to exclude, but the allowlist is kept
+// explicit so a future addition doesn't leak into this feed silently.
+var meaningfulEventReasons = []string{"Detected", "Resolved", "Reopened", "RestartMilestone", "SeverityChanged"}
+
+// GetChangesSince returns incident_events for cluster that occurred at or
+// after since, newest first, limited to meaningfulEventReasons — a
+// cursor-bounded diff of "what changed" rather than GetRecentEvents'
+// unfiltered feed.
+func (s *SQLiteStore) GetChangesSince(cluster string, since time.Time, limit int) ([]RecentEvent, error) {
+	reasonPlaceholders := make([]string, len(meaningfulEventReasons))
+	args := make([]any, 0, len(meaningfulEventReasons)+2)
+	args = append(args, cluster)
+	for i, reason := range meaningfulEventReasons {
+		reasonPlaceholders[i] = "?"
+		args = append(args, reason)
+	}
+	args = append(args, since.Unix(), limit)
+
+	rows, err := s.db.Query(fmt.Sprintf(
+		`SELECT incidents.resource, incident_events.event_reason, incident_events.occurred_at
+		 FROM incident_events
+		 JOIN incidents ON incident_events.incident_id = incidents.id
+		 WHERE incidents.cluster = ?
+		   AND incident_events.event_reason IN (%s)
+		   AND incident_events.occurred_at >= ?
+		 ORDER BY incident_events.occurred_at DESC LIMIT ?`,
+		strings.Join(reasonPlaceholders, ","),
+	), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []RecentEvent
+	for rows.Next() {
+		var resource string
+		var eventReason sql.NullString
+		var occurredAt int64
+		if err := rows.Scan(&resource, &eventReason, &occurredAt); err != nil {
+			return nil, err
+		}
+		out = append(out, RecentEvent{
+			Resource:    resource,
+			EventReason: eventReason.String,
+			OccurredAt:  time.Unix(occurredAt, 0),
+		})
+	}
+	return out, rows.Err()
+}
+
 // PruneOlderThan removes data older than cutoff for cluster, in one
 // transaction:
 //   - Resolved incidents (and their full event history) are deleted once

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -1170,16 +1170,19 @@ func (s *SQLiteStore) GetMemoryScoreboard(cluster string) (*MemoryScoreboard, er
 	return sb, nil
 }
 
-// GetRecentEvents returns the most recent incident_events for cluster,
-// newest first, joined against their parent incident's resource name.
-func (s *SQLiteStore) GetRecentEvents(cluster string, limit int) ([]RecentEvent, error) {
+// GetRecentEvents returns the most recent incident_events for cluster that
+// occurred at or after since, newest first, joined against their parent
+// incident's resource name. Unlike GetChangesSince, this is intentionally
+// unfiltered by event_reason — every event type, not just
+// meaningfulEventReasons.
+func (s *SQLiteStore) GetRecentEvents(cluster string, since time.Time, limit int) ([]RecentEvent, error) {
 	rows, err := s.db.Query(
 		`SELECT incidents.resource, incident_events.event_reason, incident_events.occurred_at
 		 FROM incident_events
 		 JOIN incidents ON incident_events.incident_id = incidents.id
-		 WHERE incidents.cluster = ?
+		 WHERE incidents.cluster = ? AND incident_events.occurred_at >= ?
 		 ORDER BY incident_events.occurred_at DESC LIMIT ?`,
-		cluster, limit,
+		cluster, since.Unix(), limit,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -1054,6 +1054,155 @@ func (s *SQLiteStore) QueryIncidents(f IncidentFilter) ([]IncidentSummary, int, 
 	return items, total, nil
 }
 
+// countAccelerating counts active incidents whose Trend (computed the same
+// way QueryIncidents derives it) is "accelerating".
+func (s *SQLiteStore) countAccelerating(cluster string) (int, error) {
+	rows, err := s.db.Query(
+		`SELECT id, current_restart_count, first_seen FROM incidents
+		 WHERE cluster = ? AND status = 'active'`,
+		cluster,
+	)
+	if err != nil {
+		return 0, err
+	}
+	type activeRow struct {
+		id           int64
+		restartCount int
+		firstSeen    int64
+	}
+	var actives []activeRow
+	for rows.Next() {
+		var r activeRow
+		if err := rows.Scan(&r.id, &r.restartCount, &r.firstSeen); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		actives = append(actives, r)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	rows.Close()
+
+	if len(actives) == 0 {
+		return 0, nil
+	}
+
+	ids := make([]int64, len(actives))
+	for i, r := range actives {
+		ids[i] = r.id
+	}
+	trendInputs, err := s.batchTrendEvents(ids)
+	if err != nil {
+		return 0, err
+	}
+
+	count := 0
+	for _, r := range actives {
+		if deriveTrend(trendInputs[r.id], r.restartCount, r.firstSeen) == "accelerating" {
+			count++
+		}
+	}
+	return count, nil
+}
+
+// GetMemoryScoreboard summarizes a cluster's accrued incident history:
+// totals, reopen/acceleration counts, the longest-running active incident,
+// and the namespace with the most incident history.
+func (s *SQLiteStore) GetMemoryScoreboard(cluster string) (*MemoryScoreboard, error) {
+	sb := &MemoryScoreboard{}
+
+	if err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM incidents WHERE cluster = ?`, cluster,
+	).Scan(&sb.TotalSeen); err != nil {
+		return nil, err
+	}
+
+	if err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM incidents WHERE cluster = ? AND status = 'resolved'`, cluster,
+	).Scan(&sb.Resolved); err != nil {
+		return nil, err
+	}
+
+	if err := s.db.QueryRow(
+		`SELECT COUNT(DISTINCT e.incident_id) FROM incident_events e
+		 JOIN incidents i ON i.id = e.incident_id
+		 WHERE i.cluster = ? AND e.event_type = 'REOPENED'`, cluster,
+	).Scan(&sb.Reopened); err != nil {
+		return nil, err
+	}
+
+	accelerating, err := s.countAccelerating(cluster)
+	if err != nil {
+		return nil, err
+	}
+	sb.Accelerating = accelerating
+
+	var longestName sql.NullString
+	var longestFirstSeen sql.NullInt64
+	err = s.db.QueryRow(
+		`SELECT resource, first_seen FROM incidents
+		 WHERE cluster = ? AND status = 'active'
+		 ORDER BY first_seen ASC LIMIT 1`, cluster,
+	).Scan(&longestName, &longestFirstSeen)
+	if err != nil && err != sql.ErrNoRows {
+		return nil, err
+	}
+	if longestFirstSeen.Valid {
+		sb.LongestActiveName = longestName.String
+		sb.LongestActiveDays = int(time.Since(time.Unix(longestFirstSeen.Int64, 0)).Hours() / 24)
+	}
+
+	var unstableNS sql.NullString
+	var unstableCount sql.NullInt64
+	err = s.db.QueryRow(
+		`SELECT namespace, COUNT(*) AS c FROM incidents WHERE cluster = ?
+		 GROUP BY namespace ORDER BY c DESC LIMIT 1`, cluster,
+	).Scan(&unstableNS, &unstableCount)
+	if err != nil && err != sql.ErrNoRows {
+		return nil, err
+	}
+	if unstableNS.Valid {
+		sb.MostUnstableNamespace = unstableNS.String
+		sb.MostUnstableCount = int(unstableCount.Int64)
+	}
+
+	return sb, nil
+}
+
+// GetRecentEvents returns the most recent incident_events for cluster,
+// newest first, joined against their parent incident's resource name.
+func (s *SQLiteStore) GetRecentEvents(cluster string, limit int) ([]RecentEvent, error) {
+	rows, err := s.db.Query(
+		`SELECT incidents.resource, incident_events.event_reason, incident_events.occurred_at
+		 FROM incident_events
+		 JOIN incidents ON incident_events.incident_id = incidents.id
+		 WHERE incidents.cluster = ?
+		 ORDER BY incident_events.occurred_at DESC LIMIT ?`,
+		cluster, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []RecentEvent
+	for rows.Next() {
+		var resource string
+		var eventReason sql.NullString
+		var occurredAt int64
+		if err := rows.Scan(&resource, &eventReason, &occurredAt); err != nil {
+			return nil, err
+		}
+		out = append(out, RecentEvent{
+			Resource:    resource,
+			EventReason: eventReason.String,
+			OccurredAt:  time.Unix(occurredAt, 0),
+		})
+	}
+	return out, rows.Err()
+}
+
 // PruneOlderThan removes data older than cutoff for cluster, in one
 // transaction:
 //   - Resolved incidents (and their full event history) are deleted once

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -14,6 +14,8 @@ type Store interface {
 	GetIncidentHistory(cluster string, fingerprint string) (*IncidentRecord, error)
 	GetIncidentTimeline(cluster string, fingerprint string) ([]IncidentEvent, error)
 	QueryIncidents(f IncidentFilter) (items []IncidentSummary, total int, err error)
+	GetMemoryScoreboard(cluster string) (*MemoryScoreboard, error)
+	GetRecentEvents(cluster string, limit int) ([]RecentEvent, error)
 	PruneOlderThan(cluster string, cutoff time.Time) (pruned int, err error)
 	Close() error
 }
@@ -116,6 +118,26 @@ type IncidentSummary struct {
 	LastSeen     time.Time
 	RestartCount int
 	Trend        string // "accelerating" | "stable" | "recovering" | ""
+}
+
+// MemoryScoreboard summarizes a cluster's operational memory: how much
+// incident history it has accrued and how it is trending.
+type MemoryScoreboard struct {
+	TotalSeen             int
+	Resolved              int
+	Reopened              int // count of DISTINCT incidents with >=1 REOPENED event
+	Accelerating          int // count of active incidents whose Trend == "accelerating"
+	LongestActiveDays     int
+	LongestActiveName     string // resource name of that incident
+	MostUnstableNamespace string // namespace with the most incidents (active+resolved)
+	MostUnstableCount     int
+}
+
+// RecentEvent is one row of a cluster-wide recent-activity feed.
+type RecentEvent struct {
+	Resource    string
+	EventReason string // "Detected" | "Resolved" | "Reopened" | "RestartMilestone" | "SeverityChanged"
+	OccurredAt  time.Time
 }
 
 // RetentionCutoff computes the cutoff time for PruneOlderThan given a

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -15,7 +15,7 @@ type Store interface {
 	GetIncidentTimeline(cluster string, fingerprint string) ([]IncidentEvent, error)
 	QueryIncidents(f IncidentFilter) (items []IncidentSummary, total int, err error)
 	GetMemoryScoreboard(cluster string) (*MemoryScoreboard, error)
-	GetRecentEvents(cluster string, limit int) ([]RecentEvent, error)
+	GetRecentEvents(cluster string, since time.Time, limit int) ([]RecentEvent, error)
 	GetChangesSince(cluster string, since time.Time, limit int) ([]RecentEvent, error)
 	PruneOlderThan(cluster string, cutoff time.Time) (pruned int, err error)
 	Close() error

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -16,6 +16,7 @@ type Store interface {
 	QueryIncidents(f IncidentFilter) (items []IncidentSummary, total int, err error)
 	GetMemoryScoreboard(cluster string) (*MemoryScoreboard, error)
 	GetRecentEvents(cluster string, limit int) ([]RecentEvent, error)
+	GetChangesSince(cluster string, since time.Time, limit int) ([]RecentEvent, error)
 	PruneOlderThan(cluster string, cutoff time.Time) (pruned int, err error)
 	Close() error
 }

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -336,6 +336,14 @@ func TestNullStore(t *testing.T) {
 	if err != nil || tl != nil {
 		t.Fatalf("GetIncidentTimeline: %+v, %v", tl, err)
 	}
+	sb, err := s.GetMemoryScoreboard("c")
+	if err != nil || sb == nil {
+		t.Fatalf("GetMemoryScoreboard: %+v, %v", sb, err)
+	}
+	events, err := s.GetRecentEvents("c", 10)
+	if err != nil || events != nil {
+		t.Fatalf("GetRecentEvents: %+v, %v", events, err)
+	}
 	if err := s.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
@@ -1808,5 +1816,151 @@ func TestPruneOlderThan(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("expected recent scan_history kept, got %d rows", count)
+	}
+}
+
+// ── Memory scoreboard / recent events ───────────────────────────────────────
+
+// setIncidentFirstSeen backdates an incident's first_seen column directly,
+// simulating a long-lived incident without sleeping in tests. UpsertIncidents
+// never overwrites first_seen on conflict, so this survives later upserts.
+func setIncidentFirstSeen(t *testing.T, s *SQLiteStore, cluster, fingerprint string, firstSeen time.Time) {
+	t.Helper()
+	if _, err := s.db.Exec(
+		`UPDATE incidents SET first_seen=? WHERE cluster=? AND fingerprint=?`,
+		firstSeen.Unix(), cluster, fingerprint,
+	); err != nil {
+		t.Fatalf("set first_seen: %v", err)
+	}
+}
+
+// insertTestEvent writes a synthetic incident_events row with an explicit
+// occurred_at, letting ordering tests control timestamps precisely instead
+// of relying on real wall-clock gaps between fast test operations.
+func insertTestEvent(t *testing.T, s *SQLiteStore, incidentID int64, occurredAt int64, eventReason string) {
+	t.Helper()
+	if _, err := s.db.Exec(
+		`INSERT INTO incident_events (
+			incident_id, scan_id, occurred_at, event_type, event_reason,
+			restart_count, severity, state, message
+		) VALUES (?, 'test-scan', ?, 'UPDATED', ?, 0, 'warning', 'active', 'test event')`,
+		incidentID, occurredAt, eventReason,
+	); err != nil {
+		t.Fatalf("insert test event: %v", err)
+	}
+}
+
+func TestGetMemoryScoreboard(t *testing.T) {
+	s := openTestStore(t)
+	cluster := "test-cluster"
+
+	// ns-a: a1 stays active and is driven "accelerating"; a2 resolves and
+	// stays resolved.
+	a1 := IncidentData{Fingerprint: "ns-a/Deployment/svc-a1/crash_loop", Namespace: "ns-a", Resource: "svc-a1", IssueType: "crash_loop", Severity: "critical", RestartCount: 5}
+	a2 := IncidentData{Fingerprint: "ns-a/Deployment/svc-a2/oom", Namespace: "ns-a", Resource: "svc-a2", IssueType: "oom", Severity: "warning"}
+
+	// ns-b: b1 resolves then genuinely reopens; b2 resolves and stays
+	// resolved; b3 stays active with no restart movement ("stable").
+	b1 := IncidentData{Fingerprint: "ns-b/Deployment/svc-b1/crash_loop", Namespace: "ns-b", Resource: "svc-b1", IssueType: "crash_loop", Severity: "critical"}
+	b2 := IncidentData{Fingerprint: "ns-b/Deployment/svc-b2/oom", Namespace: "ns-b", Resource: "svc-b2", IssueType: "oom", Severity: "warning"}
+	b3 := IncidentData{Fingerprint: "ns-b/Deployment/svc-b3/probe_failure", Namespace: "ns-b", Resource: "svc-b3", IssueType: "probe_failure", Severity: "warning"}
+
+	if err := s.UpsertIncidents(cluster, "scan-1", []IncidentData{a1, a2, b1, b2, b3}); err != nil {
+		t.Fatalf("UpsertIncidents(initial): %v", err)
+	}
+
+	// Cross a1's 10-restart milestone so it has two DETECTED/RestartMilestone
+	// events for deriveTrend to compare.
+	time.Sleep(1100 * time.Millisecond)
+	a1.RestartCount = 20
+	if err := s.UpsertIncidents(cluster, "scan-2", []IncidentData{a1, a2, b1, b2, b3}); err != nil {
+		t.Fatalf("UpsertIncidents(a1 restart bump): %v", err)
+	}
+	// Backdate a1's first_seen so its lifetime restart rate is low, making
+	// the recent restart burst read as "accelerating" rather than "stable".
+	setIncidentFirstSeen(t, s, cluster, a1.Fingerprint, time.Now().Add(-10*24*time.Hour-time.Hour))
+
+	// Resolve a2 and b2 — absent from every scan below, they stay resolved.
+	driveToResolved(t, s, cluster, []IncidentData{a1, b1, b3}, "scan-resolve-a2b2")
+
+	// Resolve b1, then reopen it past the flap-absorption window (a genuine
+	// recurrence, not a flap).
+	driveToResolved(t, s, cluster, []IncidentData{a1, b3}, "scan-resolve-b1")
+	backdateIncidentEvents(t, s, cluster, b1.Fingerprint, flapAbsorptionWindow+time.Minute)
+	if err := s.UpsertIncidents(cluster, "scan-reopen-b1", []IncidentData{a1, b1, b3}); err != nil {
+		t.Fatalf("UpsertIncidents(reopen b1): %v", err)
+	}
+
+	sb, err := s.GetMemoryScoreboard(cluster)
+	if err != nil {
+		t.Fatalf("GetMemoryScoreboard: %v", err)
+	}
+
+	if sb.TotalSeen != 5 {
+		t.Fatalf("expected TotalSeen=5, got %d", sb.TotalSeen)
+	}
+	if sb.Resolved != 2 {
+		t.Fatalf("expected Resolved=2 (a2, b2), got %d", sb.Resolved)
+	}
+	if sb.Reopened != 1 {
+		t.Fatalf("expected Reopened=1 (b1), got %d", sb.Reopened)
+	}
+	if sb.Accelerating != 1 {
+		t.Fatalf("expected Accelerating=1 (a1), got %d", sb.Accelerating)
+	}
+	if sb.LongestActiveName != "svc-a1" {
+		t.Fatalf("expected LongestActiveName=svc-a1, got %q", sb.LongestActiveName)
+	}
+	if sb.LongestActiveDays < 9 || sb.LongestActiveDays > 11 {
+		t.Fatalf("expected LongestActiveDays ~10, got %d", sb.LongestActiveDays)
+	}
+	if sb.MostUnstableNamespace != "ns-b" {
+		t.Fatalf("expected MostUnstableNamespace=ns-b, got %q", sb.MostUnstableNamespace)
+	}
+	if sb.MostUnstableCount != 3 {
+		t.Fatalf("expected MostUnstableCount=3, got %d", sb.MostUnstableCount)
+	}
+}
+
+func TestGetRecentEvents(t *testing.T) {
+	s := openTestStore(t)
+	cluster := "test-cluster"
+
+	incA := IncidentData{Fingerprint: "default/Deployment/svc-a/crash_loop", Namespace: "default", Resource: "svc-a", IssueType: "crash_loop", Severity: "critical"}
+	incB := IncidentData{Fingerprint: "default/Deployment/svc-b/oom", Namespace: "default", Resource: "svc-b", IssueType: "oom", Severity: "warning"}
+	if err := s.UpsertIncidents(cluster, "scan-1", []IncidentData{incA, incB}); err != nil {
+		t.Fatalf("UpsertIncidents: %v", err)
+	}
+
+	var idA, idB int64
+	if err := s.db.QueryRow("SELECT id FROM incidents WHERE cluster=? AND fingerprint=?", cluster, incA.Fingerprint).Scan(&idA); err != nil {
+		t.Fatalf("lookup idA: %v", err)
+	}
+	if err := s.db.QueryRow("SELECT id FROM incidents WHERE cluster=? AND fingerprint=?", cluster, incB.Fingerprint).Scan(&idB); err != nil {
+		t.Fatalf("lookup idB: %v", err)
+	}
+
+	// idA and idB each already have a DETECTED event from UpsertIncidents
+	// above; layer two more, newest last, with explicit timestamps so
+	// ordering doesn't depend on real wall-clock gaps.
+	base := time.Now().Unix()
+	insertTestEvent(t, s, idB, base+100, "RestartMilestone") // 2nd newest
+	insertTestEvent(t, s, idA, base+200, "SeverityChanged")  // newest
+
+	events, err := s.GetRecentEvents(cluster, 2)
+	if err != nil {
+		t.Fatalf("GetRecentEvents: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected limit=2 to return 2 events, got %d: %+v", len(events), events)
+	}
+	if events[0].Resource != "svc-a" || events[0].EventReason != "SeverityChanged" {
+		t.Fatalf("expected newest event (svc-a/SeverityChanged) first, got %+v", events[0])
+	}
+	if events[1].Resource != "svc-b" || events[1].EventReason != "RestartMilestone" {
+		t.Fatalf("expected second-newest event (svc-b/RestartMilestone) second, got %+v", events[1])
+	}
+	if !events[0].OccurredAt.After(events[1].OccurredAt) {
+		t.Fatalf("expected descending order by OccurredAt: %+v vs %+v", events[0].OccurredAt, events[1].OccurredAt)
 	}
 }

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -344,6 +344,10 @@ func TestNullStore(t *testing.T) {
 	if err != nil || events != nil {
 		t.Fatalf("GetRecentEvents: %+v, %v", events, err)
 	}
+	changes, err := s.GetChangesSince("c", time.Now(), 10)
+	if err != nil || changes != nil {
+		t.Fatalf("GetChangesSince: %+v, %v", changes, err)
+	}
 	if err := s.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
@@ -1962,5 +1966,70 @@ func TestGetRecentEvents(t *testing.T) {
 	}
 	if !events[0].OccurredAt.After(events[1].OccurredAt) {
 		t.Fatalf("expected descending order by OccurredAt: %+v vs %+v", events[0].OccurredAt, events[1].OccurredAt)
+	}
+}
+
+func TestGetChangesSince(t *testing.T) {
+	s := openTestStore(t)
+	cluster := "test-cluster"
+
+	incA := IncidentData{Fingerprint: "default/Deployment/svc-a/crash_loop", Namespace: "default", Resource: "svc-a", IssueType: "crash_loop", Severity: "critical"}
+	incB := IncidentData{Fingerprint: "default/Deployment/svc-b/oom", Namespace: "default", Resource: "svc-b", IssueType: "oom", Severity: "warning"}
+	if err := s.UpsertIncidents(cluster, "scan-1", []IncidentData{incA, incB}); err != nil {
+		t.Fatalf("UpsertIncidents: %v", err)
+	}
+
+	var idA, idB int64
+	if err := s.db.QueryRow("SELECT id FROM incidents WHERE cluster=? AND fingerprint=?", cluster, incA.Fingerprint).Scan(&idA); err != nil {
+		t.Fatalf("lookup idA: %v", err)
+	}
+	if err := s.db.QueryRow("SELECT id FROM incidents WHERE cluster=? AND fingerprint=?", cluster, incB.Fingerprint).Scan(&idB); err != nil {
+		t.Fatalf("lookup idB: %v", err)
+	}
+
+	// idA and idB's DETECTED events (from UpsertIncidents above) sit well
+	// before the cursor. Layer explicit before/after events around a known
+	// cursor timestamp.
+	cursor := time.Now().Add(10 * time.Hour)
+	insertTestEvent(t, s, idA, cursor.Add(-time.Hour).Unix(), "SeverityChanged")   // before cursor: excluded
+	insertTestEvent(t, s, idB, cursor.Add(time.Minute).Unix(), "RestartMilestone") // after cursor: 2nd newest
+	insertTestEvent(t, s, idA, cursor.Add(time.Hour).Unix(), "Resolved")           // after cursor: newest
+	insertTestEvent(t, s, idB, cursor.Add(2*time.Hour).Unix(), "Reopened")         // after cursor: absolute newest, excluded by limit
+
+	events, err := s.GetChangesSince(cluster, cursor, 2)
+	if err != nil {
+		t.Fatalf("GetChangesSince: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected limit=2 to return 2 events, got %d: %+v", len(events), events)
+	}
+	if events[0].Resource != "svc-b" || events[0].EventReason != "Reopened" {
+		t.Fatalf("expected newest event (svc-b/Reopened) first, got %+v", events[0])
+	}
+	if events[1].Resource != "svc-a" || events[1].EventReason != "Resolved" {
+		t.Fatalf("expected second-newest event (svc-a/Resolved) second, got %+v", events[1])
+	}
+	if !events[0].OccurredAt.After(events[1].OccurredAt) {
+		t.Fatalf("expected descending order by OccurredAt: %+v vs %+v", events[0].OccurredAt, events[1].OccurredAt)
+	}
+	for _, e := range events {
+		if e.OccurredAt.Before(cursor) {
+			t.Fatalf("expected only events at/after cursor %v, got %+v", cursor, e)
+		}
+	}
+
+	// Raise the limit to confirm the before-cursor SeverityChanged event
+	// never appears, no matter how high the limit goes.
+	all, err := s.GetChangesSince(cluster, cursor, 10)
+	if err != nil {
+		t.Fatalf("GetChangesSince(limit=10): %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("expected 3 events at/after cursor, got %d: %+v", len(all), all)
+	}
+	for _, e := range all {
+		if e.EventReason == "SeverityChanged" {
+			t.Fatalf("expected before-cursor SeverityChanged event to be excluded, got %+v", all)
+		}
 	}
 }

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -340,7 +340,7 @@ func TestNullStore(t *testing.T) {
 	if err != nil || sb == nil {
 		t.Fatalf("GetMemoryScoreboard: %+v, %v", sb, err)
 	}
-	events, err := s.GetRecentEvents("c", 10)
+	events, err := s.GetRecentEvents("c", time.Now(), 10)
 	if err != nil || events != nil {
 		t.Fatalf("GetRecentEvents: %+v, %v", events, err)
 	}
@@ -1951,7 +1951,7 @@ func TestGetRecentEvents(t *testing.T) {
 	insertTestEvent(t, s, idB, base+100, "RestartMilestone") // 2nd newest
 	insertTestEvent(t, s, idA, base+200, "SeverityChanged")  // newest
 
-	events, err := s.GetRecentEvents(cluster, 2)
+	events, err := s.GetRecentEvents(cluster, time.Now().Add(-time.Hour), 2)
 	if err != nil {
 		t.Fatalf("GetRecentEvents: %v", err)
 	}
@@ -1966,6 +1966,64 @@ func TestGetRecentEvents(t *testing.T) {
 	}
 	if !events[0].OccurredAt.After(events[1].OccurredAt) {
 		t.Fatalf("expected descending order by OccurredAt: %+v vs %+v", events[0].OccurredAt, events[1].OccurredAt)
+	}
+}
+
+// TestGetRecentEvents_WindowExcludesOlderEvents covers the fixed lookback
+// window (e.g. 7 days) buildOverviewData now passes: events older than
+// since must be excluded even though GetRecentEvents is otherwise
+// unfiltered by event_reason, ordering and limit still apply within the
+// window.
+func TestGetRecentEvents_WindowExcludesOlderEvents(t *testing.T) {
+	s := openTestStore(t)
+	cluster := "test-cluster"
+
+	inc := IncidentData{Fingerprint: "default/Deployment/svc-a/crash_loop", Namespace: "default", Resource: "svc-a", IssueType: "crash_loop", Severity: "critical"}
+	if err := s.UpsertIncidents(cluster, "scan-1", []IncidentData{inc}); err != nil {
+		t.Fatalf("UpsertIncidents: %v", err)
+	}
+
+	var id int64
+	if err := s.db.QueryRow("SELECT id FROM incidents WHERE cluster=? AND fingerprint=?", cluster, inc.Fingerprint).Scan(&id); err != nil {
+		t.Fatalf("lookup id: %v", err)
+	}
+
+	window := 7 * 24 * time.Hour
+	since := time.Now().Add(-window)
+
+	// One event well outside the window, two inside it.
+	insertTestEvent(t, s, id, since.Add(-48*time.Hour).Unix(), "SeverityChanged") // outside: excluded
+	insertTestEvent(t, s, id, since.Add(24*time.Hour).Unix(), "RestartMilestone") // inside: 2nd newest
+	insertTestEvent(t, s, id, since.Add(6*24*time.Hour).Unix(), "Reopened")       // inside: newest
+
+	events, err := s.GetRecentEvents(cluster, since, 20)
+	if err != nil {
+		t.Fatalf("GetRecentEvents: %v", err)
+	}
+	// +1 for the DETECTED event UpsertIncidents itself emitted (well
+	// within the window, since the test runs "now").
+	if len(events) != 3 {
+		t.Fatalf("expected 3 in-window events (Detected, RestartMilestone, Reopened), got %d: %+v", len(events), events)
+	}
+	for _, e := range events {
+		if e.OccurredAt.Before(since) {
+			t.Fatalf("expected only events at/after the window start %v, got %+v", since, e)
+		}
+	}
+	if events[0].EventReason != "Detected" {
+		t.Fatalf("expected the most recent event (Detected, from UpsertIncidents) first, got %+v", events[0])
+	}
+	if events[1].EventReason != "Reopened" || events[2].EventReason != "RestartMilestone" {
+		t.Fatalf("expected descending order Reopened, RestartMilestone, got %+v then %+v", events[1], events[2])
+	}
+
+	// Limit still applies within the window.
+	limited, err := s.GetRecentEvents(cluster, since, 1)
+	if err != nil {
+		t.Fatalf("GetRecentEvents(limit=1): %v", err)
+	}
+	if len(limited) != 1 || limited[0].EventReason != "Detected" {
+		t.Fatalf("expected limit=1 to return only the newest (Detected) event, got %+v", limited)
 	}
 }
 


### PR DESCRIPTION
## Overview page redesign — Tier 1 (verdict-first, memory-backed)

Replaces the KPI-grid Overview with a verdict-first design: a written
cluster assessment leads the page, backed by operational memory that no
stateless tool (Grafana, Lens, k9s) can produce.

### What's new
- **Situation Briefing**: a two-sentence cluster verdict generated from
  the same incident data driving War Room/Top 5 — no separate/conflicting
  "worst issue" logic. Includes a resolved-since-last-visit line when
  applicable.
- **Operational Memory scoreboard**: total incidents seen, resolved,
  reopened, accelerating — plus longest-active incident and most-unstable
  namespace. All backed by `incident_events`, none of it available to a
  point-in-time tool.
- **"What's Changed Since Last Scan"**: a cursor-based feed (cookie-backed
  `last_viewed` timestamp) showing only what's happened since your last
  visit — distinct from the broader 7-day **Recent Events** feed.
- **Top 5 Things To Fix**: each row now carries a memory line (first
  detected, reopen count, trend) and routes correctly — a single-incident
  row deep-links to its Investigation page ("Fix now →"); a multi-pod
  group routes to a filtered Incidents view ("View all N →") instead of
  arbitrarily picking one pod.
- **"If you only fix one thing today"** banner: promotes the same #1 Top
  Issue, same routing rule.
- **Cluster Health / Namespace Health / Security Status**: real per-namespace
  pod-readiness ratios and a compact per-workload health strip, capped
  with "View all" links rather than rendering unbounded lists.
- Bottom strip demoted to a quiet trend-delta summary with real buttons to
  Cost Intelligence / Waste & Drift.

### Backend additions (pkg/store)
- `GetMemoryScoreboard`, `GetRecentEvents` (7-day window), `GetChangesSince`
  (cursor-based), all reusing existing `deriveTrend`/`batchTrendEvents`
  logic — no parallel heuristics.
- `ClusterResourceAnalysis.Workloads`: full workload enumeration retained
  from data already fetched during scan (no new clientset calls), enabling
  the Workload Health grid to show healthy workloads, not just ones with
  active incidents.

### Testing
Every piece unit-tested; full page rendering verified live against a real
cluster (screenshots reviewed manually across several rounds — several
real bugs found and fixed in the process: topIssue.URL hardcoded to
/warroom, verdict/Top-5 disagreement on "worst issue", Recent Events and
What's-Changed showing near-duplicate content, card height mismatches).

No functional changes to War Room, Incidents, or Investigation pages.