### PR TITLE
perf(cli): batch operational-memory lookups in emergency enrichment

### DIFF
--- a/cmd/opscart-scan/emergency.go
+++ b/cmd/opscart-scan/emergency.go
@@ -84,30 +84,39 @@ func mapIssuesToIncidents(issues []models.EmergencyIssue) []store.IncidentData {
 	return incidents
 }
 
-// enrichIssues looks up each issue's operational memory. Missing history,
-// a nil lookup, or a NullStore (stateless mode) all degrade silently to no
-// enrichment — never an error shown to the user.
+// enrichIssues looks up every issue's operational memory in two batched
+// calls covering all fingerprints at once, rather than a pair of queries
+// per issue. Missing history, a lookup error, or a NullStore (stateless
+// mode) all degrade silently to no enrichment — never an error shown to
+// the user.
 func enrichIssues(db store.Store, clusterContext string, issues []models.EmergencyIssue) []enrichedIssue {
 	enriched := make([]enrichedIssue, len(issues))
+	fingerprints := make([]string, len(issues))
 	for i, issue := range issues {
 		enriched[i] = enrichedIssue{EmergencyIssue: issue}
+		fingerprints[i] = incidentFingerprint(issue)
+	}
 
-		fingerprint := incidentFingerprint(issue)
-		rec, err := db.GetIncidentHistory(clusterContext, fingerprint)
-		if err != nil || rec == nil {
+	history, err := db.BatchGetIncidentHistory(clusterContext, fingerprints)
+	if err != nil {
+		return enriched
+	}
+
+	ids := make([]int64, 0, len(history))
+	for _, rec := range history {
+		ids = append(ids, rec.ID)
+	}
+	// A failed reopen-count lookup still leaves FirstDetected enriched
+	// below; reopenCounts stays nil, and indexing a nil map yields 0.
+	reopenCounts, _ := db.BatchGetReopenCounts(ids)
+
+	for i, fingerprint := range fingerprints {
+		rec, ok := history[fingerprint]
+		if !ok || rec == nil {
 			continue
 		}
 		enriched[i].FirstDetected = formatDuration(time.Since(rec.FirstSeen))
-
-		events, err := db.GetIncidentTimeline(clusterContext, fingerprint)
-		if err != nil {
-			continue
-		}
-		for _, e := range events {
-			if e.EventType == "REOPENED" {
-				enriched[i].ReopenCount++
-			}
-		}
+		enriched[i].ReopenCount = reopenCounts[rec.ID]
 	}
 	return enriched
 }

--- a/cmd/opscart-scan/emergency_test.go
+++ b/cmd/opscart-scan/emergency_test.go
@@ -32,6 +32,41 @@ func (f *fakeStore) GetIncidentTimeline(cluster, fingerprint string) ([]store.In
 	return f.timeline, f.timelineErr
 }
 
+// BatchGetIncidentHistory mirrors GetIncidentHistory's single fake record
+// across every requested fingerprint, so tests written against the old
+// per-issue API still exercise the same scenarios against the batched one.
+func (f *fakeStore) BatchGetIncidentHistory(cluster string, fingerprints []string) (map[string]*store.IncidentRecord, error) {
+	if f.historyErr != nil {
+		return nil, f.historyErr
+	}
+	out := make(map[string]*store.IncidentRecord)
+	if f.history != nil {
+		for _, fp := range fingerprints {
+			out[fp] = f.history
+		}
+	}
+	return out, nil
+}
+
+// BatchGetReopenCounts mirrors GetIncidentTimeline's fake REOPENED count
+// for every requested id.
+func (f *fakeStore) BatchGetReopenCounts(ids []int64) (map[int64]int, error) {
+	if f.timelineErr != nil {
+		return nil, f.timelineErr
+	}
+	count := 0
+	for _, e := range f.timeline {
+		if e.EventType == "REOPENED" {
+			count++
+		}
+	}
+	out := make(map[int64]int, len(ids))
+	for _, id := range ids {
+		out[id] = count
+	}
+	return out, nil
+}
+
 func (f *fakeStore) UpsertIncidents(cluster, scanID string, incidents []store.IncidentData) error {
 	return f.upsertErr
 }
@@ -102,6 +137,93 @@ func TestMapIssuesToIncidents(t *testing.T) {
 	}
 	if !strings.Contains(inc.DetailsJSON, "crash looping") {
 		t.Errorf("DetailsJSON missing message, got %s", inc.DetailsJSON)
+	}
+}
+
+// countingStore counts calls made to each Store lookup method, so tests can
+// assert enrichIssues batches its operational-memory lookups instead of
+// regressing to the old N+1 pattern of one GetIncidentHistory/
+// GetIncidentTimeline call per issue.
+type countingStore struct {
+	store.NullStore
+
+	historyCalls      int // legacy per-fingerprint GetIncidentHistory
+	timelineCalls     int // legacy per-fingerprint GetIncidentTimeline
+	batchHistoryCalls int
+	batchReopenCalls  int
+
+	records      map[string]*store.IncidentRecord
+	reopenCounts map[int64]int
+}
+
+func (c *countingStore) GetIncidentHistory(cluster, fingerprint string) (*store.IncidentRecord, error) {
+	c.historyCalls++
+	return nil, nil
+}
+
+func (c *countingStore) GetIncidentTimeline(cluster, fingerprint string) ([]store.IncidentEvent, error) {
+	c.timelineCalls++
+	return nil, nil
+}
+
+func (c *countingStore) BatchGetIncidentHistory(cluster string, fingerprints []string) (map[string]*store.IncidentRecord, error) {
+	c.batchHistoryCalls++
+	out := make(map[string]*store.IncidentRecord)
+	for _, fp := range fingerprints {
+		if rec, ok := c.records[fp]; ok {
+			out[fp] = rec
+		}
+	}
+	return out, nil
+}
+
+func (c *countingStore) BatchGetReopenCounts(ids []int64) (map[int64]int, error) {
+	c.batchReopenCalls++
+	out := make(map[int64]int, len(ids))
+	for _, id := range ids {
+		out[id] = c.reopenCounts[id]
+	}
+	return out, nil
+}
+
+func TestEnrichIssues_BatchesLookups_NoPerIssueQueries(t *testing.T) {
+	issues := []models.EmergencyIssue{
+		{Namespace: "prod", Name: "checkout-7d9f8b6c5-x7z2m9", Reason: "CrashLoopBackOff", Severity: "critical"},
+		{Namespace: "prod", Name: "billing-6c9f8b6c5-x7z2m9", Reason: "OOMKilled", Severity: "critical"},
+		{Namespace: "prod", Name: "auth-5c9f8b6c5-x7z2m9", Reason: "CrashLoopBackOff", Severity: "high"},
+	}
+	fp0 := incidentFingerprint(issues[0])
+	fp1 := incidentFingerprint(issues[1])
+
+	cs := &countingStore{
+		records: map[string]*store.IncidentRecord{
+			fp0: {ID: 1, FirstSeen: time.Now().Add(-2 * 24 * time.Hour)},
+			fp1: {ID: 2, FirstSeen: time.Now().Add(-1 * time.Hour)},
+			// issues[2]'s fingerprint has no record: brand-new issue.
+		},
+		reopenCounts: map[int64]int{1: 3, 2: 0},
+	}
+
+	enriched := enrichIssues(cs, "prod-cluster", issues)
+
+	if cs.historyCalls != 0 || cs.timelineCalls != 0 {
+		t.Fatalf("expected no per-issue lookups, got historyCalls=%d timelineCalls=%d", cs.historyCalls, cs.timelineCalls)
+	}
+	if cs.batchHistoryCalls != 1 {
+		t.Errorf("batchHistoryCalls = %d, want exactly 1 regardless of issue count", cs.batchHistoryCalls)
+	}
+	if cs.batchReopenCalls != 1 {
+		t.Errorf("batchReopenCalls = %d, want exactly 1 regardless of issue count", cs.batchReopenCalls)
+	}
+
+	if enriched[0].FirstDetected != "2d" || enriched[0].ReopenCount != 3 {
+		t.Errorf("issue 0 = %+v, want FirstDetected=2d ReopenCount=3", enriched[0])
+	}
+	if enriched[1].FirstDetected != "1h" || enriched[1].ReopenCount != 0 {
+		t.Errorf("issue 1 = %+v, want FirstDetected=1h ReopenCount=0", enriched[1])
+	}
+	if enriched[2].FirstDetected != "" || enriched[2].ReopenCount != 0 {
+		t.Errorf("issue 2 (no history) = %+v, want zero enrichment", enriched[2])
 	}
 }
 

--- a/pkg/store/null.go
+++ b/pkg/store/null.go
@@ -40,6 +40,14 @@ func (NullStore) GetIncidentTimeline(cluster string, fingerprint string) ([]Inci
 	return nil, nil
 }
 
+func (NullStore) BatchGetIncidentHistory(cluster string, fingerprints []string) (map[string]*IncidentRecord, error) {
+	return nil, nil
+}
+
+func (NullStore) BatchGetReopenCounts(ids []int64) (map[int64]int, error) {
+	return nil, nil
+}
+
 func (NullStore) QueryIncidents(f IncidentFilter) ([]IncidentSummary, int, error) {
 	return nil, 0, nil
 }

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -754,6 +754,61 @@ func (s *SQLiteStore) GetIncidentTimeline(cluster string, fingerprint string) ([
 	return out, rows.Err()
 }
 
+// BatchGetIncidentHistory returns operational-memory history for every
+// fingerprint in fingerprints, keyed by fingerprint. One query for the
+// whole set — never one query per fingerprint. Fingerprints with no
+// matching incident are simply absent from the returned map.
+func (s *SQLiteStore) BatchGetIncidentHistory(cluster string, fingerprints []string) (map[string]*IncidentRecord, error) {
+	out := make(map[string]*IncidentRecord, len(fingerprints))
+	if len(fingerprints) == 0 {
+		return out, nil
+	}
+
+	placeholders := make([]string, len(fingerprints))
+	args := make([]any, 0, len(fingerprints)+1)
+	args = append(args, cluster)
+	for i, fp := range fingerprints {
+		placeholders[i] = "?"
+		args = append(args, fp)
+	}
+
+	rows, err := s.db.Query(fmt.Sprintf(
+		`SELECT id, fingerprint, first_seen, last_seen, status, details_json
+		 FROM incidents
+		 WHERE cluster = ? AND fingerprint IN (%s)`,
+		strings.Join(placeholders, ","),
+	), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id, firstSeen, lastSeen int64
+		var fingerprint string
+		var status, detailsJSON sql.NullString
+		if err := rows.Scan(&id, &fingerprint, &firstSeen, &lastSeen, &status, &detailsJSON); err != nil {
+			return nil, err
+		}
+		out[fingerprint] = &IncidentRecord{
+			ID:          id,
+			Fingerprint: fingerprint,
+			FirstSeen:   time.Unix(firstSeen, 0),
+			LastSeen:    time.Unix(lastSeen, 0),
+			Status:      status.String,
+			DetailsJSON: detailsJSON.String,
+		}
+	}
+	return out, rows.Err()
+}
+
+// BatchGetReopenCounts exports batchReopenCounts (already used internally
+// by QueryIncidents) for callers outside this package that need reopen
+// counts for a batch of incident ids without a per-id query.
+func (s *SQLiteStore) BatchGetReopenCounts(ids []int64) (map[int64]int, error) {
+	return s.batchReopenCounts(ids)
+}
+
 // inClause builds a "?,?,?" placeholder string and matching args slice for
 // an IN(...) clause over ids. Callers must guard len(ids) == 0 themselves
 // (an empty IN() is invalid SQL).

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -13,6 +13,8 @@ type Store interface {
 	GetLatestSnapshot(cluster string) (*SnapshotData, error)
 	GetIncidentHistory(cluster string, fingerprint string) (*IncidentRecord, error)
 	GetIncidentTimeline(cluster string, fingerprint string) ([]IncidentEvent, error)
+	BatchGetIncidentHistory(cluster string, fingerprints []string) (map[string]*IncidentRecord, error)
+	BatchGetReopenCounts(ids []int64) (map[int64]int, error)
 	QueryIncidents(f IncidentFilter) (items []IncidentSummary, total int, err error)
 	GetMemoryScoreboard(cluster string) (*MemoryScoreboard, error)
 	GetRecentEvents(cluster string, since time.Time, limit int) ([]RecentEvent, error)
@@ -70,6 +72,7 @@ type OverviewTrend struct {
 }
 
 type IncidentRecord struct {
+	ID          int64 // 0 when unset (e.g. GetIncidentHistory does not look it up)
 	Fingerprint string
 	FirstSeen   time.Time
 	LastSeen    time.Time

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -583,6 +584,133 @@ func TestTimeline_ReopenedAfterResolve(t *testing.T) {
 	}
 	if events[2].EventType != "REOPENED" || events[2].EventReason != "Reopened" {
 		t.Fatalf("event[2] = %+v", events[2])
+	}
+}
+
+// ── Batched incident lookups ────────────────────────────────────────────────
+
+// TestBatchGetIncidentHistory_ReturnsAllKeyed seeds 5 incidents and confirms
+// a single BatchGetIncidentHistory call returns every one of them, correctly
+// keyed by fingerprint, plus its incident id (needed to chain into
+// BatchGetReopenCounts) — rather than requiring one GetIncidentHistory call
+// per fingerprint.
+func TestBatchGetIncidentHistory_ReturnsAllKeyed(t *testing.T) {
+	s := openTestStore(t)
+
+	var incs []IncidentData
+	for i := 0; i < 5; i++ {
+		incs = append(incs, IncidentData{
+			Fingerprint: fmt.Sprintf("default/Deployment/svc-%d/crash_loop", i),
+			Namespace:   "default",
+			Resource:    fmt.Sprintf("svc-%d", i),
+			IssueType:   "crash_loop",
+			Severity:    "critical",
+			DetailsJSON: fmt.Sprintf(`{"n":%d}`, i),
+		})
+	}
+	if err := s.UpsertIncidents("test-cluster", "scan-1", incs); err != nil {
+		t.Fatalf("UpsertIncidents: %v", err)
+	}
+	// A fingerprint with no incident must simply be absent from the result.
+	fingerprints := []string{
+		"default/Deployment/svc-0/crash_loop",
+		"default/Deployment/svc-1/crash_loop",
+		"default/Deployment/svc-2/crash_loop",
+		"default/Deployment/svc-3/crash_loop",
+		"default/Deployment/svc-4/crash_loop",
+		"default/Deployment/nonexistent/crash_loop",
+	}
+
+	got, err := s.BatchGetIncidentHistory("test-cluster", fingerprints)
+	if err != nil {
+		t.Fatalf("BatchGetIncidentHistory: %v", err)
+	}
+	if len(got) != 5 {
+		t.Fatalf("expected 5 records, got %d: %+v", len(got), got)
+	}
+	if _, ok := got["default/Deployment/nonexistent/crash_loop"]; ok {
+		t.Fatalf("expected no record for a fingerprint with no incident")
+	}
+
+	seenIDs := make(map[int64]bool)
+	for i, inc := range incs {
+		rec, ok := got[inc.Fingerprint]
+		if !ok {
+			t.Fatalf("missing record for %s", inc.Fingerprint)
+		}
+		if rec.Fingerprint != inc.Fingerprint {
+			t.Errorf("record %d: Fingerprint = %q, want %q", i, rec.Fingerprint, inc.Fingerprint)
+		}
+		if rec.Status != "active" {
+			t.Errorf("record %d: Status = %q, want active", i, rec.Status)
+		}
+		if rec.ID == 0 {
+			t.Errorf("record %d: expected non-zero incident id", i)
+		}
+		if seenIDs[rec.ID] {
+			t.Errorf("record %d: id %d reused across incidents", i, rec.ID)
+		}
+		seenIDs[rec.ID] = true
+		if !strings.Contains(rec.DetailsJSON, fmt.Sprintf(`"n":%d`, i)) {
+			t.Errorf("record %d: DetailsJSON = %q, want it to contain n:%d", i, rec.DetailsJSON, i)
+		}
+	}
+}
+
+func TestBatchGetIncidentHistory_EmptyInput(t *testing.T) {
+	s := openTestStore(t)
+	got, err := s.BatchGetIncidentHistory("test-cluster", nil)
+	if err != nil {
+		t.Fatalf("BatchGetIncidentHistory: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty result for empty input, got %+v", got)
+	}
+}
+
+// TestBatchGetReopenCounts_MatchesQueryIncidentsReopenCount confirms the
+// exported BatchGetReopenCounts wrapper returns the same counts QueryIncidents
+// already derives internally via the unexported batchReopenCounts it wraps.
+func TestBatchGetReopenCounts_MatchesQueryIncidentsReopenCount(t *testing.T) {
+	s := openTestStore(t)
+
+	inc := IncidentData{Fingerprint: "default/Deployment/svc-a/crash_loop", Namespace: "default", Resource: "svc-a", IssueType: "crash_loop", Severity: "critical"}
+	if err := s.UpsertIncidents("test-cluster", "scan-1", []IncidentData{inc}); err != nil {
+		t.Fatalf("UpsertIncidents(1): %v", err)
+	}
+	driveToResolved(t, s, "test-cluster", nil, "scan-miss")
+	backdateIncidentEvents(t, s, "test-cluster", inc.Fingerprint, flapAbsorptionWindow+time.Minute)
+	if err := s.UpsertIncidents("test-cluster", "scan-reopen", []IncidentData{inc}); err != nil {
+		t.Fatalf("UpsertIncidents(reopen): %v", err)
+	}
+
+	rec, err := s.GetIncidentHistory("test-cluster", inc.Fingerprint)
+	if err != nil || rec == nil {
+		t.Fatalf("GetIncidentHistory: %v, %+v", err, rec)
+	}
+
+	var incidentID int64
+	if err := s.db.QueryRow(
+		"SELECT id FROM incidents WHERE cluster=? AND fingerprint=?",
+		"test-cluster", inc.Fingerprint,
+	).Scan(&incidentID); err != nil {
+		t.Fatalf("lookup incident id: %v", err)
+	}
+
+	counts, err := s.BatchGetReopenCounts([]int64{incidentID})
+	if err != nil {
+		t.Fatalf("BatchGetReopenCounts: %v", err)
+	}
+	if counts[incidentID] != 1 {
+		t.Fatalf("BatchGetReopenCounts[%d] = %d, want 1", incidentID, counts[incidentID])
+	}
+
+	items, _, err := s.QueryIncidents(IncidentFilter{Cluster: "test-cluster"})
+	if err != nil {
+		t.Fatalf("QueryIncidents: %v", err)
+	}
+	if len(items) != 1 || items[0].ReopenCount != counts[incidentID] {
+		t.Fatalf("QueryIncidents ReopenCount diverges from BatchGetReopenCounts: %+v vs %d", items, counts[incidentID])
 	}
 }
 


### PR DESCRIPTION
enrichIssues was calling GetIncidentHistory + GetIncidentTimeline once per issue (~140 SQLite round-trips for 70 issues), confirmed via real corp-cluster testing to cause a ~3 minute delay. Added BatchGetIncidentHistory + BatchGetReopenCounts (thin wrapper around the existing batchReopenCounts already used by QueryIncidents) — reduces to 2 queries total regardless of issue count. Output format unchanged.