### PR TITLE
fix: single classification per pod (priority order, one fingerprint)

### DIFF
--- a/cmd/opscart-scan/emergency.go
+++ b/cmd/opscart-scan/emergency.go
@@ -24,7 +24,6 @@ type enrichedIssue struct {
 	FirstDetected string // formatDuration(time since first seen); "" when no history
 	ReopenCount   int
 	firstSeenAt   time.Time // raw form of FirstDetected, used only to pick a group's representative
-	probeFailure  bool      // true when a CrashLoopBackOff pod's recent events show a probe-failure signature (see annotateProbeFailures)
 }
 
 func runEmergencyScan(clusterContext string) error {
@@ -34,29 +33,175 @@ func runEmergencyScan(clusterContext string) error {
 		return fmt.Errorf("connecting to cluster: %w", err)
 	}
 
-	issues, err := s.FindEmergencyIssues(namespace)
+	rawIssues, err := s.FindEmergencyIssues(namespace)
 	if err != nil {
 		return fmt.Errorf("scanning cluster: %w", err)
 	}
+
+	probeFailures := detectProbeFailures(clusterContext, rawIssues)
+	issues := classifyIssues(rawIssues, probeFailures)
 
 	// Persist findings to operational memory (best-effort, never blocks
 	// printing results — this is secondary to the CLI's primary job).
 	persistFindings(opStore, clusterContext, newScanID(), issues)
 
 	enriched := enrichIssues(opStore, clusterContext, issues)
-	enriched = annotateProbeFailures(clusterContext, enriched)
+	enriched = applyCriticalDebounce(opStore, clusterContext, enriched)
 	printEmergencyIssuesEnriched(os.Stdout, enriched)
 	return nil
 }
 
-// annotateProbeFailures checks each CrashLoopBackOff issue's recent pod
-// events for a probe-failure signature (see hasProbeFailureSignature) and
-// records the result on the issue for mergeCrashLoopOOM/printCriticalItem
-// to act on at print time. Best-effort: a pod with no CrashLoopBackOff
-// issues never triggers a clientset connection at all, and any lookup
-// failure (can't connect, can't list events for one pod) just leaves that
-// issue's classification as plain CrashLoopBackOff — exactly like today.
-func annotateProbeFailures(clusterContext string, issues []enrichedIssue) []enrichedIssue {
+// classifiablePodReasons is the set of per-container "health" reasons
+// analyzePodForIssues (pkg/scanner/cluster.go) can emit for a pod:
+// CrashLoopBackOff, OOMKilled, ImagePullBackOff/ErrImagePull, and
+// HighRestartCount are each their own independent `if`, not an if/else
+// chain, so the SAME pod commonly produces two or more of these in a
+// single scan (e.g. a container with >10 restarts that also happens to
+// be Waiting in CrashLoopBackOff this instant satisfies both the
+// CrashLoopBackOff check and the HighRestartCount check at once). A
+// crash-looping pod's own brief post-backoff Running window can also
+// make different single reasons from this set appear on consecutive
+// scans, even with no real change in the pod's health. classifyPod
+// collapses whichever of these reasons a pod has this run into exactly
+// one verdict, so a physical pod problem never produces more than one
+// fingerprint/incident. Reasons outside this set (PodFailed, Pending,
+// PVC issues) are unaffected — classifyIssues passes them through
+// untouched.
+var classifiablePodReasons = map[string]bool{
+	"CrashLoopBackOff": true,
+	"OOMKilled":        true,
+	"ImagePullBackOff": true,
+	"ErrImagePull":     true,
+	"HighRestartCount": true,
+}
+
+// classifyPod picks exactly one issue to represent a single pod's
+// classifiable issues (see classifiablePodReasons), in this exact
+// priority order, first match wins:
+//
+//  1. OOMKilled + CrashLoopBackOff -> "CrashLoopBackOff (OOMKilled)", CRITICAL
+//  2. ProbeFailure signature + CrashLoopBackOff -> "CrashLoopBackOff (ProbeFailure)", CRITICAL
+//  3. Plain CrashLoopBackOff (neither of the above) -> "CrashLoopBackOff", CRITICAL
+//  4. ImagePullBackOff / ErrImagePull -> unchanged (HIGH, exactly as the scanner classifies it)
+//  5. HighRestartCount, only if none of 1-4 matched -> "HighRestartCount", MEDIUM
+//  6. Otherwise -> ok is false: podIssues held nothing classifiable
+//
+// One case sits outside that 6-step list but is required to preserve
+// pre-existing behavior: OOMKilled with NO CrashLoopBackOff present.
+// cs.LastTerminationState is sticky — it keeps reporting "OOMKilled"
+// until the container's next restart, long after the container is back
+// to Running — so a pod that OOM'd once and stabilized still carries a
+// live OOMKilled signal indefinitely. That's already CRITICAL and no
+// less real for lacking a current crash loop, so it's checked directly
+// after case 3, before ImagePullBackOff/HighRestartCount, on the same
+// "CRITICAL beats everything below it" logic as cases 1-3.
+//
+// probeFailure is detectProbeFailures' pre-computed result for this pod:
+// checking recent events needs a clientset call per pod, done once up
+// front (see detectProbeFailures) rather than inside this pure function.
+//
+// podIssues must all share the same namespace/name (one physical pod);
+// callers (classifyIssues, tests) are responsible for that grouping.
+func classifyPod(podIssues []models.EmergencyIssue, probeFailure bool) (models.EmergencyIssue, bool) {
+	var crashLoop, oom, imagePull, highRestart *models.EmergencyIssue
+	for i := range podIssues {
+		switch podIssues[i].Reason {
+		case "CrashLoopBackOff":
+			crashLoop = &podIssues[i]
+		case "OOMKilled":
+			oom = &podIssues[i]
+		case "ImagePullBackOff", "ErrImagePull":
+			imagePull = &podIssues[i]
+		case "HighRestartCount":
+			highRestart = &podIssues[i]
+		}
+	}
+
+	if crashLoop != nil && oom != nil {
+		out := *crashLoop
+		out.Reason = "CrashLoopBackOff (OOMKilled)"
+		container := extractCrashLoopContainer(crashLoop.Message)
+		out.Message = fmt.Sprintf("Container %s is being OOM-killed, causing the crash loop — check resources.limits.memory", container)
+		return out, true
+	}
+	if crashLoop != nil && probeFailure {
+		out := *crashLoop
+		out.Reason = "CrashLoopBackOff (ProbeFailure)"
+		container := extractCrashLoopContainer(crashLoop.Message)
+		out.Message = fmt.Sprintf("Container %s is being killed by its startup/liveness probe before it can stabilize — check probe initialDelaySeconds/periodSeconds/failureThreshold against actual container startup time", container)
+		return out, true
+	}
+	if crashLoop != nil {
+		return *crashLoop, true
+	}
+	if oom != nil {
+		return *oom, true
+	}
+	if imagePull != nil {
+		return *imagePull, true
+	}
+	if highRestart != nil {
+		return *highRestart, true
+	}
+	return models.EmergencyIssue{}, false
+}
+
+// classifyIssues is this task's root fix applied to a full scan: every
+// pod-resource issue whose Reason is in classifiablePodReasons is grouped
+// by pod and reduced to classifyPod's single verdict. Every other issue —
+// a non-pod resource (e.g. PVC) or a pod issue classifyPod doesn't cover
+// (PodFailed, Pending) — passes through untouched, exactly once. A pod's
+// classified verdict takes the position of that pod's first classifiable
+// raw issue, so scan order is preserved as closely as collapsing allows.
+func classifyIssues(issues []models.EmergencyIssue, probeFailureByPod map[string]bool) []models.EmergencyIssue {
+	groups := make(map[string][]models.EmergencyIssue)
+	slot := make(map[string]int)
+	var podOrder []string
+
+	out := make([]models.EmergencyIssue, 0, len(issues))
+	for _, iss := range issues {
+		if iss.Resource != "pod" || !classifiablePodReasons[iss.Reason] {
+			out = append(out, iss)
+			continue
+		}
+		key := podKey(iss.Namespace, iss.Name)
+		if _, seen := groups[key]; !seen {
+			podOrder = append(podOrder, key)
+			slot[key] = len(out)
+			out = append(out, models.EmergencyIssue{})
+		}
+		groups[key] = append(groups[key], iss)
+	}
+
+	for _, key := range podOrder {
+		if classified, ok := classifyPod(groups[key], probeFailureByPod[key]); ok {
+			out[slot[key]] = classified
+		}
+	}
+
+	// Drop the zero-value placeholder for any pod whose classifiable
+	// issues, against all expectation, still failed to classify (see
+	// classifyPod's step 6) — every reason in classifiablePodReasons is
+	// handled explicitly above, so this is defensive, not reachable today.
+	filtered := out[:0]
+	for _, iss := range out {
+		if iss.Reason == "" && iss.Name == "" && iss.Namespace == "" {
+			continue
+		}
+		filtered = append(filtered, iss)
+	}
+	return filtered
+}
+
+// detectProbeFailures checks, for every distinct pod with a raw
+// CrashLoopBackOff issue in issues, whether its recent events show a
+// probe-failure signature (see hasProbeFailureSignature) — the input
+// classifyPod's priority 2 needs. Best-effort: a scan with no
+// CrashLoopBackOff issues never triggers a clientset connection at all,
+// and any lookup failure (can't connect, can't list events for one pod)
+// just leaves that pod out of the returned map, which classifyPod treats
+// identically to "no signature found".
+func detectProbeFailures(clusterContext string, issues []models.EmergencyIssue) map[string]bool {
 	hasCrashLoop := false
 	for _, issue := range issues {
 		if issue.Reason == "CrashLoopBackOff" {
@@ -65,27 +210,32 @@ func annotateProbeFailures(clusterContext string, issues []enrichedIssue) []enri
 		}
 	}
 	if !hasCrashLoop {
-		return issues
+		return nil
 	}
 
 	clientset, err := getKubernetesClient(clusterContext)
 	if err != nil {
 		log.Printf("opscart-scan: could not check probe-failure events: %v", err)
-		return issues
+		return nil
 	}
 
-	for i, issue := range issues {
+	result := make(map[string]bool)
+	for _, issue := range issues {
 		if issue.Reason != "CrashLoopBackOff" {
 			continue
+		}
+		key := podKey(issue.Namespace, issue.Name)
+		if _, done := result[key]; done {
+			continue // already checked this pod (multi-container case)
 		}
 		messages, err := recentPodEventMessages(clientset, issue.Namespace, issue.Name)
 		if err != nil {
 			log.Printf("opscart-scan: could not list events for %s/%s: %v", issue.Namespace, issue.Name, err)
 			continue
 		}
-		issues[i].probeFailure = hasProbeFailureSignature(messages)
+		result[key] = hasProbeFailureSignature(messages)
 	}
-	return issues
+	return result
 }
 
 // hasProbeFailureSignature reports whether any event message shows a
@@ -109,6 +259,132 @@ func hasProbeFailureSignature(messages []string) bool {
 		}
 	}
 	return false
+}
+
+// criticalDebounceReasons are every Reason classifyPod can produce at
+// CRITICAL severity — the crash-loop family whose underlying symptom (a
+// crash loop, an OOM kill) is one Kubernetes' own exponential backoff can
+// make transiently invisible to a single point-in-time scan. A
+// crash-looping pod cycles crash -> wait -> briefly Running -> crash
+// again, and a scan landing in that "briefly Running" window sees only
+// a high restart count (HighRestartCount, MEDIUM) instead of the
+// CrashLoopBackOff/OOMKilled that's still, moments later, exactly what
+// it is.
+var criticalDebounceReasons = []string{
+	"CrashLoopBackOff (OOMKilled)",
+	"CrashLoopBackOff (ProbeFailure)",
+	"CrashLoopBackOff",
+	"OOMKilled",
+}
+
+// applyCriticalDebounce is this task's fix: consult operational memory
+// before letting a pod's severity drop below CRITICAL for this run's
+// display. It mirrors what ResolveMissing's 3-consecutive-scan
+// missing_scans counter already does for the dashboard (pkg/store/
+// sqlite.go) — treat a single contradicting live snapshot as noise, not
+// truth, when memory disagrees — applied here to the CLI's classification
+// step instead of the store's resolve step.
+//
+// For every issue about to display below CRITICAL, it checks whether an
+// active CRITICAL incident already exists in memory for the same pod
+// under one of criticalDebounceReasons. If so, this run's display keeps
+// the issue at CRITICAL under that reason, on the theory that a pod
+// which was crash-looping moments ago and has no confirmed resolution
+// yet is still crash-looping now, not fixed. A brand-new issue with no
+// prior CRITICAL history is left exactly as classified — this never
+// inflates a genuinely new, milder problem. A RESOLVED incident is never
+// resurrected, since only Status == "active" qualifies.
+//
+// This affects only what THIS run prints/counts. persistFindings (see
+// above) already wrote and resolved this scan's classified findings
+// before this function runs, and the store's own ResolveMissing debounce
+// remains the sole authority on when an incident is actually resolved —
+// this function never touches that pipeline.
+//
+// In --stateless mode, this smoothing has no effect — a pod's severity
+// can still flicker scan-to-scan, since there is no memory to defend the
+// previous classification. This is an inherent tradeoff of choosing no
+// persistence, not a bug. No explicit stateless check is needed: on
+// NullStore, BatchGetIncidentHistory always returns an empty map (see
+// pkg/store/null.go), so the lookup below naturally finds nothing and
+// today's exact live-classification behavior falls through unchanged.
+//
+// classifyIssues (see above) already guarantees at most one issue per pod
+// by the time issues reaches this function, so the alreadyCritical guard
+// below only ever needs to skip a pod whose single issue is already
+// CRITICAL under one of criticalDebounceReasons — it can no longer also
+// be defending against a second, coexisting non-critical entry for that
+// same pod.
+func applyCriticalDebounce(db store.Store, clusterContext string, issues []enrichedIssue) []enrichedIssue {
+	alreadyCritical := make(map[string]bool)
+	var candidates []string
+	for _, issue := range issues {
+		if issue.Resource != "pod" {
+			continue
+		}
+		if issue.Severity == "critical" {
+			if isCriticalDebounceReason(issue.Reason) {
+				alreadyCritical[podKey(issue.Namespace, issue.Name)] = true
+			}
+			continue
+		}
+		owner := store.OwnerNameFromPod(issue.Name)
+		for _, reason := range criticalDebounceReasons {
+			candidates = append(candidates, store.Fingerprint(issue.Namespace, "Workload", owner, reason))
+		}
+	}
+	if len(candidates) == 0 {
+		return issues
+	}
+
+	history, err := db.BatchGetIncidentHistory(clusterContext, candidates)
+	if err != nil || len(history) == 0 {
+		return issues
+	}
+
+	for i, issue := range issues {
+		if issue.Resource != "pod" || issue.Severity == "critical" {
+			continue
+		}
+		if alreadyCritical[podKey(issue.Namespace, issue.Name)] {
+			continue
+		}
+		owner := store.OwnerNameFromPod(issue.Name)
+		for _, reason := range criticalDebounceReasons {
+			rec, ok := history[store.Fingerprint(issue.Namespace, "Workload", owner, reason)]
+			if !ok || rec == nil || rec.Status != "active" {
+				continue
+			}
+			issues[i].Severity = "critical"
+			issues[i].Reason = reason
+			issues[i].Message = criticalDebounceMessage(reason)
+			break
+		}
+	}
+	return issues
+}
+
+// isCriticalDebounceReason reports whether reason is one of
+// criticalDebounceReasons.
+func isCriticalDebounceReason(reason string) bool {
+	for _, r := range criticalDebounceReasons {
+		if reason == r {
+			return true
+		}
+	}
+	return false
+}
+
+// criticalDebounceMessage produces the display message for a pod
+// relabeled by applyCriticalDebounce — deliberately distinct from the
+// scanner's own CrashLoopBackOff/OOMKilled messages (cluster.go), which
+// name the specific container from a live probe this run didn't take, so
+// as not to imply detail this scan didn't actually observe.
+func criticalDebounceMessage(reason string) string {
+	if reason == "OOMKilled" {
+		return "Pod's container was OOMKilled and has not been confirmed resolved; this scan caught it between kills"
+	}
+	return "Pod is in an active CrashLoopBackOff cycle; this scan caught it mid-backoff, during its brief Running window"
 }
 
 // persistFindings writes this scan's findings to operational memory and
@@ -193,11 +469,14 @@ func enrichIssues(db store.Store, clusterContext string, issues []models.Emergen
 // grouping and box-drawing style exactly, with memory-context lines
 // appended to each issue block when available.
 //
-// Before printing, HIGH and MEDIUM tiers are deduplicated and lightly
-// grouped (see dedupeHighTier, dedupeMediumTier, groupIssues below) to
-// collapse redundant entries that describe the same underlying workload
-// problem. CRITICAL stays one-line-per-pod, unchanged, as it's the tier
-// operators act on first and its detail shouldn't be compressed.
+// Before printing, HIGH and MEDIUM tiers are lightly grouped (see
+// dedupeHighTier, groupIssues below) to collapse redundant entries that
+// describe the same underlying workload problem across DIFFERENT pods.
+// CRITICAL stays one-line-per-pod, unchanged, as it's the tier operators
+// act on first and its detail shouldn't be compressed. Unlike HIGH/MEDIUM,
+// CRITICAL needs no same-pod dedup here: classifyIssues (see above)
+// already guarantees at most one issue per pod before issues ever reaches
+// this function.
 func printEmergencyIssuesEnriched(w io.Writer, issues []enrichedIssue) {
 	if len(issues) == 0 {
 		fmt.Fprintln(w, "✅ No critical issues found!")
@@ -216,28 +495,25 @@ func printEmergencyIssuesEnriched(w io.Writer, issues []enrichedIssue) {
 		}
 	}
 
-	medium = dedupeMediumTier(medium, critical)
 	high = dedupeHighTier(high)
-	criticalItems := mergeCrashLoopOOM(critical)
 	highGroups := groupIssues(high)
 	mediumGroups := groupIssues(medium)
 
 	fmt.Fprintln(w, "╔════════════════════════════════════════════════════════════╗")
 	fmt.Fprintln(w, "║             WAR ROOM - EMERGENCY ISSUES                    ║")
 	fmt.Fprintln(w, "╚════════════════════════════════════════════════════════════╝")
-	// These counts are printed-entry counts (a 3-pod group or a merged
-	// pair counts as 1), not underlying pod counts — the header answers
-	// "how many things do I need to read," and must match what a reader
-	// can literally count below it. Underlying pod counts still show up
-	// inside a grouped entry's own title/body (e.g. "3 pods cannot pull
-	// image from ...").
-	fmt.Fprintf(w, "\n🔴 CRITICAL: %d    🟡 HIGH: %d    🟠 MEDIUM: %d\n\n", len(criticalItems), len(highGroups), len(mediumGroups))
+	// These counts are printed-entry counts (a 3-pod group counts as 1),
+	// not underlying pod counts — the header answers "how many things do
+	// I need to read," and must match what a reader can literally count
+	// below it. Underlying pod counts still show up inside a grouped
+	// entry's own title/body (e.g. "3 pods cannot pull image from ...").
+	fmt.Fprintf(w, "\n🔴 CRITICAL: %d    🟡 HIGH: %d    🟠 MEDIUM: %d\n\n", len(critical), len(highGroups), len(mediumGroups))
 
-	if len(criticalItems) > 0 {
+	if len(critical) > 0 {
 		fmt.Fprintln(w, "🔴 CRITICAL ISSUES:")
 		fmt.Fprintln(w, strings.Repeat("═", 80))
-		for _, item := range criticalItems {
-			printCriticalItem(w, item)
+		for _, issue := range critical {
+			printEnrichedIssue(w, issue)
 		}
 		fmt.Fprintln(w)
 	}
@@ -259,38 +535,19 @@ func printEmergencyIssuesEnriched(w io.Writer, issues []enrichedIssue) {
 // podKey identifies a pod for dedup purposes. EmergencyIssue has no
 // separate container field (the container name only ever appears inside
 // Message's free text), so namespace+pod name is the finest-grained key
-// available; in practice every duplicate case this file's Fix 1/2 handle
-// is a whole pod reported twice, not two different containers in it.
+// available; in practice every case this file's classification and
+// dedup logic handle is a whole pod reported twice, not two different
+// containers in it.
 func podKey(namespace, name string) string {
 	return namespace + "/" + name
 }
 
-// dedupeMediumTier implements Fix 1: a pod already shown under CRITICAL
-// as CrashLoopBackOff or OOMKilled has its restart count printed there
-// already, so a MEDIUM HighRestartCount entry for the same pod is pure
-// noise. A pod that reaches MEDIUM on its own (no CRITICAL entry) keeps
-// its HighRestartCount line.
-func dedupeMediumTier(medium, critical []enrichedIssue) []enrichedIssue {
-	criticalKeys := make(map[string]bool, len(critical))
-	for _, issue := range critical {
-		if issue.Reason == "CrashLoopBackOff" || issue.Reason == "OOMKilled" {
-			criticalKeys[podKey(issue.Namespace, issue.Name)] = true
-		}
-	}
-
-	var out []enrichedIssue
-	for _, issue := range medium {
-		if issue.Reason == "HighRestartCount" && criticalKeys[podKey(issue.Namespace, issue.Name)] {
-			continue
-		}
-		out = append(out, issue)
-	}
-	return out
-}
-
-// dedupeHighTier implements Fix 2: a pod stuck Pending because its image
-// can't be pulled shows up once as Pending and once as ImagePullBackOff/
-// ErrImagePull for the same root cause. Keep only the more actionable
+// dedupeHighTier: a pod stuck Pending because its image can't be pulled
+// shows up once as Pending (from analyzePodForIssues' pod-phase check)
+// and once as ImagePullBackOff/ErrImagePull (from its per-container
+// check) for the same root cause — these are two different reasons, so
+// classifyPod's single-pod collapse (scoped to classifiablePodReasons)
+// doesn't touch Pending at all. Keep only the more actionable
 // ImagePullBackOff/ErrImagePull entry. A Pending pod with no matching
 // image-pull entry is a distinct, real scenario and is left alone.
 func dedupeHighTier(high []enrichedIssue) []enrichedIssue {
@@ -312,10 +569,9 @@ func dedupeHighTier(high []enrichedIssue) []enrichedIssue {
 }
 
 // issueGroup holds one or more issues collapsed under the same
-// fingerprint (see groupKeyFor) within a single severity tier.
-// len(issues) == 1 is the common case and prints exactly as before; 2+
-// prints as one grouped entry (Fix 3 of the prior task / this task's
-// Fix 1).
+// fingerprint (see groupKeyFor) within a single severity tier. len(issues)
+// == 1 is the common case and prints exactly as before; 2+ prints as one
+// grouped entry.
 type issueGroup struct {
 	issues []enrichedIssue
 }
@@ -376,8 +632,7 @@ func groupIssues(tier []enrichedIssue) []issueGroup {
 //     happening to run a container with the same name is a coincidence,
 //     not one incident.
 //   - Anything else falls back to the previous heuristic: the message
-//     text after its first ": ", un-namespaced, same as before this
-//     task's fingerprinting was added.
+//     text after its first ": ", un-namespaced.
 func groupKeyFor(issue enrichedIssue) groupKey {
 	switch issue.Reason {
 	case "ImagePullBackOff", "ErrImagePull":
@@ -464,9 +719,9 @@ func extractRestartContainer(message string) string {
 
 // extractCrashLoopContainer pulls the container name out of a
 // CrashLoopBackOff message (see cluster.go's "Container %s is crash
-// looping: %s" format), for the merged CrashLoopBackOff+OOMKilled
-// message (Fix 3). Falls back to a generic noun if the message doesn't
-// match the expected shape.
+// looping: %s" format), for classifyPod's merged CrashLoopBackOff+
+// OOMKilled/ProbeFailure message. Falls back to a generic noun if the
+// message doesn't match the expected shape.
 func extractCrashLoopContainer(message string) string {
 	if m := crashLoopContainerRe.FindStringSubmatch(message); len(m) == 2 {
 		return m[1]
@@ -566,113 +821,6 @@ func printGroupedIssue(w io.Writer, issues []enrichedIssue) {
 	}
 	if rep.ReopenCount > 0 {
 		fmt.Fprintf(w, "  └─ Reopened: %dx (%s)\n", rep.ReopenCount, rep.Name)
-	}
-	fmt.Fprintln(w)
-}
-
-// criticalItem is a printable CRITICAL-tier entry: either a single issue
-// (the common case, unchanged from before), a CrashLoopBackOff merged
-// with the same-pod OOMKilled that caused it (Fix 3 of the prior task),
-// or a CrashLoopBackOff relabeled with a probe-failure root cause found
-// in its recent events (this task's fix).
-type criticalItem struct {
-	issue        enrichedIssue
-	oomCause     *enrichedIssue // non-nil only when issue is a merged CrashLoopBackOff+OOMKilled
-	probeFailure bool           // true only when issue is CrashLoopBackOff, has no OOMKilled cause, and its events show a probe-failure signature
-}
-
-// mergeCrashLoopOOM implements Fix 3 of the prior task (CrashLoopBackOff+
-// OOMKilled merge) and this task's probe-failure relabeling, narrowly
-// scoped in the same way: when the SAME pod (see podKey's container-
-// granularity caveat) appears as both CrashLoopBackOff and OOMKilled at
-// CRITICAL, the OOMKilled is the cause of the crash loop, not a second,
-// independent problem — merge the pair into one entry. When a
-// CrashLoopBackOff pod has no OOMKilled cause but annotateProbeFailures
-// found a probe-failure signature in its recent events, relabel it as
-// caused by its probe instead. Every other CRITICAL issue (including a
-// pod that's ONLY CrashLoopBackOff with neither signal, or ONLY
-// OOMKilled with no crash loop) is left exactly as-is, one line per pod,
-// per the existing CRITICAL format.
-//
-// Precedence when a pod has BOTH an OOMKilled cause and a probe-failure
-// event signature: OOMKilled wins, and the probe signal is dropped
-// silently. An observed OOM is a direct, first-hand cause; a
-// probe-failure event only correlates with the crash loop (the pod could
-// still be crashing from the same memory pressure that trips its probe).
-// Showing both would just be noise once we already have the more certain
-// cause.
-//
-// This is intentionally narrow: it does not attempt to detect or merge
-// any other status pair. PodFailed following an OOMKilled, for instance,
-// looks like it could be a similarly causal pair, but there's no
-// evidence yet that it needs the same treatment — flagged in the task
-// summary as a possible follow-up rather than guessed at here.
-func mergeCrashLoopOOM(critical []enrichedIssue) []criticalItem {
-	oomIndexByPod := make(map[string]int, len(critical))
-	for i, issue := range critical {
-		if issue.Reason == "OOMKilled" {
-			oomIndexByPod[podKey(issue.Namespace, issue.Name)] = i
-		}
-	}
-
-	skip := make(map[int]bool, len(critical))
-	var out []criticalItem
-	for i, issue := range critical {
-		if skip[i] {
-			continue
-		}
-		if issue.Reason == "CrashLoopBackOff" {
-			if oomIdx, ok := oomIndexByPod[podKey(issue.Namespace, issue.Name)]; ok {
-				oom := critical[oomIdx]
-				out = append(out, criticalItem{issue: issue, oomCause: &oom})
-				skip[oomIdx] = true
-				continue
-			}
-			if issue.probeFailure {
-				out = append(out, criticalItem{issue: issue, probeFailure: true})
-				continue
-			}
-		}
-		out = append(out, criticalItem{issue: issue})
-	}
-	return out
-}
-
-func printCriticalItem(w io.Writer, item criticalItem) {
-	switch {
-	case item.oomCause != nil:
-		rep := groupRepresentative([]enrichedIssue{item.issue, *item.oomCause})
-		container := extractCrashLoopContainer(item.issue.Message)
-		printMergedCriticalItem(w, item.issue, rep, "OOMKilled",
-			fmt.Sprintf("Container %s is being OOM-killed, causing the crash loop — check resources.limits.memory", container))
-	case item.probeFailure:
-		container := extractCrashLoopContainer(item.issue.Message)
-		printMergedCriticalItem(w, item.issue, item.issue, "ProbeFailure",
-			fmt.Sprintf("Container %s is being killed by its startup/liveness probe before it can stabilize — check probe initialDelaySeconds/periodSeconds/failureThreshold against actual container startup time", container))
-	default:
-		printEnrichedIssue(w, item.issue)
-	}
-}
-
-// printMergedCriticalItem prints a CrashLoopBackOff issue relabeled with
-// a merged root cause (OOMKilled or ProbeFailure). rep supplies the
-// First detected/Reopened enrichment shown — for an OOMKilled merge
-// that's groupRepresentative's pick between the two constituent issues;
-// for a probe-failure relabel there's only ever the one issue, so rep is
-// always item.issue itself.
-func printMergedCriticalItem(w io.Writer, issue, rep enrichedIssue, causeLabel, causeMessage string) {
-	fmt.Fprintf(w, "  %s/%s\n", issue.Namespace, issue.Name)
-	fmt.Fprintf(w, "  └─ Status: CrashLoopBackOff (%s)", causeLabel)
-	if issue.Restarts > 0 {
-		fmt.Fprintf(w, " | Restarts: %d", issue.Restarts)
-	}
-	fmt.Fprintf(w, " | Age: %s\n", formatDuration(issue.Age))
-	fmt.Fprintf(w, "  └─ %s\n", causeMessage)
-	if rep.FirstDetected != "" {
-		fmt.Fprintf(w, "  └─ First detected: %s ago\n", rep.FirstDetected)
-	}
-	if rep.ReopenCount > 0 {
-		fmt.Fprintf(w, "  └─ Reopened: %dx\n", rep.ReopenCount)
 	}
 	fmt.Fprintln(w)
 }

--- a/cmd/opscart-scan/emergency_classify_test.go
+++ b/cmd/opscart-scan/emergency_classify_test.go
@@ -1,0 +1,422 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/opscart/opscart-k8s-watcher/pkg/models"
+)
+
+// rawIssue builds a raw scanner finding (pre-classification), mirroring
+// what analyzePodForIssues (pkg/scanner/cluster.go) emits.
+func rawIssue(ns, name, severity, reason, message string, restarts int) models.EmergencyIssue {
+	return models.EmergencyIssue{
+		Severity:  severity,
+		Resource:  "pod",
+		Namespace: ns,
+		Name:      name,
+		Reason:    reason,
+		Message:   message,
+		Restarts:  restarts,
+	}
+}
+
+// Priority 1: OOMKilled + CrashLoopBackOff classifies as one CRITICAL
+// entry naming the real container and the causal OOM message. Matches
+// the exact stream-processor case from the corp-cluster report.
+func TestClassifyPod_OOMKilledMergesWithCrashLoop(t *testing.T) {
+	podIssues := []models.EmergencyIssue{
+		rawIssue("data-pipeline", "stream-processor-66c474d5fd-9zpwq", "critical", "CrashLoopBackOff",
+			"Container stress is crash looping: back-off restarting failed container", 6301),
+		rawIssue("data-pipeline", "stream-processor-66c474d5fd-9zpwq", "critical", "OOMKilled",
+			"Container stress killed due to out of memory", 6301),
+	}
+
+	got, ok := classifyPod(podIssues, false)
+	if !ok {
+		t.Fatalf("expected a classification")
+	}
+	if got.Reason != "CrashLoopBackOff (OOMKilled)" {
+		t.Errorf("Reason = %q, want %q", got.Reason, "CrashLoopBackOff (OOMKilled)")
+	}
+	if got.Severity != "critical" {
+		t.Errorf("Severity = %q, want critical", got.Severity)
+	}
+	if !strings.Contains(got.Message, "Container stress is being OOM-killed") {
+		t.Errorf("Message = %q, missing causal OOM text", got.Message)
+	}
+}
+
+// Priority 1 wins even when a probe-failure signature is ALSO present:
+// an observed OOM is a more certain, direct cause than a correlated
+// probe-failure event.
+func TestClassifyPod_OOMKilledTakesPrecedenceOverProbeFailure(t *testing.T) {
+	podIssues := []models.EmergencyIssue{
+		rawIssue("prod", "checkout-7d9f8b6c5-x7z2m9", "critical", "CrashLoopBackOff",
+			"Container app is crash looping: back-off restarting failed container", 42),
+		rawIssue("prod", "checkout-7d9f8b6c5-x7z2m9", "critical", "OOMKilled",
+			"Container app killed due to out of memory", 42),
+	}
+
+	got, ok := classifyPod(podIssues, true) // probe-failure signature also present
+	if !ok {
+		t.Fatalf("expected a classification")
+	}
+	if got.Reason != "CrashLoopBackOff (OOMKilled)" {
+		t.Errorf("Reason = %q, want OOMKilled to win even with a probe-failure signal present", got.Reason)
+	}
+}
+
+// Priority 2: a probe-failure signature relabels a plain CrashLoopBackOff
+// with no OOM cause.
+func TestClassifyPod_ProbeFailureRelabelsCrashLoop(t *testing.T) {
+	podIssues := []models.EmergencyIssue{
+		rawIssue("prod", "checkout-7d9f8b6c5-x7z2m9", "critical", "CrashLoopBackOff",
+			"Container app is crash looping: back-off restarting failed container", 42),
+	}
+
+	got, ok := classifyPod(podIssues, true)
+	if !ok {
+		t.Fatalf("expected a classification")
+	}
+	if got.Reason != "CrashLoopBackOff (ProbeFailure)" {
+		t.Errorf("Reason = %q, want %q", got.Reason, "CrashLoopBackOff (ProbeFailure)")
+	}
+	if !strings.Contains(got.Message, "Container app is being killed by its startup/liveness probe") {
+		t.Errorf("Message = %q, missing causal probe text", got.Message)
+	}
+}
+
+// A pod in CrashLoopBackOff with NO probe-failure event (a genuine
+// unrelated crash) must be left exactly as scanned: no relabeling.
+func TestClassifyPod_NoProbeSignatureUnaffected(t *testing.T) {
+	podIssues := []models.EmergencyIssue{
+		rawIssue("prod", "checkout-7d9f8b6c5-x7z2m9", "critical", "CrashLoopBackOff",
+			"Container app is crash looping: back-off restarting failed container", 42),
+	}
+
+	got, ok := classifyPod(podIssues, false)
+	if !ok {
+		t.Fatalf("expected a classification")
+	}
+	if got.Reason != "CrashLoopBackOff" {
+		t.Errorf("Reason = %q, want plain CrashLoopBackOff", got.Reason)
+	}
+	if strings.Contains(got.Message, "probe") {
+		t.Errorf("should show no probe-related text when no signature was found, got Message=%q", got.Message)
+	}
+}
+
+// Priority 3: plain CrashLoopBackOff, with neither an OOM cause nor a
+// probe-failure signature, is left exactly as scanned.
+func TestClassifyPod_PlainCrashLoopUnaffected(t *testing.T) {
+	podIssues := []models.EmergencyIssue{
+		rawIssue("prod", "solo-crash-pod", "critical", "CrashLoopBackOff",
+			"Container app is crash looping: back-off restarting failed container", 12),
+	}
+
+	got, ok := classifyPod(podIssues, false)
+	if !ok {
+		t.Fatalf("expected a classification")
+	}
+	if got.Reason != "CrashLoopBackOff" {
+		t.Errorf("Reason = %q, want plain CrashLoopBackOff", got.Reason)
+	}
+	if got.Message != "Container app is crash looping: back-off restarting failed container" {
+		t.Errorf("Message was rewritten, want unchanged: %q", got.Message)
+	}
+}
+
+// Not one of the 6 enumerated priority steps, but required to preserve
+// pre-existing behavior: cs.LastTerminationState is sticky and keeps
+// reporting "OOMKilled" until the container's next restart, long after
+// the container is back to stable Running, so a pod can show OOMKilled
+// with no CrashLoopBackOff at all. That's already CRITICAL and no less
+// real for lacking a current crash loop.
+func TestClassifyPod_StandaloneOOMKilled(t *testing.T) {
+	podIssues := []models.EmergencyIssue{
+		rawIssue("prod", "steady-now-pod", "critical", "OOMKilled",
+			"Container app killed due to out of memory", 3),
+	}
+
+	got, ok := classifyPod(podIssues, false)
+	if !ok {
+		t.Fatalf("expected a classification")
+	}
+	if got.Reason != "OOMKilled" {
+		t.Errorf("Reason = %q, want OOMKilled", got.Reason)
+	}
+	if got.Severity != "critical" {
+		t.Errorf("Severity = %q, want critical", got.Severity)
+	}
+}
+
+// Priority 4: ImagePullBackOff/ErrImagePull is unaffected by
+// classification — same reason, same HIGH severity the scanner already
+// assigns (per this task's explicit "existing logic, unchanged").
+func TestClassifyPod_ImagePullBackOffUnaffected(t *testing.T) {
+	podIssues := []models.EmergencyIssue{
+		rawIssue("data-pipeline", "batch-importer-5849fd86bb-q9r8m", "high", "ImagePullBackOff",
+			"Cannot pull image for container app: dial tcp: lookup company-registry.internal on 192.168.65.254:53: no such host", 0),
+	}
+
+	got, ok := classifyPod(podIssues, false)
+	if !ok {
+		t.Fatalf("expected a classification")
+	}
+	if got.Reason != "ImagePullBackOff" || got.Severity != "high" {
+		t.Errorf("got Reason=%q Severity=%q, want ImagePullBackOff/high unchanged", got.Reason, got.Severity)
+	}
+}
+
+// Priority 4 gates priority 5: ImagePullBackOff beats a coexisting
+// HighRestartCount for the same pod (e.g. a container that was already
+// restarting a lot also can't pull a newly rolled image).
+func TestClassifyPod_ImagePullBackOffGatesHighRestartCount(t *testing.T) {
+	podIssues := []models.EmergencyIssue{
+		rawIssue("prod", "rollout-pod", "high", "ImagePullBackOff",
+			"Cannot pull image for container app: dial tcp: lookup company-registry.internal on 192.168.65.254:53: no such host", 0),
+		rawIssue("prod", "rollout-pod", "medium", "HighRestartCount",
+			"Container app has restarted 15 times", 15),
+	}
+
+	got, ok := classifyPod(podIssues, false)
+	if !ok {
+		t.Fatalf("expected a classification")
+	}
+	if got.Reason != "ImagePullBackOff" {
+		t.Errorf("Reason = %q, want ImagePullBackOff to gate HighRestartCount", got.Reason)
+	}
+}
+
+// Priority 5: HighRestartCount only wins when nothing higher-priority
+// matched.
+func TestClassifyPod_HighRestartCountOnlyWhenNothingElseMatches(t *testing.T) {
+	podIssues := []models.EmergencyIssue{
+		rawIssue("prod", "worker-abc123", "medium", "HighRestartCount",
+			"Container app has restarted 15 times", 15),
+	}
+
+	got, ok := classifyPod(podIssues, false)
+	if !ok {
+		t.Fatalf("expected a classification")
+	}
+	if got.Reason != "HighRestartCount" || got.Severity != "medium" {
+		t.Errorf("got Reason=%q Severity=%q, want HighRestartCount/medium", got.Reason, got.Severity)
+	}
+}
+
+// This task's core fixture: a single pod whose raw issues match MULTIPLE
+// categories at once (a live CrashLoopBackOff and a high restart count —
+// exactly what analyzePodForIssues' independent per-container `if`s can
+// both produce for the same container in the same scan) now yields
+// EXACTLY ONE classification, in the highest-priority category, never
+// two coexisting entries.
+func TestClassifyPod_MultiCategoryPod_ExactlyOneHighestPriorityResult(t *testing.T) {
+	podIssues := []models.EmergencyIssue{
+		rawIssue("prod", "payment-processor-6c9f8b6c5-x7z2m9", "critical", "CrashLoopBackOff",
+			"Container app is crash looping: back-off restarting failed container", 6412),
+		rawIssue("prod", "payment-processor-6c9f8b6c5-x7z2m9", "medium", "HighRestartCount",
+			"Container app has restarted 6412 times", 6412),
+	}
+
+	got, ok := classifyPod(podIssues, false)
+	if !ok {
+		t.Fatalf("expected a classification")
+	}
+	if got.Reason != "CrashLoopBackOff" {
+		t.Errorf("Reason = %q, want CrashLoopBackOff (higher priority than HighRestartCount)", got.Reason)
+	}
+	if got.Severity != "critical" {
+		t.Errorf("Severity = %q, want critical", got.Severity)
+	}
+}
+
+// Step 6 of the priority list: a pod group holding nothing in
+// classifiablePodReasons yields no classification. classifyIssues never
+// actually constructs such a group in practice (every reason it groups by
+// is one classifyPod explicitly handles), but classifyPod's own contract
+// is tested directly here.
+func TestClassifyPod_NoClassifiableIssues_ReturnsNotOK(t *testing.T) {
+	_, ok := classifyPod(nil, false)
+	if ok {
+		t.Fatalf("expected ok=false for a pod with no classifiable issues")
+	}
+}
+
+// Reproduces tonight's real bug at the classification layer: the same
+// underlying pod state — where a container's Waiting state and its high
+// restart count both fire in the very same read, which is what a scan
+// straddling the crash loop's brief Running window produces — must
+// classify identically no matter how many times classification runs, and
+// regardless of the raw issues' order. Before this fix, a pod like this
+// could resolve to a DIFFERENT winning reason (and therefore a different
+// fingerprint) run to run, which is exactly what silently "resolved" the
+// CRITICAL incident in the DB.
+func TestClassifyPod_FlickerBetweenRunningAndWaiting_SameFingerprintEveryTime(t *testing.T) {
+	orderA := []models.EmergencyIssue{
+		rawIssue("prod", "payment-processor-6c9f8b6c5-x7z2m9", "critical", "CrashLoopBackOff",
+			"Container app is crash looping: back-off restarting failed container", 6412),
+		rawIssue("prod", "payment-processor-6c9f8b6c5-x7z2m9", "medium", "HighRestartCount",
+			"Container app has restarted 6412 times", 6412),
+	}
+	orderB := []models.EmergencyIssue{orderA[1], orderA[0]} // same pod, reversed scan order
+
+	run1, ok1 := classifyPod(orderA, false)
+	run2, ok2 := classifyPod(orderB, false)
+	if !ok1 || !ok2 {
+		t.Fatalf("expected both runs to classify: ok1=%v ok2=%v", ok1, ok2)
+	}
+
+	fp1 := incidentFingerprint(run1)
+	fp2 := incidentFingerprint(run2)
+	if fp1 != fp2 {
+		t.Fatalf("fingerprint changed across runs of the identical pod state: run1=%q run2=%q", fp1, fp2)
+	}
+	if run1.Reason != "CrashLoopBackOff" || run2.Reason != "CrashLoopBackOff" {
+		t.Fatalf("expected both runs to classify as CrashLoopBackOff, got run1=%q run2=%q", run1.Reason, run2.Reason)
+	}
+}
+
+// End-to-end: a classified OOMKilled-caused crash loop prints with the
+// merged status label and causal message.
+func TestClassifyPod_OOMKilledMerge_PrintsCorrectly(t *testing.T) {
+	podIssues := []models.EmergencyIssue{
+		rawIssue("data-pipeline", "stream-processor-66c474d5fd-9zpwq", "critical", "CrashLoopBackOff",
+			"Container stress is crash looping: back-off restarting failed container", 6301),
+		rawIssue("data-pipeline", "stream-processor-66c474d5fd-9zpwq", "critical", "OOMKilled",
+			"Container stress killed due to out of memory", 6301),
+	}
+	classified, ok := classifyPod(podIssues, false)
+	if !ok {
+		t.Fatalf("expected a classification")
+	}
+	classified.Age = 23 * 24 * time.Hour
+
+	var buf bytes.Buffer
+	printEnrichedIssue(&buf, enrichedIssue{EmergencyIssue: classified, FirstDetected: "14h"})
+	out := buf.String()
+
+	if strings.Count(out, "stream-processor-66c474d5fd-9zpwq") != 1 {
+		t.Errorf("expected exactly 1 printed block, got:\n%s", out)
+	}
+	if !strings.Contains(out, "data-pipeline/stream-processor-66c474d5fd-9zpwq") {
+		t.Errorf("missing pod identity, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Status: CrashLoopBackOff (OOMKilled) | Restarts: 6301 | Age: 23d") {
+		t.Errorf("missing combined status line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Container stress is being OOM-killed, causing the crash loop — check resources.limits.memory") {
+		t.Errorf("missing causal message, got:\n%s", out)
+	}
+	if !strings.Contains(out, "First detected: 14h ago") {
+		t.Errorf("missing enrichment line, got:\n%s", out)
+	}
+}
+
+func TestClassifyPod_ProbeFailureMerge_PrintsCorrectly(t *testing.T) {
+	podIssues := []models.EmergencyIssue{
+		rawIssue("prod", "checkout-7d9f8b6c5-x7z2m9", "critical", "CrashLoopBackOff",
+			"Container app is crash looping: back-off restarting failed container", 42),
+	}
+	classified, ok := classifyPod(podIssues, true)
+	if !ok {
+		t.Fatalf("expected a classification")
+	}
+
+	var buf bytes.Buffer
+	printEnrichedIssue(&buf, enrichedIssue{EmergencyIssue: classified})
+	out := buf.String()
+
+	if !strings.Contains(out, "Status: CrashLoopBackOff (ProbeFailure)") {
+		t.Errorf("missing relabeled status, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Container app is being killed by its startup/liveness probe before it can stabilize") {
+		t.Errorf("missing causal probe message, got:\n%s", out)
+	}
+}
+
+// classifyIssues collapses a pod's classifiable issues to one, while
+// leaving a non-classifiable pod issue (Pending) and a non-pod issue
+// (PVC) for a DIFFERENT resource untouched.
+func TestClassifyIssues_PassesThroughNonClassifiableAndNonPod(t *testing.T) {
+	raw := []models.EmergencyIssue{
+		rawIssue("prod", "payment-processor-6c9f8b6c5-x7z2m9", "critical", "CrashLoopBackOff",
+			"Container app is crash looping: back-off restarting failed container", 6412),
+		rawIssue("prod", "payment-processor-6c9f8b6c5-x7z2m9", "medium", "HighRestartCount",
+			"Container app has restarted 6412 times", 6412),
+		rawIssue("prod", "steady-worker", "high", "Pending", "Pod pending for extended period", 0),
+		{Severity: "critical", Resource: "pvc", Namespace: "prod", Name: "data-vol", Reason: "PVCLost", Message: "PersistentVolumeClaim in Lost state"},
+	}
+
+	got := classifyIssues(raw, nil)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 issues (1 classified pod + Pending + PVC), got %d: %+v", len(got), got)
+	}
+
+	var sawCrashLoop, sawPending, sawPVC bool
+	for _, iss := range got {
+		switch {
+		case iss.Reason == "CrashLoopBackOff" && iss.Name == "payment-processor-6c9f8b6c5-x7z2m9":
+			sawCrashLoop = true
+		case iss.Reason == "HighRestartCount":
+			t.Errorf("HighRestartCount should have been collapsed away, got %+v", iss)
+		case iss.Reason == "Pending":
+			sawPending = true
+		case iss.Reason == "PVCLost":
+			sawPVC = true
+		}
+	}
+	if !sawCrashLoop || !sawPending || !sawPVC {
+		t.Errorf("missing expected entries, got %+v", got)
+	}
+}
+
+// The full corp-cluster shape: 8 pods with a mix of raw signal
+// combinations. classifyIssues must leave exactly 8 issues — one per
+// pod — never 16.
+func TestClassifyIssues_EightPodsNotSixteen(t *testing.T) {
+	var raw []models.EmergencyIssue
+	raw = append(raw,
+		rawIssue("prod", "pod1-abc", "critical", "CrashLoopBackOff",
+			"Container app is crash looping: back-off restarting failed container", 100),
+		rawIssue("prod", "pod2-abc", "critical", "OOMKilled",
+			"Container app killed due to out of memory", 200),
+		rawIssue("prod", "pod2-abc", "medium", "HighRestartCount",
+			"Container app has restarted 200 times", 200),
+		rawIssue("prod", "pod3-abc", "medium", "HighRestartCount",
+			"Container app has restarted 300 times", 300),
+		rawIssue("prod", "pod4-abc", "critical", "CrashLoopBackOff",
+			"Container app is crash looping: back-off restarting failed container", 400),
+		rawIssue("prod", "pod4-abc", "critical", "OOMKilled",
+			"Container app killed due to out of memory", 400),
+		rawIssue("prod", "pod5-abc", "medium", "HighRestartCount",
+			"Container app has restarted 500 times", 500),
+		rawIssue("prod", "pod6-abc", "critical", "CrashLoopBackOff",
+			"Container app is crash looping: back-off restarting failed container", 600),
+		rawIssue("prod", "pod6-abc", "medium", "HighRestartCount",
+			"Container app has restarted 600 times", 600),
+		rawIssue("prod", "pod7-abc", "critical", "OOMKilled",
+			"Container app killed due to out of memory", 700),
+		rawIssue("prod", "pod8-abc", "medium", "HighRestartCount",
+			"Container app has restarted 800 times", 800),
+	)
+
+	got := classifyIssues(raw, nil)
+	if len(got) != 8 {
+		t.Fatalf("expected exactly 8 classified issues (one per pod), got %d: %+v", len(got), got)
+	}
+	seen := make(map[string]int)
+	for _, iss := range got {
+		seen[podKey(iss.Namespace, iss.Name)]++
+	}
+	for i := 1; i <= 8; i++ {
+		key := podKey("prod", fmt.Sprintf("pod%d-abc", i))
+		if seen[key] != 1 {
+			t.Errorf("expected exactly 1 classified issue for %s, got %d", key, seen[key])
+		}
+	}
+}

--- a/cmd/opscart-scan/emergency_dedup_test.go
+++ b/cmd/opscart-scan/emergency_dedup_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/opscart/opscart-k8s-watcher/pkg/models"
 )
@@ -20,49 +19,6 @@ func issue(ns, name, severity, reason, message string, restarts int) enrichedIss
 			Message:   message,
 			Restarts:  restarts,
 		},
-	}
-}
-
-// A pod at CRITICAL (CrashLoopBackOff) whose same restart count also
-// shows up in the raw MEDIUM candidates (HighRestartCount) should only be
-// printed once, under CRITICAL.
-func TestDedupe_SuppressesHighRestartCountAlreadyCritical(t *testing.T) {
-	critical := []enrichedIssue{
-		issue("prod", "token-service-786498c5c-phg2g", "critical", "CrashLoopBackOff",
-			"Container app is crash looping: back-off restarting failed container", 6228),
-	}
-	medium := []enrichedIssue{
-		issue("prod", "token-service-786498c5c-phg2g", "medium", "HighRestartCount",
-			"Container app has restarted 6228 times", 6228),
-	}
-
-	got := dedupeMediumTier(medium, critical)
-	if len(got) != 0 {
-		t.Fatalf("expected MEDIUM HighRestartCount to be suppressed, got %+v", got)
-	}
-
-	var buf bytes.Buffer
-	all := append(append([]enrichedIssue{}, critical...), medium...)
-	printEmergencyIssuesEnriched(&buf, all)
-	out := buf.String()
-	if strings.Count(out, "token-service-786498c5c-phg2g") != 1 {
-		t.Errorf("expected pod name to appear exactly once, got:\n%s", out)
-	}
-	if strings.Contains(out, "MEDIUM PRIORITY") {
-		t.Errorf("expected no MEDIUM section since its only entry was suppressed, got:\n%s", out)
-	}
-}
-
-// A MEDIUM-only high-restart-count pod (no matching CRITICAL entry) must
-// keep its HighRestartCount line.
-func TestDedupe_KeepsHighRestartCountWithoutCriticalMatch(t *testing.T) {
-	medium := []enrichedIssue{
-		issue("prod", "worker-abc123", "medium", "HighRestartCount",
-			"Container app has restarted 15 times", 15),
-	}
-	got := dedupeMediumTier(medium, nil)
-	if len(got) != 1 {
-		t.Fatalf("expected HighRestartCount entry to survive, got %+v", got)
 	}
 }
 
@@ -269,99 +225,17 @@ func TestGroupIssues_HighRestartCountDifferentNamespaceNotGrouped(t *testing.T) 
 	}
 }
 
-// Fix 3: the SAME pod+container appearing as both CrashLoopBackOff and
-// OOMKilled at CRITICAL is one causal event, not two — merge into a
-// single entry. Matches the exact stream-processor case from the corp
-// cluster report.
-func TestMergeCrashLoopOOM_StreamProcessorCase(t *testing.T) {
-	age := 23 * 24 * time.Hour
-	crashLoop := enrichedIssue{
-		EmergencyIssue: models.EmergencyIssue{
-			Severity: "critical", Resource: "pod",
-			Namespace: "data-pipeline", Name: "stream-processor-66c474d5fd-9zpwq",
-			Reason:   "CrashLoopBackOff",
-			Message:  "Container stress is crash looping: back-off restarting failed container",
-			Age:      age,
-			Restarts: 6301,
-		},
-		FirstDetected: "14h",
-	}
-	oom := enrichedIssue{
-		EmergencyIssue: models.EmergencyIssue{
-			Severity: "critical", Resource: "pod",
-			Namespace: "data-pipeline", Name: "stream-processor-66c474d5fd-9zpwq",
-			Reason:   "OOMKilled",
-			Message:  "Container stress killed due to out of memory",
-			Age:      age,
-			Restarts: 6301,
-		},
-	}
-
-	items := mergeCrashLoopOOM([]enrichedIssue{crashLoop, oom})
-	if len(items) != 1 {
-		t.Fatalf("expected 1 merged critical item, got %d: %+v", len(items), items)
-	}
-	if items[0].oomCause == nil {
-		t.Fatalf("expected item to be merged (oomCause set), got %+v", items[0])
-	}
-
-	var buf bytes.Buffer
-	printCriticalItem(&buf, items[0])
-	out := buf.String()
-
-	if strings.Count(out, "stream-processor-66c474d5fd-9zpwq") != 1 {
-		t.Errorf("expected exactly 1 printed block for the pod (not 2 separate CRITICAL entries), got:\n%s", out)
-	}
-	if !strings.Contains(out, "data-pipeline/stream-processor-66c474d5fd-9zpwq") {
-		t.Errorf("missing pod identity, got:\n%s", out)
-	}
-	if !strings.Contains(out, "Status: CrashLoopBackOff (OOMKilled) | Restarts: 6301 | Age: 23d") {
-		t.Errorf("missing combined status line, got:\n%s", out)
-	}
-	if !strings.Contains(out, "Container stress is being OOM-killed, causing the crash loop — check resources.limits.memory") {
-		t.Errorf("missing causal message, got:\n%s", out)
-	}
-	if !strings.Contains(out, "First detected: 14h ago") {
-		t.Errorf("missing enrichment line, got:\n%s", out)
-	}
-}
-
-// A pod with ONLY CrashLoopBackOff (no OOMKilled) must be left exactly
-// as before: a single, unmerged, normal entry.
-func TestMergeCrashLoopOOM_OnlyCrashLoopUnaffected(t *testing.T) {
-	critical := []enrichedIssue{
-		issue("prod", "solo-crash-pod", "critical", "CrashLoopBackOff",
-			"Container app is crash looping: back-off restarting failed container", 12),
-	}
-
-	items := mergeCrashLoopOOM(critical)
-	if len(items) != 1 || items[0].oomCause != nil {
-		t.Fatalf("expected unmerged single entry, got %+v", items)
-	}
-
-	var buf bytes.Buffer
-	printCriticalItem(&buf, items[0])
-	out := buf.String()
-	if !strings.Contains(out, "Status: CrashLoopBackOff | Restarts: 12") {
-		t.Errorf("expected unchanged status line, got:\n%s", out)
-	}
-	if strings.Contains(out, "(OOMKilled)") {
-		t.Errorf("should not show merged status when there's no OOMKilled pair, got:\n%s", out)
-	}
-}
-
-// Fix 2: the severity header must count PRINTED entries (a merged pair
-// or an N-pod group each count as 1), not underlying pod counts.
+// The severity header must count PRINTED entries (an N-pod group counts
+// as 1), not underlying pod counts. A same-pod CRITICAL+HIGH pairing is
+// no longer possible by the time issues reach the printer (classifyIssues
+// already collapsed it upstream — see emergency_classify_test.go), so
+// this exercises grouping across DIFFERENT pods only.
 func TestHeaderCount_MatchesPrintedEntries(t *testing.T) {
 	var all []enrichedIssue
 
-	// CRITICAL: a merged pair (2 raw issues -> 1 printed entry) + 1
-	// standalone entry -> 2 printed CRITICAL entries.
 	all = append(all,
 		issue("data-pipeline", "stream-processor-66c474d5fd-9zpwq", "critical", "CrashLoopBackOff",
-			"Container stress is crash looping: back-off restarting failed container", 6301),
-		issue("data-pipeline", "stream-processor-66c474d5fd-9zpwq", "critical", "OOMKilled",
-			"Container stress killed due to out of memory", 6301),
+			"Container stress is being OOM-killed, causing the crash loop — check resources.limits.memory", 6301),
 		issue("prod", "solo-crash-pod", "critical", "CrashLoopBackOff",
 			"Container app is crash looping: back-off restarting failed container", 12),
 	)
@@ -380,89 +254,94 @@ func TestHeaderCount_MatchesPrintedEntries(t *testing.T) {
 	out := buf.String()
 
 	if !strings.Contains(out, "🔴 CRITICAL: 2") {
-		t.Errorf("expected CRITICAL header to count printed entries (2: merged pair + solo), got:\n%s", out)
+		t.Errorf("expected CRITICAL header to count printed entries (2), got:\n%s", out)
 	}
 	if !strings.Contains(out, "🟡 HIGH: 2") {
 		t.Errorf("expected HIGH header to count printed entries (2: group of 3 + solo), got:\n%s", out)
 	}
 	// The header must never regress to reporting the underlying pod
-	// count (5 CRITICAL pods across 2 entries, 4 HIGH pods across 2
-	// entries).
-	if strings.Contains(out, "🔴 CRITICAL: 3") || strings.Contains(out, "🟡 HIGH: 4") {
+	// count (4 HIGH pods across 2 entries).
+	if strings.Contains(out, "🟡 HIGH: 4") {
 		t.Errorf("header appears to count underlying pods instead of printed entries, got:\n%s", out)
 	}
 }
 
-// Reproduces the real-world corp-cluster shape described in the task:
-// dozens of raw candidate entries describing a handful of distinct
-// workloads, once CRITICAL merge + HIGH/MEDIUM dedup + fingerprint-based
-// grouping are applied. Specifically covers all three bugs fixed this
-// task: the 3 image-pull pods now group despite differing per-pod text,
-// all 3 node-exporter pods group despite differing restart counts, and
-// the stream-processor CrashLoopBackOff+OOMKilled pair merges into one
-// CRITICAL entry.
+// Reproduces the real-world corp-cluster shape described in the task,
+// run through the real pipeline order (classifyIssues first, exactly as
+// runEmergencyScan does): dozens of raw candidate entries describing a
+// handful of distinct workloads collapse via classification (same-pod)
+// and fingerprint-based grouping (cross-pod). Covers: the
+// stream-processor CrashLoopBackOff+OOMKilled pair classifying to one
+// CRITICAL entry, the 3 image-pull pods grouping despite differing
+// per-pod text, and all 3 node-exporter pods grouping despite differing
+// restart counts.
 func TestPrintEmergencyIssuesEnriched_CorpClusterShape(t *testing.T) {
-	var all []enrichedIssue
+	var raw []models.EmergencyIssue
 
-	// CRITICAL: stream-processor's CrashLoopBackOff+OOMKilled pair (merges
-	// to 1), token-service CrashLoopBackOff (+ a duplicate MEDIUM
-	// HighRestartCount candidate, suppressed by Fix 1 of the prior task),
-	// and 3 more distinct, unrelated CrashLoopBackOff pods.
-	age := 23 * 24 * time.Hour
-	all = append(all,
-		issue("data-pipeline", "stream-processor-66c474d5fd-9zpwq", "critical", "CrashLoopBackOff",
+	// CRITICAL: stream-processor's CrashLoopBackOff+OOMKilled pair
+	// (classifies to 1), token-service CrashLoopBackOff (+ a coexisting
+	// raw MEDIUM HighRestartCount candidate, collapsed away by
+	// classifyIssues), and 3 more distinct, unrelated CrashLoopBackOff
+	// pods.
+	raw = append(raw,
+		rawIssue("data-pipeline", "stream-processor-66c474d5fd-9zpwq", "critical", "CrashLoopBackOff",
 			"Container stress is crash looping: back-off restarting failed container", 6301),
-		issue("data-pipeline", "stream-processor-66c474d5fd-9zpwq", "critical", "OOMKilled",
+		rawIssue("data-pipeline", "stream-processor-66c474d5fd-9zpwq", "critical", "OOMKilled",
 			"Container stress killed due to out of memory", 6301),
-		issue("prod", "token-service-786498c5c-phg2g", "critical", "CrashLoopBackOff",
+		rawIssue("prod", "token-service-786498c5c-phg2g", "critical", "CrashLoopBackOff",
 			"Container app is crash looping: back-off restarting failed container", 6228),
-		issue("prod", "token-service-786498c5c-phg2g", "medium", "HighRestartCount",
+		rawIssue("prod", "token-service-786498c5c-phg2g", "medium", "HighRestartCount",
 			"Container app has restarted 6228 times", 6228),
 	)
-	all[0].Age, all[1].Age = age, age
 	for _, name := range []string{"payments-worker-1", "payments-worker-2", "payments-worker-3"} {
-		all = append(all, issue("prod", name, "critical", "CrashLoopBackOff",
+		raw = append(raw, rawIssue("prod", name, "critical", "CrashLoopBackOff",
 			"Container app is crash looping: back-off restarting failed container", 50))
 	}
 
-	// HIGH: batch-importer's Pending+ImagePullBackOff duplicate (Fix 2 of
-	// the prior task), plus 2 more distinct pods hitting the SAME registry
-	// host with DIFFERENT per-pod message text (Fix 1 of this task), and a
-	// standalone Pending pod unrelated to image pulls.
-	all = append(all,
-		issue("data-pipeline", "batch-importer-5849fd86bb-q9r8m", "high", "Pending",
+	// HIGH: batch-importer's Pending+ImagePullBackOff duplicate, plus 2
+	// more distinct pods hitting the SAME registry host with DIFFERENT
+	// per-pod message text, and a standalone Pending pod unrelated to
+	// image pulls.
+	raw = append(raw,
+		rawIssue("data-pipeline", "batch-importer-5849fd86bb-q9r8m", "high", "Pending",
 			"Pod pending for extended period", 0),
-		issue("data-pipeline", "batch-importer-5849fd86bb-q9r8m", "high", "ImagePullBackOff",
+		rawIssue("data-pipeline", "batch-importer-5849fd86bb-q9r8m", "high", "ImagePullBackOff",
 			"Cannot pull image for container app: dial tcp: lookup company-registry.internal on 192.168.65.254:53: no such host", 0),
-		issue("inventory", "catalog-indexer-64dcbcb975-qqdmd", "high", "ImagePullBackOff",
+		rawIssue("inventory", "catalog-indexer-64dcbcb975-qqdmd", "high", "ImagePullBackOff",
 			`Cannot pull image for container worker: Back-off pulling image "company-registry.internal/catalog-indexer:v2.4.1"`, 0),
-		issue("notifications", "email-dispatcher-574556c86c-j44l6", "high", "ImagePullBackOff",
+		rawIssue("notifications", "email-dispatcher-574556c86c-j44l6", "high", "ImagePullBackOff",
 			`Cannot pull image for container app: Back-off pulling image "company-registry.internal/email-dispatcher@sha256:abc123def456"`, 0),
-		issue("prod", "resource-hog-xyz", "high", "Pending",
+		rawIssue("prod", "resource-hog-xyz", "high", "Pending",
 			"Pod pending for extended period", 0),
 	)
 
-	// MEDIUM: 3 node-exporter pods with different restart counts (Fix 1 of
-	// this task), plus 1 unrelated standalone HighRestartCount pod.
-	all = append(all,
-		issue("monitoring", "node-exporter-aaa", "medium", "HighRestartCount",
+	// MEDIUM: 3 node-exporter pods with different restart counts, plus 1
+	// unrelated standalone HighRestartCount pod.
+	raw = append(raw,
+		rawIssue("monitoring", "node-exporter-aaa", "medium", "HighRestartCount",
 			"Container node-exporter has restarted 26 times", 26),
-		issue("monitoring", "node-exporter-bbb", "medium", "HighRestartCount",
+		rawIssue("monitoring", "node-exporter-bbb", "medium", "HighRestartCount",
 			"Container node-exporter has restarted 26 times", 26),
-		issue("monitoring", "node-exporter-ccc", "medium", "HighRestartCount",
+		rawIssue("monitoring", "node-exporter-ccc", "medium", "HighRestartCount",
 			"Container node-exporter has restarted 88 times", 88),
-		issue("staging", "noisy-solo", "medium", "HighRestartCount",
+		rawIssue("staging", "noisy-solo", "medium", "HighRestartCount",
 			"Container sidecar has restarted 40 times", 40),
 	)
+
+	classified := classifyIssues(raw, nil)
+	var all []enrichedIssue
+	for _, iss := range classified {
+		all = append(all, enrichedIssue{EmergencyIssue: iss})
+	}
 
 	var buf bytes.Buffer
 	printEmergencyIssuesEnriched(&buf, all)
 	out := buf.String()
 
 	// 16 raw issues in, but the printed entries should be: CRITICAL 5
-	// (merged pair + token-service + 3 payments-workers), HIGH 2 (grouped
-	// image-pull trio + solo Pending), MEDIUM 2 (grouped node-exporter
-	// trio + solo). The header must match exactly.
+	// (stream-processor merge + token-service + 3 payments-workers), HIGH
+	// 2 (grouped image-pull trio + solo Pending), MEDIUM 2 (grouped
+	// node-exporter trio + solo). The header must match exactly.
 	if !strings.Contains(out, "🔴 CRITICAL: 5    🟡 HIGH: 2    🟠 MEDIUM: 2") {
 		t.Errorf("expected header CRITICAL:5 HIGH:2 MEDIUM:2, got:\n%s", out)
 	}
@@ -477,7 +356,7 @@ func TestPrintEmergencyIssuesEnriched_CorpClusterShape(t *testing.T) {
 		t.Errorf("expected all 3 node-exporter pods to group despite differing restart counts, got:\n%s", out)
 	}
 	if strings.Count(out, "token-service-786498c5c-phg2g") != 1 {
-		t.Errorf("expected token-service's duplicate MEDIUM entry to stay suppressed, got:\n%s", out)
+		t.Errorf("expected token-service's duplicate MEDIUM entry to stay collapsed away, got:\n%s", out)
 	}
 
 	lineCount := len(strings.Split(strings.TrimRight(out, "\n"), "\n"))

--- a/cmd/opscart-scan/emergency_probe_test.go
+++ b/cmd/opscart-scan/emergency_probe_test.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"bytes"
-	"strings"
 	"testing"
+
+	"github.com/opscart/opscart-k8s-watcher/pkg/models"
 )
 
 func TestHasProbeFailureSignature_Matches(t *testing.T) {
@@ -47,95 +47,6 @@ func TestHasProbeFailureSignature_Matches(t *testing.T) {
 	}
 }
 
-// A pod in CrashLoopBackOff with a matching probe-failure event in its
-// recent history relabels to "CrashLoopBackOff (ProbeFailure)" with the
-// probe-specific causal message.
-func TestMergeCrashLoopOOM_ProbeFailureRelabel(t *testing.T) {
-	crashLoop := issue("prod", "checkout-7d9f8b6c5-x7z2m9", "critical", "CrashLoopBackOff",
-		"Container app is crash looping: back-off restarting failed container", 42)
-	crashLoop.probeFailure = true
-
-	items := mergeCrashLoopOOM([]enrichedIssue{crashLoop})
-	if len(items) != 1 {
-		t.Fatalf("expected 1 critical item, got %d: %+v", len(items), items)
-	}
-	if items[0].oomCause != nil {
-		t.Fatalf("expected no OOMKilled merge, got oomCause=%+v", items[0].oomCause)
-	}
-	if !items[0].probeFailure {
-		t.Fatalf("expected probeFailure item, got %+v", items[0])
-	}
-
-	var buf bytes.Buffer
-	printCriticalItem(&buf, items[0])
-	out := buf.String()
-
-	if !strings.Contains(out, "Status: CrashLoopBackOff (ProbeFailure)") {
-		t.Errorf("missing relabeled status, got:\n%s", out)
-	}
-	if !strings.Contains(out, "Container app is being killed by its startup/liveness probe before it can stabilize") {
-		t.Errorf("missing causal probe message, got:\n%s", out)
-	}
-}
-
-// A pod in CrashLoopBackOff with NO probe-failure event (a genuine
-// unrelated crash) must be left exactly as today: a plain
-// CrashLoopBackOff entry, no relabeling.
-func TestMergeCrashLoopOOM_NoProbeSignatureUnaffected(t *testing.T) {
-	crashLoop := issue("prod", "checkout-7d9f8b6c5-x7z2m9", "critical", "CrashLoopBackOff",
-		"Container app is crash looping: back-off restarting failed container", 42)
-	// probeFailure left false, as if annotateProbeFailures found no
-	// matching event (or none at all).
-
-	items := mergeCrashLoopOOM([]enrichedIssue{crashLoop})
-	if len(items) != 1 || items[0].oomCause != nil || items[0].probeFailure {
-		t.Fatalf("expected unmerged, unrelabeled entry, got %+v", items)
-	}
-
-	var buf bytes.Buffer
-	printCriticalItem(&buf, items[0])
-	out := buf.String()
-	if !strings.Contains(out, "Status: CrashLoopBackOff | Restarts: 42") {
-		t.Errorf("expected unchanged plain status line, got:\n%s", out)
-	}
-	if strings.Contains(out, "ProbeFailure") || strings.Contains(out, "probe") {
-		t.Errorf("should show no probe-related text when no signature was found, got:\n%s", out)
-	}
-}
-
-// A pod with BOTH an OOMKilled cause AND a probe-failure event signature
-// must resolve to the OOMKilled merge — documented precedence: an
-// observed OOM is the more certain, direct cause; the probe-failure
-// signal is dropped rather than shown alongside it.
-func TestMergeCrashLoopOOM_OOMKilledTakesPrecedenceOverProbeFailure(t *testing.T) {
-	crashLoop := issue("prod", "checkout-7d9f8b6c5-x7z2m9", "critical", "CrashLoopBackOff",
-		"Container app is crash looping: back-off restarting failed container", 42)
-	crashLoop.probeFailure = true
-	oom := issue("prod", "checkout-7d9f8b6c5-x7z2m9", "critical", "OOMKilled",
-		"Container app killed due to out of memory", 42)
-
-	items := mergeCrashLoopOOM([]enrichedIssue{crashLoop, oom})
-	if len(items) != 1 {
-		t.Fatalf("expected 1 merged critical item, got %d: %+v", len(items), items)
-	}
-	if items[0].oomCause == nil {
-		t.Fatalf("expected OOMKilled merge to win over probe-failure signal, got %+v", items[0])
-	}
-	if items[0].probeFailure {
-		t.Errorf("probeFailure flag should not also be set once OOMKilled merge applies, got %+v", items[0])
-	}
-
-	var buf bytes.Buffer
-	printCriticalItem(&buf, items[0])
-	out := buf.String()
-	if !strings.Contains(out, "Status: CrashLoopBackOff (OOMKilled)") {
-		t.Errorf("expected OOMKilled label to take precedence, got:\n%s", out)
-	}
-	if strings.Contains(out, "ProbeFailure") {
-		t.Errorf("expected no probe-failure text once OOMKilled wins, got:\n%s", out)
-	}
-}
-
 // Reproduces the real corp-cluster medispan-dur-engine event text from
 // this session: "Startup probe failed: HTTP probe failed with
 // statuscode: 500" followed by "failed startup probe, will be
@@ -151,17 +62,16 @@ func TestHasProbeFailureSignature_MedispanDurEngineRealEvents(t *testing.T) {
 	}
 }
 
-func TestAnnotateProbeFailures_NoCrashLoopIssuesSkipsClientsetEntirely(t *testing.T) {
-	// getKubernetesClient would fail against an unresolvable context; if
-	// annotateProbeFailures tried to build a clientset here it would log
-	// an error. With no CrashLoopBackOff issues in the input there is
-	// nothing to check, so it must return early without attempting to
-	// connect at all — and therefore without mutating anything.
-	issues := []enrichedIssue{
-		issue("prod", "steady-pod", "high", "Pending", "Pod pending for extended period", 0),
+// detectProbeFailures must not attempt a clientset connection at all when
+// there are no CrashLoopBackOff issues to check — getKubernetesClient
+// would fail against an unresolvable context, which would otherwise show
+// up as a logged error with nothing to check it against.
+func TestDetectProbeFailures_NoCrashLoopIssuesSkipsClientsetEntirely(t *testing.T) {
+	issues := []models.EmergencyIssue{
+		rawIssue("prod", "steady-pod", "high", "Pending", "Pod pending for extended period", 0),
 	}
-	got := annotateProbeFailures("does-not-exist-context", issues)
-	if len(got) != 1 || got[0].probeFailure {
-		t.Fatalf("expected input returned unmodified, got %+v", got)
+	got := detectProbeFailures("does-not-exist-context", issues)
+	if got != nil {
+		t.Fatalf("expected a nil map (no clientset attempt) when there are no CrashLoopBackOff issues, got %+v", got)
 	}
 }

--- a/cmd/opscart-scan/emergency_test.go
+++ b/cmd/opscart-scan/emergency_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -391,3 +392,272 @@ func TestPersistFindings_FakeStoreErrorsDoNotCrash(t *testing.T) {
 type errString string
 
 func (e errString) Error() string { return string(e) }
+
+// TestApplyCriticalDebounce_KeepsCriticalWhenActiveIncidentExists is the
+// core fixture: a pod with an existing active CRITICAL incident in the
+// store, whose live scan this run shows as milder (Running/high-restart),
+// must still display CRITICAL, not the live MEDIUM classification.
+// fakeStore mirrors its single fake record across every fingerprint
+// queried (see fakeStore.BatchGetIncidentHistory's doc comment), so it
+// can't distinguish which of criticalDebounceReasons is "really" active —
+// applyCriticalDebounce takes the first match in priority order, which is
+// "CrashLoopBackOff (OOMKilled)".
+func TestApplyCriticalDebounce_KeepsCriticalWhenActiveIncidentExists(t *testing.T) {
+	live := []enrichedIssue{
+		issue("prod", "payment-processor-6c9f8b6c5-x7z2m9", "medium", "HighRestartCount",
+			"Container app has restarted 6412 times", 6412),
+	}
+	fs := &fakeStore{
+		history: &store.IncidentRecord{Status: "active"},
+	}
+
+	got := applyCriticalDebounce(fs, "prod-cluster", live)
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(got))
+	}
+	if got[0].Severity != "critical" {
+		t.Errorf("Severity = %q, want critical", got[0].Severity)
+	}
+	if !isCriticalDebounceReason(got[0].Reason) {
+		t.Errorf("Reason = %q, want one of criticalDebounceReasons", got[0].Reason)
+	}
+	if got[0].Restarts != 6412 {
+		t.Errorf("Restarts = %d, want unchanged 6412", got[0].Restarts)
+	}
+}
+
+// TestApplyCriticalDebounce_NewIssueStaysAtLiveSeverity is the "genuinely
+// new issue" fixture: no existing incident in the store means a
+// MEDIUM-level live finding is left exactly as classified, not inflated
+// to CRITICAL just because the debounce check ran.
+func TestApplyCriticalDebounce_NewIssueStaysAtLiveSeverity(t *testing.T) {
+	live := []enrichedIssue{
+		issue("prod", "worker-6c9f8b6c5-x7z2m9", "medium", "HighRestartCount",
+			"Container app has restarted 12 times", 12),
+	}
+	fs := &fakeStore{} // no history for any fingerprint
+
+	got := applyCriticalDebounce(fs, "prod-cluster", live)
+
+	if got[0].Severity != "medium" || got[0].Reason != "HighRestartCount" {
+		t.Errorf("brand-new issue was altered: %+v", got[0])
+	}
+}
+
+// TestApplyCriticalDebounce_ResolvedIncidentNotResurrected is the
+// "existing RESOLVED incident, live scan shows it healthy" fixture: a
+// resolved incident must never resurrect a milder live finding into
+// CRITICAL.
+func TestApplyCriticalDebounce_ResolvedIncidentNotResurrected(t *testing.T) {
+	live := []enrichedIssue{
+		issue("prod", "worker-6c9f8b6c5-x7z2m9", "medium", "HighRestartCount",
+			"Container app has restarted 11 times", 11),
+	}
+	fs := &fakeStore{
+		history: &store.IncidentRecord{Status: "resolved"},
+	}
+
+	got := applyCriticalDebounce(fs, "prod-cluster", live)
+
+	if got[0].Severity != "medium" || got[0].Reason != "HighRestartCount" {
+		t.Errorf("resolved incident was incorrectly resurrected: %+v", got[0])
+	}
+}
+
+// TestApplyCriticalDebounce_NullStore_IsExactNoOp is the "--stateless
+// equivalent" fixture: on NullStore, output must be byte-identical to
+// running with applyCriticalDebounce's code path entirely absent, proving
+// the no-explicit-stateless-branch design goal actually degrades
+// correctly rather than by coincidence.
+func TestApplyCriticalDebounce_NullStore_IsExactNoOp(t *testing.T) {
+	live := []enrichedIssue{
+		issue("prod", "worker-6c9f8b6c5-x7z2m9", "medium", "HighRestartCount",
+			"Container app has restarted 11 times", 11),
+	}
+
+	withDebounce := applyCriticalDebounce(&store.NullStore{}, "prod-cluster", append([]enrichedIssue{}, live...))
+
+	var got, want bytes.Buffer
+	printEmergencyIssuesEnriched(&got, withDebounce)
+	printEmergencyIssuesEnriched(&want, live)
+
+	if got.String() != want.String() {
+		t.Errorf("NullStore output diverges from debounce-absent output:\ngot:\n%s\nwant:\n%s", got.String(), want.String())
+	}
+}
+
+// TestApplyCriticalDebounce_RealScenario_PaymentProcessor reproduces the
+// exact session scenario that motivated this task: payment-processor was
+// CRITICAL (CrashLoopBackOff) in run 1, and run 2 — five minutes later,
+// landing during the pod's brief post-backoff Running window — saw it as
+// milder. Run 2's display must still report it CRITICAL, using run 1's
+// persisted state.
+func TestApplyCriticalDebounce_RealScenario_PaymentProcessor(t *testing.T) {
+	// Run 1: persisted to the store as an active CRITICAL incident.
+	run1 := []models.EmergencyIssue{
+		{Namespace: "prod", Name: "payment-processor-6c9f8b6c5-x7z2m9", Reason: "CrashLoopBackOff",
+			Severity: "critical", Message: "Container app is crash looping: back-off restarting failed container", Restarts: 8},
+	}
+	fs := &fakeStore{
+		history: &store.IncidentRecord{Status: "active"},
+	}
+	persistFindings(fs, "corp-cluster", "scan-1", run1)
+
+	// Run 2: live scan lands mid-backoff and classifies it milder.
+	run2 := []enrichedIssue{
+		issue("prod", "payment-processor-6c9f8b6c5-x7z2m9", "medium", "HighRestartCount",
+			"Container app has restarted 9 times", 9),
+	}
+
+	got := applyCriticalDebounce(fs, "corp-cluster", run2)
+
+	if got[0].Severity != "critical" {
+		t.Errorf("Severity = %q, want critical (run 1's persisted state should have been consulted)", got[0].Severity)
+	}
+	if !isCriticalDebounceReason(got[0].Reason) {
+		t.Errorf("Reason = %q, want one of criticalDebounceReasons", got[0].Reason)
+	}
+
+	var buf bytes.Buffer
+	printEmergencyIssuesEnriched(&buf, got)
+	if !strings.Contains(buf.String(), "CrashLoopBackOff") {
+		t.Errorf("printed output should still show CrashLoopBackOff, got:\n%s", buf.String())
+	}
+	if strings.Contains(buf.String(), "MEDIUM PRIORITY") {
+		t.Errorf("payment-processor should not be counted under MEDIUM this run, got:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "🟠 MEDIUM: 0") {
+		t.Errorf("expected MEDIUM count of 0 in header, got:\n%s", buf.String())
+	}
+}
+
+// countPodBlocks counts how many times a pod identity line ("namespace/
+// pod-name") appears in printed output — the number of separate entry
+// blocks for that pod, regardless of tier or merge shape.
+func countPodBlocks(output, namespace, name string) int {
+	return strings.Count(output, namespace+"/"+name)
+}
+
+// TestFullPipeline_NoDuplicateWhenPodAlreadyLiveCritical is the regression
+// fixture for the reported bug, run through the real pipeline order
+// (classifyIssues, then enrich/debounce, then print): cluster.go's
+// analyzePodForIssues runs independent per-container checks (not an
+// if/else chain), so a pod that's genuinely CRITICAL this run (live
+// OOMKilled, LastTerminationState persisting through a brief Running
+// window) commonly ALSO produces a raw MEDIUM HighRestartCount signal for
+// the same container in the same scan. classifyIssues collapses that pair
+// to one issue before debounce or printing ever sees it, so — unlike the
+// old print-time dedup this replaces — there is no second, synthetic
+// entry to guard against downstream. History shows an active
+// CrashLoopBackOff incident for this pod (from an earlier scan), which
+// debounce is free to ignore since the live signal is already CRITICAL.
+func TestFullPipeline_NoDuplicateWhenPodAlreadyLiveCritical(t *testing.T) {
+	raw := []models.EmergencyIssue{
+		// Raw order mirrors cluster.go's fixed per-container append
+		// order: OOMKilled is appended before HighRestartCount.
+		rawIssue("data-pipeline", "stream-processor-66c474d5fd-9zpwq", "critical", "OOMKilled",
+			"Container stress killed due to out of memory", 6301),
+		rawIssue("data-pipeline", "stream-processor-66c474d5fd-9zpwq", "medium", "HighRestartCount",
+			"Container stress has restarted 6301 times", 6301),
+	}
+	fs := &fakeStore{
+		history: &store.IncidentRecord{Status: "active"},
+	}
+
+	classified := classifyIssues(raw, nil)
+	got := applyCriticalDebounce(fs, "corp-cluster", enrichIssues(fs, "corp-cluster", classified))
+
+	var buf bytes.Buffer
+	printEmergencyIssuesEnriched(&buf, got)
+	out := buf.String()
+
+	if n := countPodBlocks(out, "data-pipeline", "stream-processor-66c474d5fd-9zpwq"); n != 1 {
+		t.Errorf("expected exactly 1 printed block for stream-processor, got %d:\n%s", n, out)
+	}
+	if !strings.Contains(out, "🔴 CRITICAL: 1") {
+		t.Errorf("expected CRITICAL count of 1, got:\n%s", out)
+	}
+	if strings.Contains(out, "container ") || strings.Contains(out, "Container container") {
+		t.Errorf("placeholder container name leaked into output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Container stress killed due to out of memory") {
+		t.Errorf("expected the real, live OOMKilled message to survive, got:\n%s", out)
+	}
+}
+
+// TestApplyCriticalDebounce_NoIncidentNoLiveIssue_AddsNothing is the
+// "genuinely healthy pod" fixture: with no existing incident and nothing
+// found live, applyCriticalDebounce must not manufacture an entry.
+func TestApplyCriticalDebounce_NoIncidentNoLiveIssue_AddsNothing(t *testing.T) {
+	fs := &fakeStore{} // no history for any fingerprint
+
+	got := applyCriticalDebounce(fs, "corp-cluster", nil)
+	if len(got) != 0 {
+		t.Errorf("expected no issues added for a pod with no live entry and no history, got %+v", got)
+	}
+}
+
+// TestFullPipeline_EightPodsNotSixteen reproduces the full session
+// scenario through the real pipeline order (classifyIssues first, then
+// enrich/debounce, then print): 8 pods, each with an existing active
+// CRITICAL incident, in a mix of raw states (still genuinely CRITICAL,
+// CRITICAL+coexisting MEDIUM raw signals for the same container, and
+// MEDIUM-only caught mid-backoff). classifyIssues collapses each pod to
+// one issue before debounce ever runs. The final CRITICAL count must be
+// 8, not 16 — every pod must appear exactly once.
+func TestFullPipeline_EightPodsNotSixteen(t *testing.T) {
+	var raw []models.EmergencyIssue
+	raw = append(raw,
+		// pod1: still genuinely CrashLoopBackOff this run.
+		rawIssue("prod", "pod1-abc", "critical", "CrashLoopBackOff",
+			"Container app is crash looping: back-off restarting failed container", 100),
+		// pod2: live OOMKilled + coexisting raw MEDIUM HighRestartCount for the same container.
+		rawIssue("prod", "pod2-abc", "critical", "OOMKilled",
+			"Container app killed due to out of memory", 200),
+		rawIssue("prod", "pod2-abc", "medium", "HighRestartCount",
+			"Container app has restarted 200 times", 200),
+		// pod3: caught mid-backoff, MEDIUM-only this run.
+		rawIssue("prod", "pod3-abc", "medium", "HighRestartCount",
+			"Container app has restarted 300 times", 300),
+		// pod4: both CrashLoopBackOff and OOMKilled live (real merge case).
+		rawIssue("prod", "pod4-abc", "critical", "CrashLoopBackOff",
+			"Container app is crash looping: back-off restarting failed container", 400),
+		rawIssue("prod", "pod4-abc", "critical", "OOMKilled",
+			"Container app killed due to out of memory", 400),
+		// pod5: caught mid-backoff, MEDIUM-only this run.
+		rawIssue("prod", "pod5-abc", "medium", "HighRestartCount",
+			"Container app has restarted 500 times", 500),
+		// pod6: live CrashLoopBackOff + coexisting raw MEDIUM for the same container.
+		rawIssue("prod", "pod6-abc", "critical", "CrashLoopBackOff",
+			"Container app is crash looping: back-off restarting failed container", 600),
+		rawIssue("prod", "pod6-abc", "medium", "HighRestartCount",
+			"Container app has restarted 600 times", 600),
+		// pod7: live OOMKilled only, no crash loop.
+		rawIssue("prod", "pod7-abc", "critical", "OOMKilled",
+			"Container app killed due to out of memory", 700),
+		// pod8: caught mid-backoff, MEDIUM-only this run.
+		rawIssue("prod", "pod8-abc", "medium", "HighRestartCount",
+			"Container app has restarted 800 times", 800),
+	)
+	fs := &fakeStore{
+		history: &store.IncidentRecord{Status: "active"},
+	}
+
+	classified := classifyIssues(raw, nil)
+	got := applyCriticalDebounce(fs, "corp-cluster", enrichIssues(fs, "corp-cluster", classified))
+
+	var buf bytes.Buffer
+	printEmergencyIssuesEnriched(&buf, got)
+	out := buf.String()
+
+	if !strings.Contains(out, "🔴 CRITICAL: 8") {
+		t.Errorf("expected CRITICAL count of 8, got:\n%s", out)
+	}
+	for i := 1; i <= 8; i++ {
+		name := fmt.Sprintf("pod%d-abc", i)
+		if n := countPodBlocks(out, "prod", name); n != 1 {
+			t.Errorf("expected exactly 1 printed block for %s, got %d:\n%s", name, n, out)
+		}
+	}
+}


### PR DESCRIPTION
Root cause of tonight's duplicate-entries and count-instability: CrashLoopBackOff/OOMKilled/ProbeFailure/HighRestartCount were evaluated independently, producing multiple fingerprints/incidents for one physical pod. classifyPod() now returns exactly one classification per pod, priority order, first match wins. Removed mergeCrashLoopOOM, dedupeMediumTier, and the print-time-merge functions — all were workarounds for the duplication this fix eliminates at the source.