### PR TITLE
Feature/workload scoped incidents

### DIFF
--- a/cmd/opscart-dashboard/incident.go
+++ b/cmd/opscart-dashboard/incident.go
@@ -26,6 +26,7 @@ type incidentsPageData struct {
 	IncidentsHref string
 	ActivePage    string
 	ClusterName   string
+	ClusterParam  string
 	CriticalCount int
 	Clusters      []sidebarCluster
 
@@ -95,6 +96,7 @@ func (srv *server) handleIncidentsPage(w http.ResponseWriter, r *http.Request) {
 		IncidentsHref: "/incidents" + clusterQ,
 		ActivePage:    "incidents",
 		ClusterName:   displayName(ctx),
+		ClusterParam:  ctx,
 		CriticalCount: countCriticalIssues(scan),
 		Filter:        f,
 		Page:          page,
@@ -228,6 +230,10 @@ var getIncidentsTmpl = sync.OnceValue(func() *template.Template {
 				"prevPage":      prevPage,
 				"nextPage":      nextPage,
 				"pageRange":     pageRange,
+				"ownerName":     store.OwnerNameFromPod,
+				"isNamespaceScoped": func(issueType string) bool {
+					return issueType == "unprotected_namespace" || issueType == "idle_namespace"
+				},
 			}).
 			ParseFS(templateFS,
 				"templates/base.html",

--- a/cmd/opscart-dashboard/incident_test.go
+++ b/cmd/opscart-dashboard/incident_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/opscart/opscart-k8s-watcher/pkg/store"
+)
+
+func TestRenderIncidentsUsesWorkloadIdentity(t *testing.T) {
+	data := incidentsPageData{
+		ClusterName:  "opscart",
+		ClusterParam: "opscart",
+		Page:         1,
+		PerPage:      50,
+		Total:        2,
+		TotalPages:   1,
+		Incidents: []store.IncidentSummary{
+			{
+				Namespace: "payments", Resource: "fraud-detection-7cddf79d98-jxmtx",
+				IssueType: "crash_loop", Severity: "critical", Status: "active",
+				ReopenCount: 1095, FirstSeen: time.Now().Add(-26 * 24 * time.Hour),
+			},
+			{
+				Namespace: "monitoring", Resource: "namespace",
+				IssueType: "idle_namespace", Severity: "high", Status: "active",
+			},
+		},
+	}
+	rec := httptest.NewRecorder()
+	renderIncidents(rec, data)
+	body := rec.Body.String()
+
+	for _, want := range []string{
+		"<th>Workload</th>",
+		"Workload/fraud-detection",
+		"currently: fraud-detection-7cddf79d98-jxmtx",
+		"crash_loop",
+		"Namespace/monitoring",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("rendered incidents page missing %q", want)
+		}
+	}
+	if strings.Contains(body, "×1095") {
+		t.Error("rendered incidents page exposed an untrusted recurrence count")
+	}
+	if strings.Contains(body, "cluster=current-context") {
+		t.Error("rendered incidents page leaked current-context into a URL")
+	}
+	if strings.Contains(body, "/investigate?pod=namespace") {
+		t.Error("namespace incident link included a synthetic pod parameter")
+	}
+	if !strings.Contains(body, "/investigate?ns=monitoring") {
+		t.Error("namespace incident link omitted namespace")
+	}
+	if !strings.Contains(body, "/investigate?pod=fraud-detection-7cddf79d98-jxmtx") {
+		t.Error("workload incident link omitted the Focus Pod")
+	}
+}

--- a/cmd/opscart-dashboard/investigation.go
+++ b/cmd/opscart-dashboard/investigation.go
@@ -44,13 +44,17 @@ type investigationPageData struct {
 	Clusters      []sidebarCluster
 
 	// Pod identity
-	PodName       string
-	Namespace     string
-	IssueType     string // crash_loop, image_pull_backoff, oomkilled, privileged_container, probe_failure...
-	Severity      string
-	OwnerKind     string // Deployment / StatefulSet / Job / (none)
-	OwnerName     string
-	ContainerName string // set when the finding is container-scoped (e.g. privileged_container); empty otherwis
+	PodName         string
+	Namespace       string
+	IssueType       string // crash_loop, image_pull_backoff, oomkilled, privileged_container, probe_failure...
+	Severity        string
+	OwnerKind       string // Deployment / StatefulSet / Job / (none)
+	OwnerName       string
+	ContainerName   string // set when the finding is container-scoped (e.g. privileged_container); empty otherwis
+	WorkloadLabel   string
+	TrackingLabel   string
+	PodAge          string
+	DescribeCommand string
 
 	// Status
 	Phase         string
@@ -136,12 +140,12 @@ func investigationHints(issueType string, stateReason string, restarts int32, po
 		hints = append(hints, investigationHint{
 			Confidence: "high",
 			Title:      "Apply a default-deny NetworkPolicy",
-			Reason:     "No NetworkPolicy means every pod in this namespace can be reached by every other pod in the cluster.",
+			Reason:     "No NetworkPolicy was detected; review the namespace's intended ingress and egress controls before applying a default-deny policy.",
 			Command:    fmt.Sprintf("kubectl get networkpolicies -n %s", namespace),
 		})
 		hints = append(hints, investigationHint{
 			Confidence: "medium",
-			Title:      "Review which pods are actually exposed",
+			Title:      "Review pods and intended network access",
 			Reason:     "Confirm the pod count and whether any of them handle sensitive data or traffic.",
 			Command:    fmt.Sprintf("kubectl get pods -n %s", namespace),
 		})
@@ -165,7 +169,10 @@ func investigationHints(issueType string, stateReason string, restarts int32, po
 			hints = append(hints, investigationHint{
 				Confidence: "high",
 				Title:      "Deterministic failure — not transient",
-				Reason:     fmt.Sprintf("Restart count of %d indicates the failure reproduces consistently on every start.", restarts),
+				Reason: fmt.Sprintf(
+					"The pod has restarted %d times. Review previous container logs and restart timing to identify the recurring condition.",
+					restarts,
+				),
 			})
 		}
 		hints = append(hints, investigationHint{
@@ -668,7 +675,8 @@ func populateNamespaceFinding(data *investigationPageData, scan *clusterScan, is
 		for _, ns := range scan.netAudit.UnprotectedNamespaces {
 			if ns.Name == namespace {
 				data.NamespacePodCount = ns.PodCount
-				data.NamespaceFinding = ns.RiskReason
+				data.NamespaceFinding = "No default-deny NetworkPolicy detected in a system namespace"
+				data.Severity = strings.ToLower(ns.RiskLevel)
 				return
 			}
 		}
@@ -692,7 +700,11 @@ func (srv *server) handleInvestigationPage(w http.ResponseWriter, r *http.Reques
 	namespace := r.URL.Query().Get("ns")
 	issueType := r.URL.Query().Get("type")
 
-	if podName == "" || namespace == "" {
+	namespaceScopedTypes := map[string]bool{
+		"unprotected_namespace": true,
+		"idle_namespace":        true,
+	}
+	if namespace == "" || issueType == "" || (podName == "" && !namespaceScopedTypes[issueType]) {
 		http.Error(w, "missing pod or ns query parameter", http.StatusBadRequest)
 		return
 	}
@@ -727,16 +739,16 @@ func (srv *server) handleInvestigationPage(w http.ResponseWriter, r *http.Reques
 		PodName:       podName,
 		Namespace:     namespace,
 		IssueType:     issueType,
+		WorkloadLabel: "Workload/" + store.OwnerNameFromPod(podName),
+		TrackingLabel: "Workload scoped",
 		BackURL:       backURL,
 		ScannedAtMs:   time.Now().UnixMilli(),
 	}
 
-	var namespaceScopedTypes = map[string]bool{
-		"unprotected_namespace": true,
-		"idle_namespace":        true,
-	}
 	if namespaceScopedTypes[issueType] {
 		data.NamespaceScoped = true
+		data.WorkloadLabel = "Namespace/" + namespace
+		data.TrackingLabel = "Namespace scoped"
 		populateNamespaceFinding(&data, scan, issueType, namespace)
 		data.Hints = investigationHints(issueType, "", 0, nil, namespace)
 		for _, h := range data.Hints {
@@ -807,16 +819,32 @@ func (srv *server) handleInvestigationPage(w http.ResponseWriter, r *http.Reques
 	// Status
 	data.Phase = string(pod.Status.Phase)
 	data.AgeDays = int(time.Since(pod.CreationTimestamp.Time).Hours() / 24)
+	data.PodAge = humanAge(time.Since(pod.CreationTimestamp.Time))
 	data.Severity = "critical"
 	for _, cs := range pod.Status.ContainerStatuses {
 		data.Restarts += cs.RestartCount
-		if cs.State.Waiting != nil && data.StateReason == "" {
-			data.StateReason = cs.State.Waiting.Reason
+		if state := effectiveContainerState(cs); state != "" && data.StateReason == "" {
+			data.StateReason = state
+			if data.ContainerName == "" {
+				data.ContainerName = cs.Name
+			}
 		}
 	}
 
 	// Owner, events, related resources, hints
 	data.OwnerKind, data.OwnerName = resolveOwner(clientset, pod)
+	if data.OwnerKind != "" {
+		data.WorkloadLabel = data.OwnerKind + "/" + data.OwnerName
+		if data.OwnerKind == "StatefulSet" {
+			data.TrackingLabel = "StatefulSet instance scoped"
+		} else {
+			data.TrackingLabel = data.OwnerKind + " scoped"
+		}
+	} else {
+		data.WorkloadLabel = "Pod/" + podName
+		data.TrackingLabel = "Pod scoped"
+	}
+	data.DescribeCommand = fmt.Sprintf("kubectl describe pod %s -n %s", podName, namespace)
 	data.Events = podEvents(clientset, namespace, podName, 10)
 	data.ConfigMaps, data.Secrets, data.PVCs = referencedResources(pod)
 	data.Hints = investigationHints(issueType, data.StateReason, data.Restarts, pod, namespace)
@@ -867,11 +895,26 @@ func (srv *server) handleInvestigationPage(w http.ResponseWriter, r *http.Reques
 	renderInvestigation(w, data)
 }
 
+func effectiveContainerState(status corev1.ContainerStatus) string {
+	if status.State.Waiting != nil {
+		return status.State.Waiting.Reason
+	}
+	if status.State.Terminated != nil {
+		if status.State.Terminated.Reason != "" {
+			return status.State.Terminated.Reason
+		}
+		return fmt.Sprintf("Terminated (exit code %d)", status.State.Terminated.ExitCode)
+	}
+	return ""
+}
+
 var getInvestigationTmpl = sync.OnceValue(func() *template.Template {
 	return template.Must(
 		template.New("investigation.html").
 			Funcs(template.FuncMap{
-				"mul": func(a, b int) int { return a * b },
+				"mul":                   func(a, b int) int { return a * b },
+				"issueTypeLabel":        issueTypeLabel,
+				"unrepresentedCommands": unrepresentedCommands,
 				"div": func(a, b int) int {
 					if b == 0 {
 						return 0
@@ -923,85 +966,121 @@ func buildOperationalSummary(data *investigationPageData) string {
 		return "This pod no longer exists — it may have been deleted or recreated with a new name since the last scan."
 	}
 
-	var parts []string
-
 	if data.NamespaceScoped {
-		parts = append(parts, fmt.Sprintf("Namespace %s: %s", data.Namespace, data.NamespaceFinding))
-	} else {
-		// Restart pattern
-		if data.Restarts > 0 {
-			rate := "stable"
-			if data.AgeDays > 0 && int(data.Restarts)/data.AgeDays > 200 {
-				rate = "accelerating"
-			}
-			failureType := "deterministic configuration or application"
-			if rate == "accelerating" {
-				failureType = "worsening or resource-related"
-			}
-			parts = append(parts, fmt.Sprintf(
-				"This workload has restarted %d times over %d day(s). The restart rate appears %s, suggesting a %s failure.",
-				data.Restarts, max(data.AgeDays, 1), rate, failureType))
+		var summary string
+		switch data.IssueType {
+		case "unprotected_namespace":
+			summary = fmt.Sprintf("No NetworkPolicy was detected in the %s namespace.", data.Namespace)
+		case "idle_namespace":
+			summary = fmt.Sprintf("An idle namespace finding is active for the %s namespace.", data.Namespace)
+		default:
+			summary = fmt.Sprintf("A %s finding is active for the %s namespace.", strings.ToLower(issueTypeLabel(data.IssueType)), data.Namespace)
 		}
+		summary += fmt.Sprintf(" The namespace currently contains %d pods.", data.NamespacePodCount)
+		if data.Severity != "" {
+			summary += fmt.Sprintf(" This finding is classified as %s.", strings.ToLower(data.Severity))
+		}
+		return summary
+	}
 
-		// Config references
-		if len(data.Secrets) == 0 && len(data.ConfigMaps) == 0 {
-			parts = append(parts,
-				"No referenced ConfigMaps or Secrets were detected in the pod spec — missing configuration is unlikely to be the root cause.")
+	subject := data.WorkloadLabel
+	if subject == "" {
+		subject = "This workload"
+	}
+	summary := fmt.Sprintf("A %s incident is active for %s.",
+		strings.ToLower(issueTypeLabel(data.IssueType)), subject)
+	if data.FirstDetected != "" {
+		summary += fmt.Sprintf(" Operational memory first detected this incident %s.", relativePart(data.FirstDetected))
+	}
+
+	status := data.StateReason
+	if status == "" {
+		status = data.Phase
+	}
+	focus := fmt.Sprintf(" The Focus Pod %s", data.PodName)
+	if status != "" {
+		focus += fmt.Sprintf(" is currently in %s", status)
+	}
+	if data.PodAge != "" {
+		if status != "" {
+			focus += fmt.Sprintf(", is %s old", data.PodAge)
 		} else {
-			parts = append(parts, fmt.Sprintf(
-				"The pod references %d ConfigMap(s) and %d Secret(s) — verify these exist and contain the expected keys.",
-				len(data.ConfigMaps), len(data.Secrets)))
+			focus += fmt.Sprintf(" is %s old", data.PodAge)
 		}
 	}
-
-	// Issue-specific recommendation
-	switch data.IssueType {
-	case "crash_loop":
-		parts = append(parts,
-			"Investigation should begin with previous container logs. Estimated time: 5–10 minutes.")
-	case "image_pull_backoff":
-		parts = append(parts,
-			"Investigation should begin with registry credentials and image tag verification. Estimated time: 2–5 minutes.")
-	case "oomkilled":
-		parts = append(parts,
-			"Investigation should begin with memory limit configuration. Estimated time: 5 minutes.")
-	case "privileged_container":
-		parts = append(parts,
-			"Review whether privileged mode is genuinely required — most workloads can use specific capabilities instead.")
-	case "probe_failure":
-		parts = append(parts,
-			"Investigation should begin with the probe configuration — this container is starting successfully but being killed for failing its startup or liveness check. Estimated time: 5–10 minutes.")
-	case "unprotected_namespace":
-		parts = append(parts,
-			"This is a configuration gap, not a runtime failure — no pod-level investigation applies here.")
-	case "idle_namespace":
-		parts = append(parts,
-			"This is a configuration/waste finding, not a runtime failure — no pod-level investigation applies here.")
-	}
-
-	return strings.Join(parts, " ")
+	focus += fmt.Sprintf(", and has restarted %d times.", data.Restarts)
+	return summary + focus
 }
 
-func max(a, b int) int {
-	if a > b {
-		return a
+func issueTypeLabel(issueType string) string {
+	switch issueType {
+	case "probe_failure":
+		return "Probe Failure"
+	case "crash_loop":
+		return "CrashLoopBackOff"
+	case "image_pull_backoff":
+		return "ImagePullBackOff"
+	case "oomkilled":
+		return "OOMKilled"
+	case "privileged_container":
+		return "Privileged Container"
+	case "unprotected_namespace":
+		return "Unprotected Namespace"
+	case "idle_namespace":
+		return "Idle Namespace"
 	}
-	return b
+	words := strings.Fields(strings.ReplaceAll(issueType, "_", " "))
+	for i := range words {
+		words[i] = strings.ToUpper(words[i][:1]) + words[i][1:]
+	}
+	return strings.Join(words, " ")
+}
+
+func relativePart(label string) string {
+	if _, relative, ok := strings.Cut(label, " · "); ok {
+		return relative
+	}
+	return label
+}
+
+func unrepresentedCommands(commands []string, hints []investigationHint) []string {
+	represented := make(map[string]bool, len(hints))
+	for _, hint := range hints {
+		if hint.Command != "" {
+			represented[hint.Command] = true
+		}
+	}
+	var result []string
+	for _, command := range commands {
+		if command != "" && !represented[command] {
+			result = append(result, command)
+		}
+	}
+	return result
 }
 
 // firstDetectedLabel converts a first_seen timestamp to a human label.
-// Returns "today", "1 day ago", "N days ago", or "" for zero time.
+// It combines an absolute date with a relative calendar-day duration.
 func firstDetectedLabel(t time.Time) string {
+	return firstDetectedLabelAt(t, time.Now())
+}
+
+func firstDetectedLabelAt(t, now time.Time) string {
 	if t.IsZero() {
 		return ""
 	}
-	days := int(time.Since(t).Hours() / 24)
+	t = t.In(now.Location())
+	startOfToday := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	startOfFirstSeen := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, now.Location())
+	days := int(startOfToday.Sub(startOfFirstSeen).Hours() / 24)
+	var relative string
 	switch days {
 	case 0:
-		return "today"
+		relative = "today"
 	case 1:
-		return "1 day ago"
+		relative = "1 day"
 	default:
-		return fmt.Sprintf("%d days ago", days)
+		relative = fmt.Sprintf("%d days", days)
 	}
+	return t.Format("Jan 2") + " · " + relative
 }

--- a/cmd/opscart-dashboard/investigation_test.go
+++ b/cmd/opscart-dashboard/investigation_test.go
@@ -5,9 +5,12 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/opscart/opscart-k8s-watcher/pkg/analyzer"
 	"github.com/opscart/opscart-k8s-watcher/pkg/store"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // bogusClusterCtx is a kubeconfig context name that will never exist on the
@@ -31,7 +34,7 @@ func TestHandleInvestigationPage_NamespaceScopedSkipsPodLookup(t *testing.T) {
 			scan: &clusterScan{
 				netAudit: &analyzer.NetworkPolicyAudit{
 					UnprotectedNamespaces: []analyzer.NamespaceNetworkStatus{
-						{Name: "test-ns", PodCount: 8, RiskLevel: "HIGH", RiskReason: "Production namespace with no network isolation"},
+						{Name: "test-ns", PodCount: 8, RiskLevel: "HIGH", RiskReason: "critical infrastructure exposed"},
 					},
 				},
 			},
@@ -68,7 +71,36 @@ func TestHandleInvestigationPage_NamespaceScopedSkipsPodLookup(t *testing.T) {
 			if strings.Contains(body, "Blast Radius") {
 				t.Errorf("namespace-scoped page should not render the Blast Radius section")
 			}
+			if strings.Contains(body, "critical infrastructure exposed") {
+				t.Errorf("namespace-scoped page rendered unsupported source text")
+			}
 		})
+	}
+}
+
+func TestHandleInvestigationPage_NamespaceScopedWithoutPodParameter(t *testing.T) {
+	srv := newTestServer()
+	state := srv.getState(bogusClusterCtx)
+	state.scan = &clusterScan{
+		netAudit: &analyzer.NetworkPolicyAudit{
+			UnprotectedNamespaces: []analyzer.NamespaceNetworkStatus{{
+				Name: "test-ns", PodCount: 8, RiskLevel: "HIGH", RiskReason: "critical infrastructure exposed",
+			}},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/investigate?ns=test-ns&type=unprotected_namespace&cluster="+bogusClusterCtx, nil)
+	rec := httptest.NewRecorder()
+	srv.handleInvestigationPage(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("namespace-scoped URL without pod should render, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "critical infrastructure exposed") {
+		t.Errorf("complete rendered namespace page contained unsupported finding text")
+	}
+	if !strings.Contains(rec.Body.String(), "No default-deny NetworkPolicy detected in a system namespace") {
+		t.Errorf("rendered namespace page missing mapped finding")
 	}
 }
 
@@ -113,6 +145,9 @@ func TestPopulateNamespaceFinding(t *testing.T) {
 		if data.NamespacePodCount != 8 || data.NamespaceFinding == "" {
 			t.Errorf("expected pod count 8 and non-empty finding, got %d / %q", data.NamespacePodCount, data.NamespaceFinding)
 		}
+		if data.NamespaceFinding != "No default-deny NetworkPolicy detected in a system namespace" {
+			t.Errorf("unexpected mapped finding: %q", data.NamespaceFinding)
+		}
 	})
 
 	t.Run("idle_namespace match", func(t *testing.T) {
@@ -155,21 +190,24 @@ func TestInvestigationHintsNamespaceScopedNilPod(t *testing.T) {
 
 func TestBuildOperationalSummaryNamespaceScoped(t *testing.T) {
 	data := &investigationPageData{
-		NamespaceScoped:  true,
-		Namespace:        "test-ns",
-		NamespaceFinding: "No NetworkPolicy present",
-		IssueType:        "unprotected_namespace",
+		NamespaceScoped:   true,
+		Namespace:         "test-ns",
+		NamespaceFinding:  "No NetworkPolicy present",
+		IssueType:         "unprotected_namespace",
+		NamespacePodCount: 8,
+		Severity:          "critical",
 	}
 	summary := buildOperationalSummary(data)
 
-	if !strings.Contains(summary, "test-ns") || !strings.Contains(summary, "No NetworkPolicy present") {
-		t.Errorf("expected summary to include namespace and finding, got %q", summary)
+	for _, want := range []string{"No NetworkPolicy was detected", "test-ns", "8 pods", "classified as critical"} {
+		if !strings.Contains(summary, want) {
+			t.Errorf("expected summary to include %q, got %q", want, summary)
+		}
 	}
-	if strings.Contains(summary, "restarted") {
-		t.Errorf("namespace-scoped summary should not include pod restart language, got %q", summary)
-	}
-	if !strings.Contains(summary, "not a runtime failure") {
-		t.Errorf("expected closing sentence about configuration gap, got %q", summary)
+	for _, unsupported := range []string{"restarted", "critical infrastructure exposed", "every pod"} {
+		if strings.Contains(summary, unsupported) {
+			t.Errorf("namespace-scoped summary contains unsupported language %q: %q", unsupported, summary)
+		}
 	}
 }
 
@@ -193,5 +231,238 @@ func TestRenderInvestigationTemplate_NamespaceScoped(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "Namespace Finding") {
 		t.Errorf("expected rendered page to contain the Namespace Finding section")
+	}
+	if !strings.Contains(rec.Body.String(), "apiVersion: networking.k8s.io/v1") {
+		t.Errorf("expected rendered page to preserve the NetworkPolicy YAML")
+	}
+}
+
+func TestRenderInvestigationTemplateUsesFocusPodLabel(t *testing.T) {
+	data := investigationPageData{
+		Namespace:     "default",
+		PodName:       "fraud-detection-7cddf79d98-jxmtx",
+		IssueType:     "crash_loop",
+		Severity:      "critical",
+		WorkloadLabel: "Deployment/fraud-detection",
+		PodAge:        "5m",
+	}
+
+	rec := httptest.NewRecorder()
+	renderInvestigation(rec, data)
+	body := rec.Body.String()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d: %s", rec.Code, body)
+	}
+	if !strings.Contains(body, "Focus Pod") {
+		t.Errorf("expected Focus Pod label, got %q", body)
+	}
+	if strings.Contains(body, "Current Pod") {
+		t.Errorf("rendered page retained Current Pod label")
+	}
+}
+
+func TestInvestigationClassificationIndependentFromCurrentStatus(t *testing.T) {
+	data := investigationPageData{
+		Namespace:     "default",
+		PodName:       "fraud-detection-7cddf79d98-jxmtx",
+		IssueType:     "probe_failure",
+		Severity:      "critical",
+		WorkloadLabel: "Deployment/fraud-detection",
+		TrackingLabel: "Deployment scoped",
+		Phase:         "Running",
+		StateReason:   "CrashLoopBackOff",
+		PodAge:        "3 hours",
+		Restarts:      47,
+		FirstDetected: "Jul 29 · today",
+		OperationalSummary: buildOperationalSummary(&investigationPageData{
+			PodName: "fraud-detection-7cddf79d98-jxmtx", IssueType: "probe_failure",
+			WorkloadLabel: "Deployment/fraud-detection", StateReason: "CrashLoopBackOff",
+			PodAge: "3 hours", Restarts: 47, FirstDetected: "Jul 29 · today",
+		}),
+	}
+
+	body := renderInvestigationBody(t, data)
+	assertInOrder(t, body,
+		"Classification", "Probe Failure",
+		"Pod Phase", "Running",
+		"Container State", "CrashLoopBackOff",
+	)
+	for _, want := range []string{
+		"A probe failure incident is active for Deployment/fraud-detection.",
+		"The Focus Pod fraud-detection-7cddf79d98-jxmtx is currently in CrashLoopBackOff",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("workload page missing %q", want)
+		}
+	}
+	if strings.Contains(body, "currently in Running") {
+		t.Errorf("briefing contradicted the effective container state: %s", body)
+	}
+}
+
+func TestInvestigationHintsUseObservationalRestartLanguage(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "default"}}
+	hints := investigationHints("crash_loop", "CrashLoopBackOff", 101, pod, "default")
+	var reasons string
+	for _, hint := range hints {
+		reasons += hint.Reason
+	}
+	want := "The pod has restarted 101 times. Review previous container logs and restart timing to identify the recurring condition."
+	if !strings.Contains(reasons, want) {
+		t.Errorf("restart guidance missing observational wording: %q", reasons)
+	}
+	if strings.Contains(reasons, "failure reproduces consistently on every start") {
+		t.Errorf("restart guidance retained unsupported deterministic claim")
+	}
+}
+
+func TestEffectiveContainerState(t *testing.T) {
+	tests := []struct {
+		name   string
+		status corev1.ContainerStatus
+		want   string
+	}{
+		{
+			name: "waiting",
+			status: corev1.ContainerStatus{State: corev1.ContainerState{
+				Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+			}},
+			want: "CrashLoopBackOff",
+		},
+		{
+			name: "terminated error",
+			status: corev1.ContainerStatus{State: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{Reason: "Error", ExitCode: 1},
+			}},
+			want: "Error",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := effectiveContainerState(tc.status); got != tc.want {
+				t.Errorf("effectiveContainerState() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInvestigationWorkloadSectionsAndLabels(t *testing.T) {
+	data := investigationPageData{
+		Namespace:          "default",
+		PodName:            "fraud-detection-7cddf79d98-jxmtx",
+		IssueType:          "crash_loop",
+		Severity:           "critical",
+		WorkloadLabel:      "Deployment/fraud-detection",
+		TrackingLabel:      "Deployment scoped",
+		StateReason:        "CrashLoopBackOff",
+		PodAge:             "3 hours",
+		Restarts:           47,
+		FirstDetected:      "Jul 10 · 19 days",
+		OperationalSummary: "A CrashLoopBackOff incident is active. The Focus Pod is observed from live data.",
+		Hints:              []investigationHint{{Confidence: "high", Title: "Check logs"}},
+		Timeline: []store.IncidentEvent{{
+			OccurredAt: time.Now(), EventType: "DETECTED", Message: "crash_loop first detected",
+		}},
+		BlastSiblings: []blastRadiusPod{{Name: "fraud-detection-a", Phase: "Running", Healthy: true}},
+		BlastHealthy:  1,
+		BlastTotal:    2,
+	}
+
+	body := renderInvestigationBody(t, data)
+	if strings.Contains(body, "<h2>Evidence</h2>") || strings.Contains(body, "<div class=\"inv-evidence-label\">State</div>") {
+		t.Errorf("workload page rendered legacy Evidence content")
+	}
+	for _, want := range []string{"Replica Health", "Jul 10 · 19 days"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("workload page missing %q", want)
+		}
+	}
+	assertInOrder(t, body,
+		"Situation Briefing",
+		"Operational Identity",
+		"Current Observation",
+		"Recommended Investigation",
+		"Incident Timeline",
+		"Blast Radius",
+		"Recent Events",
+		"Related Resources",
+	)
+}
+
+func TestInvestigationNamespaceSectionsAndEvidence(t *testing.T) {
+	command := "kubectl get networkpolicies -n monitoring"
+	data := investigationPageData{
+		Namespace:          "monitoring",
+		PodName:            "namespace",
+		IssueType:          "unprotected_namespace",
+		Severity:           "critical",
+		NamespaceScoped:    true,
+		NamespacePodCount:  8,
+		NamespaceFinding:   "No NetworkPolicy present",
+		OperationalSummary: "No NetworkPolicy was detected in the monitoring namespace. The namespace currently contains 8 pods.",
+		Hints:              []investigationHint{{Confidence: "high", Title: "Apply a policy", Command: command}},
+		Commands:           []string{command},
+		Timeline: []store.IncidentEvent{{
+			OccurredAt: time.Now(), EventType: "DETECTED", Message: "unprotected_namespace first detected",
+		}},
+	}
+
+	body := renderInvestigationBody(t, data)
+	for _, want := range []string{
+		"Namespace Finding", "Namespace", "Pods affected", "Finding",
+		"apiVersion: networking.k8s.io/v1", "kind: NetworkPolicy",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("namespace page missing %q", want)
+		}
+	}
+	if strings.Contains(body, "<h2>Investigation Commands</h2>") {
+		t.Errorf("namespace page duplicated a command already represented by Recommended Investigation")
+	}
+	assertInOrder(t, body,
+		"Situation Briefing",
+		"Namespace Finding",
+		"Recommended Investigation",
+		"Incident Timeline",
+		"Recent Events",
+	)
+}
+
+func TestFirstDetectedLabelIncludesAbsoluteAndRelativeDate(t *testing.T) {
+	location := time.FixedZone("test", -4*60*60)
+	now := time.Date(2026, time.July, 29, 12, 0, 0, 0, location)
+	tests := []struct {
+		firstSeen time.Time
+		want      string
+	}{
+		{time.Date(2026, time.July, 29, 1, 0, 0, 0, location), "Jul 29 · today"},
+		{time.Date(2026, time.July, 10, 23, 0, 0, 0, location), "Jul 10 · 19 days"},
+	}
+	for _, tc := range tests {
+		if got := firstDetectedLabelAt(tc.firstSeen, now); got != tc.want {
+			t.Errorf("firstDetectedLabelAt(%v) = %q, want %q", tc.firstSeen, got, tc.want)
+		}
+	}
+}
+
+func renderInvestigationBody(t *testing.T, data investigationPageData) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	renderInvestigation(rec, data)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d: %s", rec.Code, rec.Body.String())
+	}
+	return rec.Body.String()
+}
+
+func assertInOrder(t *testing.T, body string, labels ...string) {
+	t.Helper()
+	position := -1
+	for _, label := range labels {
+		next := strings.Index(body[position+1:], label)
+		if next < 0 {
+			t.Fatalf("rendered page missing %q", label)
+		}
+		position += next + 1
 	}
 }

--- a/cmd/opscart-dashboard/main_test.go
+++ b/cmd/opscart-dashboard/main_test.go
@@ -1011,6 +1011,16 @@ func TestInvestigateURL(t *testing.T) {
 			want: "/investigate?pod=payments-api%2Fabc123&ns=payments+prod&type=crash_loop&cluster=my+cluster&from=warroom",
 		},
 		{
+			name:      "namespace finding omits synthetic pod parameter",
+			namespace: "monitoring", resource: "namespace", issueType: "unprotected_namespace", ctx: "my cluster",
+			want: "/investigate?ns=monitoring&type=unprotected_namespace&cluster=my+cluster&from=warroom",
+		},
+		{
+			name:      "idle namespace omits synthetic pod parameter",
+			namespace: "batch", resource: "namespace", issueType: "idle_namespace", ctx: "my cluster",
+			want: "/investigate?ns=batch&type=idle_namespace&cluster=my+cluster&from=warroom",
+		},
+		{
 			name:      "empty namespace falls back to /warroom",
 			namespace: "", resource: "payments-api", issueType: "crash_loop", ctx: "test-cluster",
 			want: "/warroom",
@@ -1037,6 +1047,70 @@ func TestInvestigateURL(t *testing.T) {
 				t.Errorf("investigateURL(%q, %q, %q, %q) = %q, want %q", tt.namespace, tt.resource, tt.issueType, tt.ctx, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestRenderWarRoomCardInvestigationLinks(t *testing.T) {
+	namespaceCard := renderWarRoomCard(warRoomIssue{
+		Resource: "namespace", Namespace: "monitoring", Type: "unprotected_namespace",
+	}, "prod-cluster")
+	if strings.Contains(namespaceCard, "pod=namespace") {
+		t.Errorf("namespace card included synthetic pod parameter: %s", namespaceCard)
+	}
+	if !strings.Contains(namespaceCard, "/investigate?ns=monitoring&type=unprotected_namespace&cluster=prod-cluster&from=warroom") {
+		t.Errorf("namespace card missing ns/type investigation link: %s", namespaceCard)
+	}
+
+	workloadCard := renderWarRoomCard(warRoomIssue{
+		Resource: "fraud-detection-abc", Namespace: "payments", Type: "crash_loop",
+	}, "prod-cluster")
+	if !strings.Contains(workloadCard, "/investigate?pod=fraud-detection-abc&ns=payments&type=crash_loop&cluster=prod-cluster&from=warroom") {
+		t.Errorf("workload card omitted Focus Pod: %s", workloadCard)
+	}
+
+	emptyContextCard := renderWarRoomCard(warRoomIssue{
+		Resource: "fraud-detection-abc", Namespace: "payments", Type: "crash_loop",
+	}, "")
+	if strings.Contains(emptyContextCard, "cluster=current-context") {
+		t.Errorf("empty active context emitted synthetic cluster context: %s", emptyContextCard)
+	}
+	if !strings.Contains(emptyContextCard, "&from=warroom") {
+		t.Errorf("empty active context omitted source parameter: %s", emptyContextCard)
+	}
+
+	emptyResourceNamespaceCard := renderWarRoomCard(warRoomIssue{
+		Namespace: "monitoring", Type: "unprotected_namespace",
+	}, "prod-cluster")
+	if !strings.Contains(emptyResourceNamespaceCard, "Investigate →") {
+		t.Errorf("namespace card with empty Resource omitted Investigate action: %s", emptyResourceNamespaceCard)
+	}
+	if strings.Contains(emptyResourceNamespaceCard, "pod=") {
+		t.Errorf("namespace card with empty Resource emitted pod parameter: %s", emptyResourceNamespaceCard)
+	}
+}
+
+func TestRenderWarRoomPagePassesActiveContextToCards(t *testing.T) {
+	scan := &clusterScan{
+		wasteAudit: &analyzer.WasteAudit{
+			StalePods: []analyzer.StalePod{{
+				Name: "fraud-detection-abc", Namespace: "payments",
+				Kind: analyzer.StalePodZombie, Status: "CrashLoopBackOff",
+			}},
+		},
+		netAudit: &analyzer.NetworkPolicyAudit{
+			UnprotectedNamespaces: []analyzer.NamespaceNetworkStatus{{
+				Name: "monitoring", RiskLevel: "HIGH",
+			}},
+		},
+	}
+	body := renderWarRoomPage(scan, "prod-cluster", []string{"prod-cluster"})
+	for _, want := range []string{
+		"/investigate?pod=fraud-detection-abc&ns=payments&type=crash_loop&cluster=prod-cluster&from=warroom",
+		"/investigate?ns=monitoring&type=unprotected_namespace&cluster=prod-cluster&from=warroom",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("rendered War Room page missing context-aware link %q", want)
+		}
 	}
 }
 

--- a/cmd/opscart-dashboard/server.go
+++ b/cmd/opscart-dashboard/server.go
@@ -1264,12 +1264,23 @@ func buildWorkloadHealthGrid(scan *clusterScan) []workloadHealthCell {
 // buildTopIssues (orphaned PVCs, security score, zero-replica workloads)
 // have no single corresponding incident to deep-link to.
 func investigateURL(namespace, resource, issueType, activeCtx string) string {
-	if namespace == "" || resource == "" || issueType == "" {
+	if namespace == "" || issueType == "" {
 		return "/warroom"
 	}
-	return fmt.Sprintf("/investigate?pod=%s&ns=%s&type=%s&cluster=%s&from=warroom",
+	clusterParam := ""
+	if activeCtx != "" {
+		clusterParam = "&cluster=" + url.QueryEscape(activeCtx)
+	}
+	if issueType == "unprotected_namespace" || issueType == "idle_namespace" {
+		return fmt.Sprintf("/investigate?ns=%s&type=%s%s&from=warroom",
+			url.QueryEscape(namespace), url.QueryEscape(issueType), clusterParam)
+	}
+	if resource == "" {
+		return "/warroom"
+	}
+	return fmt.Sprintf("/investigate?pod=%s&ns=%s&type=%s%s&from=warroom",
 		url.QueryEscape(resource), url.QueryEscape(namespace),
-		url.QueryEscape(issueType), url.QueryEscape(activeCtx))
+		url.QueryEscape(issueType), clusterParam)
 }
 
 func buildTopIssues(scan *clusterScan, wrIssues []warRoomIssue, activeCtx string) []topIssue {

--- a/cmd/opscart-dashboard/templates/incidents.html
+++ b/cmd/opscart-dashboard/templates/incidents.html
@@ -53,8 +53,9 @@
 .inc-sev-medium{background:rgba(100,116,139,.18);color:#94a3b8}
 .inc-sev-low{background:rgba(100,116,139,.12);color:#64748b}
 
-/* incident name cell */
-.inc-name{font-weight:600;color:var(--text);max-width:220px;overflow:hidden;text-overflow:ellipsis}
+/* workload identity cell */
+.inc-workload{font-weight:600;color:var(--text);max-width:260px;overflow:hidden;text-overflow:ellipsis}
+.inc-pod{font-family:'Consolas','Monaco',monospace;font-size:.68rem;color:var(--text-muted);margin-top:3px;max-width:260px;overflow:hidden;text-overflow:ellipsis}
 .inc-type{font-family:'Consolas','Monaco',monospace;font-size:.7rem;color:var(--text-muted);margin-top:1px}
 
 /* namespace */
@@ -128,7 +129,7 @@
 
   <!-- Filter form -->
   <form method="GET" action="/incidents" id="inc-form">
-    <input type="hidden" name="cluster" value="{{.ClusterName}}">
+    <input type="hidden" name="cluster" value="{{.ClusterParam}}">
     <div class="inc-filters">
       <div class="inc-search">
         <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
@@ -166,7 +167,7 @@
       </select>
       <button type="submit" class="inc-btn">Search</button>
       {{if or .Filter.Text .Filter.Namespace .Filter.IssueType .Filter.Severity}}
-      <a href="/incidents?cluster={{.ClusterName}}" class="inc-btn-clear">Clear</a>
+      <a href="/incidents?cluster={{.ClusterParam}}" class="inc-btn-clear">Clear</a>
       {{end}}
     </div>
   </form>
@@ -186,21 +187,21 @@
       <thead>
         <tr>
           <th>Severity</th>
-          <th>Incident</th>
+          <th>Workload</th>
           <th>Namespace</th>
           <th>Status</th>
           <th class="sortable{{if eq .Filter.SortBy "first_seen"}} sort-active{{end}}">
-            <a href="?cluster={{.ClusterName}}&q={{.Filter.Text}}&ns={{.Filter.Namespace}}&type={{.Filter.IssueType}}&severity={{.Filter.Severity}}&status={{.Filter.Status}}&sort=first_seen" style="color:inherit;text-decoration:none">
+            <a href="?cluster={{.ClusterParam}}&q={{.Filter.Text}}&ns={{.Filter.Namespace}}&type={{.Filter.IssueType}}&severity={{.Filter.Severity}}&status={{.Filter.Status}}&sort=first_seen" style="color:inherit;text-decoration:none">
               First detected <span class="sort-icon">▲▼</span>
             </a>
           </th>
           <th class="sortable{{if eq .Filter.SortBy "last_seen"}} sort-active{{end}}">
-            <a href="?cluster={{.ClusterName}}&q={{.Filter.Text}}&ns={{.Filter.Namespace}}&type={{.Filter.IssueType}}&severity={{.Filter.Severity}}&status={{.Filter.Status}}&sort=last_seen" style="color:inherit;text-decoration:none">
+            <a href="?cluster={{.ClusterParam}}&q={{.Filter.Text}}&ns={{.Filter.Namespace}}&type={{.Filter.IssueType}}&severity={{.Filter.Severity}}&status={{.Filter.Status}}&sort=last_seen" style="color:inherit;text-decoration:none">
               Last seen <span class="sort-icon">▲▼</span>
             </a>
           </th>
           <th class="sortable{{if eq .Filter.SortBy "restarts"}} sort-active{{end}}" style="text-align:right">
-            <a href="?cluster={{.ClusterName}}&q={{.Filter.Text}}&ns={{.Filter.Namespace}}&type={{.Filter.IssueType}}&severity={{.Filter.Severity}}&status={{.Filter.Status}}&sort=restarts" style="color:inherit;text-decoration:none">
+            <a href="?cluster={{.ClusterParam}}&q={{.Filter.Text}}&ns={{.Filter.Namespace}}&type={{.Filter.IssueType}}&severity={{.Filter.Severity}}&status={{.Filter.Status}}&sort=restarts" style="color:inherit;text-decoration:none">
               Restarts <span class="sort-icon">▲▼</span>
             </a>
           </th>
@@ -211,22 +212,30 @@
       <tbody>
         {{range .Incidents}}
         <tr class="{{if eq .Status "resolved"}}inc-row-resolved{{end}}"
-            onclick="window.location='/investigate?pod={{.Resource}}&ns={{.Namespace}}&type={{.IssueType}}&cluster={{$.ClusterName}}&from=incidents'">
+            {{if isNamespaceScoped .IssueType}}
+            onclick="window.location='/investigate?ns={{.Namespace}}&type={{.IssueType}}&cluster={{$.ClusterParam}}&from=incidents'"
+            {{else}}
+            onclick="window.location='/investigate?pod={{.Resource}}&ns={{.Namespace}}&type={{.IssueType}}&cluster={{$.ClusterParam}}&from=incidents'"
+            {{end}}>
           <td>
             <span class="inc-sev inc-sev-{{.Severity}}">{{.Severity}}</span>
           </td>
           <td>
-            <div class="inc-name">
-              {{if eq .IssueType "unprotected_namespace"}}{{.Namespace}}{{else}}{{.Resource}}{{end}}
-            </div>
-            <div class="inc-type">{{.IssueType}}</div>
+            {{if isNamespaceScoped .IssueType}}
+              <div class="inc-workload">Namespace/{{.Namespace}}</div>
+              <div class="inc-pod">{{.IssueType}}</div>
+            {{else}}
+              <div class="inc-workload">Workload/{{ownerName .Resource}}</div>
+              <div class="inc-pod">↳ currently: {{.Resource}}</div>
+              <div class="inc-type">{{.IssueType}}</div>
+            {{end}}
           </td>
           <td class="inc-ns">{{.Namespace}}</td>
           <td>
             {{if eq .Status "resolved"}}
               <span class="inc-status inc-status-resolved"><span class="inc-dot"></span>Resolved</span>
             {{else if gt .ReopenCount 0}}
-              <span class="inc-status inc-status-reopened"><span class="inc-dot"></span>Reopened<span class="inc-reopen-n">×{{.ReopenCount}}</span></span>
+              <span class="inc-status inc-status-reopened"><span class="inc-dot"></span>Reopened</span>
             {{else}}
               <span class="inc-status inc-status-active"><span class="inc-dot"></span>Active</span>
             {{end}}
@@ -266,7 +275,7 @@
       </span>
       <div class="inc-pager-btns">
         {{if gt .Page 1}}
-        <a href="?cluster={{.ClusterName}}&q={{.Filter.Text}}&ns={{.Filter.Namespace}}&type={{.Filter.IssueType}}&severity={{.Filter.Severity}}&status={{.Filter.Status}}&sort={{.Filter.SortBy}}&page={{prevPage .Page}}">
+        <a href="?cluster={{.ClusterParam}}&q={{.Filter.Text}}&ns={{.Filter.Namespace}}&type={{.Filter.IssueType}}&severity={{.Filter.Severity}}&status={{.Filter.Status}}&sort={{.Filter.SortBy}}&page={{prevPage .Page}}">
           <button class="inc-pg">‹ Prev</button>
         </a>
         {{end}}
@@ -276,7 +285,7 @@
         </a>
         {{end}}
         {{if lt .Page .TotalPages}}
-        <a href="?cluster={{.ClusterName}}&q={{.Filter.Text}}&ns={{.Filter.Namespace}}&type={{.Filter.IssueType}}&severity={{.Filter.Severity}}&status={{.Filter.Status}}&sort={{.Filter.SortBy}}&page={{nextPage .Page .TotalPages}}">
+        <a href="?cluster={{.ClusterParam}}&q={{.Filter.Text}}&ns={{.Filter.Namespace}}&type={{.Filter.IssueType}}&severity={{.Filter.Severity}}&status={{.Filter.Status}}&sort={{.Filter.SortBy}}&page={{nextPage .Page .TotalPages}}">
           <button class="inc-pg">Next ›</button>
         </a>
         {{end}}
@@ -290,7 +299,7 @@
       <div class="inc-empty-msg">No incidents match your filters</div>
       <div class="inc-empty-sub">
         {{if or .Filter.Text .Filter.Namespace .Filter.IssueType .Filter.Severity}}
-          Try clearing some filters — <a href="/incidents?cluster={{.ClusterName}}" style="color:var(--primary-light)">show all active</a>
+          Try clearing some filters — <a href="/incidents?cluster={{.ClusterParam}}" style="color:var(--primary-light)">show all active</a>
         {{else}}
           No active incidents detected. This cluster looks healthy.
         {{end}}

--- a/cmd/opscart-dashboard/templates/investigation.html
+++ b/cmd/opscart-dashboard/templates/investigation.html
@@ -49,6 +49,15 @@
 .inv-summary{background:var(--surface);border-left:3px solid var(--primary-light);border-radius:var(--radius-sm);padding:1rem 1.25rem;margin-bottom:1.5rem}
 .inv-summary-label{font-size:0.7rem;text-transform:uppercase;letter-spacing:1px;color:var(--primary-light);font-weight:700;margin-bottom:0.5rem}
 .inv-summary-text{font-size:0.88rem;color:var(--text);line-height:1.7}
+.inv-briefing{background:rgba(245,158,11,.055);border:1px solid rgba(245,158,11,.48);border-radius:var(--radius-sm);padding:1rem 1.25rem;margin-bottom:1rem}
+.inv-briefing .inv-summary-label{color:#fbbf24}
+.inv-scope-grid{display:grid;grid-template-columns:minmax(260px,.8fr) minmax(360px,1.2fr);gap:1rem;margin-bottom:1.5rem}
+.inv-scope-card{background:linear-gradient(135deg,var(--surface),rgba(30,41,59,.7));border:1px solid var(--border);border-radius:var(--radius-sm);padding:1rem 1.25rem}
+.inv-scope-title{font-size:.7rem;text-transform:uppercase;letter-spacing:.6px;color:var(--primary-light);font-weight:700;margin-bottom:.75rem}
+.inv-scope-row{display:grid;grid-template-columns:130px 1fr;gap:1rem;padding:.48rem 0;border-bottom:1px solid rgba(51,65,85,.45);font-size:.8rem}
+.inv-scope-row:last-child{border-bottom:none}.inv-scope-key{color:var(--text-muted)}.inv-scope-value{color:var(--text);font-weight:500;min-width:0;overflow-wrap:anywhere}
+.inv-current-status{color:#f87171}.inv-current-status:before{content:"";display:inline-block;width:8px;height:8px;border-radius:50%;background:#f87171;margin-right:.4rem}
+.inv-describe{margin-top:.75rem}
 .inv-evidence{display:flex;gap:1rem;flex-wrap:wrap;margin-bottom:1.5rem}
 .inv-evidence-chip{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);padding:0.6rem 1rem;min-width:120px}
 .inv-evidence-label{font-size:0.65rem;text-transform:uppercase;letter-spacing:0.5px;color:var(--text-muted);margin-bottom:0.25rem}
@@ -65,7 +74,7 @@
 .inv-conf-high{background:rgba(239,68,68,0.15);color:#f87171}
 .inv-conf-medium{background:rgba(245,158,11,0.15);color:#fbbf24}
 .inv-conf-low{background:rgba(100,116,139,0.15);color:#94a3b8}
-@media(max-width:768px){.inv-resources{grid-template-columns:1fr}.inv-bar{flex-direction:column}.inv-evidence{flex-direction:column}}
+@media(max-width:900px){.inv-scope-grid{grid-template-columns:1fr}}@media(max-width:768px){.inv-resources{grid-template-columns:1fr}.inv-bar{flex-direction:column}.inv-evidence{flex-direction:column}.inv-scope-row{grid-template-columns:110px 1fr}}
 </style>
 </head>
 <body>
@@ -74,8 +83,8 @@
 <main class="main">
   <div class="page-hdr">
     <div>
-      <h1>Investigation</h1>
-      <p>{{.Namespace}} / {{.PodName}}</p>
+      <h1>{{if .NamespaceScoped}}Namespace Investigation{{else}}Workload Investigation{{end}}</h1>
+      <p>{{.Namespace}} / {{.WorkloadLabel}}</p>
     </div>
     <div class="page-meta">
       <div>Last scanned: <strong id="inv-age">just now</strong></div>
@@ -134,47 +143,104 @@
 
   {{else}}
 
-  <div class="inv-bar">
-    <div class="inv-chip danger">
-      <div>
-        <div class="inv-badge">CRITICAL</div>
-        {{if .StateReason}}<div class="inv-state-reason">{{.StateReason}}{{if eq .IssueType "probe_failure"}} (ProbeFailure){{end}}</div>{{end}}
+  {{if .OperationalSummary}}
+  <div class="inv-briefing">
+    <div class="inv-summary-label">⚠ Situation Briefing</div>
+    <div class="inv-summary-text">{{.OperationalSummary}}</div>
+  </div>
+  {{end}}
+
+  {{if .NamespaceScoped}}
+  <div class="inv-section">
+    <div class="inv-section-hdr">
+      <h2>Namespace Finding</h2>
+    </div>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:0.75rem;margin-bottom:1.5rem">
+      <div class="inv-evidence-chip">
+        <div class="inv-evidence-label">Namespace</div>
+        <div class="inv-evidence-value" style="font-size:0.88rem">{{.Namespace}}</div>
+      </div>
+      <div class="inv-evidence-chip">
+        <div class="inv-evidence-label">Pods affected</div>
+        <div class="inv-evidence-value">{{.NamespacePodCount}}</div>
       </div>
     </div>
-    <div class="inv-chip">
-      <div>
-        <div class="inv-chip-label">Restarts</div>
-        <div class="inv-chip-value">{{.Restarts}}</div>
-      </div>
-    </div>
-    <div class="inv-chip">
-      <div>
-        <div class="inv-chip-label">Age</div>
-        <div class="inv-chip-value">{{.AgeDays}}d</div>
-      </div>
-    </div>
-    {{if .FirstDetected}}
-    <div class="inv-chip">
-      <div>
-        <div class="inv-chip-label">First detected</div>
-        <div class="inv-chip-value">{{.FirstDetected}}</div>
-      </div>
+    {{if .NamespaceFinding}}
+    <div class="inv-summary">
+      <div class="inv-summary-label">Finding</div>
+      <div class="inv-summary-text">{{.NamespaceFinding}}</div>
     </div>
     {{end}}
-    {{if .OwnerKind}}
-    <div class="inv-chip">
-      <div>
-        <div class="inv-chip-label">Owner</div>
-        <div class="inv-chip-value">{{.OwnerKind}}/{{.OwnerName}}</div>
+    {{if eq .IssueType "unprotected_namespace"}}
+    <div>
+      <div class="inv-evidence-label" style="margin-bottom:0.6rem">Sample default-deny NetworkPolicy</div>
+      <div class="inv-cmd" style="align-items:flex-start">
+        <pre id="np-yaml" style="white-space:pre;overflow-x:auto;margin:0;font-family:'Consolas','Monaco',monospace;font-size:0.78rem;color:var(--primary-light);flex:1">apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: {{.Namespace}}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress</pre>
+        <button class="wr-copy-btn" onclick="navigator.clipboard.writeText(document.getElementById('np-yaml').textContent)">Copy</button>
       </div>
     </div>
     {{end}}
   </div>
+  {{end}}
 
-  {{if .OperationalSummary}}
-  <div class="inv-summary">
-    <div class="inv-summary-label">OpsCart Assessment</div>
-    <div class="inv-summary-text">{{.OperationalSummary}}</div>
+  {{if not .NamespaceScoped}}<div class="inv-scope-grid">
+    <section class="inv-scope-card">
+      <div class="inv-scope-title">▧ Operational Identity</div>
+      <div class="inv-scope-row"><span class="inv-scope-key">Classification</span><span class="inv-scope-value">{{issueTypeLabel .IssueType}}</span></div>
+      <div class="inv-scope-row"><span class="inv-scope-key">Severity</span><span class="inv-scope-value" style="text-transform:capitalize">{{.Severity}}</span></div>
+      <div class="inv-scope-row"><span class="inv-scope-key">Tracking</span><span class="inv-scope-value">{{.TrackingLabel}}</span></div>
+      {{if .FirstDetected}}<div class="inv-scope-row"><span class="inv-scope-key">Open Since</span><span class="inv-scope-value">{{.FirstDetected}}</span></div>{{end}}
+    </section>
+    <section class="inv-scope-card">
+      <div class="inv-scope-title">◉ Current Observation</div>
+      <div class="inv-scope-row"><span class="inv-scope-key">Namespace</span><span class="inv-scope-value">{{.Namespace}}</span></div>
+      <div class="inv-scope-row"><span class="inv-scope-key">Workload</span><span class="inv-scope-value">{{.WorkloadLabel}}</span></div>
+      <div class="inv-scope-row"><span class="inv-scope-key">Focus Pod</span><span class="inv-scope-value">{{.PodName}}</span></div>
+      <div class="inv-scope-row"><span class="inv-scope-key">Pod Age</span><span class="inv-scope-value">{{.PodAge}}</span></div>
+      <div class="inv-scope-row"><span class="inv-scope-key">Restart Count</span><span class="inv-scope-value">{{.Restarts}}</span></div>
+      {{if .ContainerName}}<div class="inv-scope-row"><span class="inv-scope-key">Container</span><span class="inv-scope-value">{{.ContainerName}}</span></div>{{end}}
+      {{if .StateReason}}
+      <div class="inv-scope-row"><span class="inv-scope-key">Pod Phase</span><span class="inv-scope-value">{{.Phase}}</span></div>
+      <div class="inv-scope-row"><span class="inv-scope-key">Container State</span><span class="inv-scope-value inv-current-status">{{.StateReason}}</span></div>
+      {{else}}
+      <div class="inv-scope-row"><span class="inv-scope-key">Current Status</span><span class="inv-scope-value inv-current-status">{{.Phase}}</span></div>
+      {{end}}
+      {{if .DescribeCommand}}<div class="inv-cmd inv-describe"><code>{{.DescribeCommand}}</code><button class="wr-copy-btn" data-command="{{.DescribeCommand}}" onclick="navigator.clipboard.writeText(this.dataset.command)">Copy</button></div>{{end}}
+    </section>
+  </div>{{end}}
+
+  {{if .Hints}}
+  <div class="inv-section">
+    <div class="inv-section-hdr">
+      <h2>Recommended Investigation</h2>
+    </div>
+    <div class="inv-hints">
+      {{range .Hints}}
+      <div class="inv-hint inv-hint-{{.Confidence}}">
+        <div class="inv-hint-header">
+          {{if .Step}}<span style="font-size:0.72rem;font-weight:700;color:var(--text-muted);min-width:52px">STEP {{.Step}}</span>{{end}}
+          <span class="inv-conf-badge inv-conf-{{.Confidence}}">{{if eq .Confidence "high"}}High{{else if eq .Confidence "medium"}}Medium{{else}}Low{{end}}</span>
+          <span class="inv-hint-title">{{.Title}}</span>
+        </div>
+        <div class="inv-hint-reason">{{.Reason}}</div>
+        {{if .Command}}
+        <div class="inv-hint-cmd">
+          <code>{{.Command}}</code>
+          <button class="wr-copy-btn" onclick="navigator.clipboard.writeText('{{.Command}}')">Copy</button>
+        </div>
+        {{end}}
+      </div>
+      {{end}}
+    </div>
   </div>
   {{end}}
 
@@ -182,7 +248,6 @@
 <div class="inv-section">
   <div class="inv-section-hdr">
     <h2>Incident Timeline</h2>
-    <span style="font-size:0.8rem;color:var(--text-muted);margin-left:auto">{{len .Timeline}} events</span>
   </div>
   <div style="position:relative;padding-left:1.5rem">
     {{/* vertical line */}}
@@ -209,84 +274,22 @@
   </div>
 </div>
 {{end}}
+
+  {{if .NamespaceScoped}}
+  {{$commands := unrepresentedCommands .Commands .Hints}}
+  {{if $commands}}
   <div class="inv-section">
     <div class="inv-section-hdr">
-      <h2>Evidence</h2>
+      <h2>Investigation Commands</h2>
     </div>
-<div class="inv-evidence">
-      {{if .Severity}}
-      <div class="inv-evidence-chip" style="border-color:rgba(239,68,68,0.4);background:rgba(239,68,68,0.04)">
-        <div class="inv-evidence-label">Severity</div>
-        <div class="inv-evidence-value" style="color:#f87171;text-transform:capitalize">{{.Severity}}</div>
-      </div>
+    <div class="inv-cmds">
+      {{range $commands}}
+      <div class="inv-cmd"><code>{{.}}</code><button class="wr-copy-btn" onclick="navigator.clipboard.writeText('{{.}}')">Copy</button></div>
       {{end}}
-      {{if .FirstDetected}}
-      <div class="inv-evidence-chip">
-        <div class="inv-evidence-label">First detected</div>
-        <div class="inv-evidence-value">{{.FirstDetected}}</div>
-      </div>
-      {{end}}
-      {{if not .NamespaceScoped}}
-      <div class="inv-evidence-chip">
-        <div class="inv-evidence-label">Restarts</div>
-        <div class="inv-evidence-value">{{.Restarts}}</div>
-      </div>
-      <div class="inv-evidence-chip">
-        <div class="inv-evidence-label">State</div>
-        <div class="inv-evidence-value">{{if .StateReason}}{{.StateReason}}{{if eq .IssueType "probe_failure"}} (ProbeFailure){{end}}{{else}}Unknown{{end}}</div>
-      </div>
-      <div class="inv-evidence-chip">
-        <div class="inv-evidence-label">Age</div>
-        <div class="inv-evidence-value">{{.AgeDays}}d</div>
-      </div>
-      <div class="inv-evidence-chip">
-        <div class="inv-evidence-label">Owner</div>
-        <div class="inv-evidence-value">{{if .OwnerKind}}{{.OwnerKind}}/{{.OwnerName}}{{else}}None{{end}}</div>
-      </div>
-      {{end}}
-    </div>
-  </div>
-{{if .NamespaceScoped}}
-<div class="inv-section">
-  <div class="inv-section-hdr">
-    <h2>Namespace Finding</h2>
-  </div>
-  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:0.75rem;margin-bottom:1.5rem">
-    <div class="inv-evidence-chip">
-      <div class="inv-evidence-label">Namespace</div>
-      <div class="inv-evidence-value" style="font-size:0.88rem">{{.Namespace}}</div>
-    </div>
-    <div class="inv-evidence-chip">
-      <div class="inv-evidence-label">Pods affected</div>
-      <div class="inv-evidence-value">{{.NamespacePodCount}}</div>
-    </div>
-  </div>
-  {{if .NamespaceFinding}}
-  <div class="inv-summary">
-    <div class="inv-summary-label">Finding</div>
-    <div class="inv-summary-text">{{.NamespaceFinding}}</div>
-  </div>
-  {{end}}
-  {{if eq .IssueType "unprotected_namespace"}}
-  <div>
-    <div class="inv-evidence-label" style="margin-bottom:0.6rem">Sample default-deny NetworkPolicy</div>
-    <div class="inv-cmd" style="align-items:flex-start">
-      <pre id="np-yaml" style="white-space:pre;overflow-x:auto;margin:0;font-family:'Consolas','Monaco',monospace;font-size:0.78rem;color:var(--primary-light);flex:1">apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: default-deny-all
-  namespace: {{.Namespace}}
-spec:
-  podSelector: {}
-  policyTypes:
-    - Ingress
-    - Egress</pre>
-      <button class="wr-copy-btn" onclick="navigator.clipboard.writeText(document.getElementById('np-yaml').textContent)">Copy</button>
     </div>
   </div>
   {{end}}
-</div>
-{{end}}
+  {{end}}
 
 {{if not .NamespaceScoped}}
 {{if or .BlastSiblings .BlastServices .BlastIngresses .BlastNamespacePods}}
@@ -307,7 +310,7 @@ spec:
     </div>
     {{if .BlastTotal}}
     <div class="inv-evidence-chip" style="{{if eq .BlastHealthy 0}}border-color:rgba(239,68,68,0.4);background:rgba(239,68,68,0.04){{end}}">
-      <div class="inv-evidence-label">Replicas down</div>
+      <div class="inv-evidence-label">Replica Health</div>
       <div class="inv-evidence-value" style="font-size:0.88rem;{{if eq .BlastHealthy 0}}color:#f87171{{end}}">
         {{.BlastHealthy}}/{{.BlastTotal}} healthy
         {{if eq .BlastHealthy 0}}<span style="font-size:0.7rem;margin-left:0.4rem;opacity:0.8">(100% failure)</span>{{end}}
@@ -442,45 +445,6 @@ spec:
 {{end}}
 {{end}}
 
-  {{if .Hints}}
-  <div class="inv-section">
-    <div class="inv-section-hdr">
-      <h2>Recommended Investigation</h2>
-    </div>
-    <div class="inv-hints">
-      {{range .Hints}}
-      <div class="inv-hint inv-hint-{{.Confidence}}">
-        <div class="inv-hint-header">
-          {{if .Step}}<span style="font-size:0.72rem;font-weight:700;color:var(--text-muted);min-width:52px">STEP {{.Step}}</span>{{end}}
-          <span class="inv-conf-badge inv-conf-{{.Confidence}}">{{if eq .Confidence "high"}}High{{else if eq .Confidence "medium"}}Medium{{else}}Low{{end}}</span>
-          <span class="inv-hint-title">{{.Title}}</span>
-        </div>
-        <div class="inv-hint-reason">{{.Reason}}</div>
-        {{if .Command}}
-        <div class="inv-hint-cmd">
-          <code>{{.Command}}</code>
-          <button class="wr-copy-btn" onclick="navigator.clipboard.writeText('{{.Command}}')">Copy</button>
-        </div>
-        {{end}}
-      </div>
-      {{end}}
-    </div>
-  </div>
-  {{end}}
-
-  {{if .Commands}}
-  <div class="inv-section">
-    <div class="inv-section-hdr">
-      <h2>Investigation Commands</h2>
-    </div>
-    <div class="inv-cmds">
-      {{range .Commands}}
-      <div class="inv-cmd"><code>{{.}}</code><button class="wr-copy-btn" onclick="navigator.clipboard.writeText('{{.}}')">Copy</button></div>
-      {{end}}
-    </div>
-  </div>
-  {{end}}
-
   <div class="inv-section">
     <div class="inv-section-hdr">
       <h2>Recent Events</h2>
@@ -511,10 +475,11 @@ spec:
       </table>
     </div>
     {{else}}
-    <div class="inv-empty">No recent events recorded for this pod</div>
+    <div class="inv-empty">No recent events recorded for this {{if .NamespaceScoped}}namespace{{else}}pod{{end}}</div>
     {{end}}
   </div>
 
+  {{if not .NamespaceScoped}}
   <div class="inv-section">
     <div class="inv-section-hdr">
       <h2>Related Resources</h2>
@@ -540,6 +505,7 @@ spec:
       </div>
     </div>
   </div>
+  {{end}}
 
   {{end}}
 

--- a/cmd/opscart-dashboard/templates/warroom.html
+++ b/cmd/opscart-dashboard/templates/warroom.html
@@ -130,7 +130,7 @@
     </div>
     {{else}}
     <div class="wr-grid">
-      {{range .Critical}}{{renderCard .}}{{end}}
+      {{range .Critical}}{{renderCard . $.ActiveCtx}}{{end}}
     </div>
     {{end}}
   </div>
@@ -147,7 +147,7 @@
     </div>
     {{else}}
     <div class="wr-grid">
-      {{range .Warnings}}{{renderCard .}}{{end}}
+      {{range .Warnings}}{{renderCard . $.ActiveCtx}}{{end}}
     </div>
     {{end}}
   </div>

--- a/cmd/opscart-dashboard/warroom.go
+++ b/cmd/opscart-dashboard/warroom.go
@@ -53,6 +53,7 @@ type warRoomIssue struct {
 
 type warRoomPageData struct {
 	ClusterName   string
+	ActiveCtx     string
 	StatusDesc    string
 	DashURL       string
 	CritChipClass string
@@ -197,6 +198,7 @@ func renderWarRoomPage(scan *clusterScan, activeCtx string, clusterList []string
 
 	data := warRoomPageData{
 		ClusterName:   clusterName,
+		ActiveCtx:     activeCtx,
 		StatusDesc:    fmt.Sprintf("%d issue(s) detected", len(critical)+len(warnings)),
 		DashURL:       "/" + q,
 		CritChipClass: critChipClass,
@@ -224,8 +226,8 @@ func getWarRoomTmpl() *template.Template {
 	warRoomTmplOnce.Do(func() {
 		warRoomTmpl = template.Must(
 			template.New("warroom.html").Funcs(template.FuncMap{
-				"renderCard": func(issue warRoomIssue) template.HTML {
-					return template.HTML(renderWarRoomCard(issue))
+				"renderCard": func(issue warRoomIssue, activeCtx string) template.HTML {
+					return template.HTML(renderWarRoomCard(issue, activeCtx))
 				},
 			}).ParseFS(templateFS, "templates/base.html", "templates/warroom.html"),
 		)
@@ -233,7 +235,7 @@ func getWarRoomTmpl() *template.Template {
 	return warRoomTmpl
 }
 
-func renderWarRoomCard(issue warRoomIssue) string {
+func renderWarRoomCard(issue warRoomIssue, activeCtx string) string {
 	sc := "c"
 	bl := "CRITICAL"
 	if issue.Severity == "warning" {
@@ -270,14 +272,10 @@ func renderWarRoomCard(issue warRoomIssue) string {
 	sb.WriteString(`<button class="copy-btn" onclick="var b=this,c=this.previousElementSibling.textContent;navigator.clipboard.writeText(c).then(function(){b.textContent='✓';setTimeout(function(){b.textContent='Copy'},1500)})">Copy</button>`)
 	sb.WriteString(`</div>`)
 	// Investigate button — links to investigation page
-	if issue.Resource != "" && issue.Namespace != "" {
-		investigateURL := fmt.Sprintf("/investigate?pod=%s&ns=%s&type=%s",
-			url.QueryEscape(issue.Resource),
-			url.QueryEscape(issue.Namespace),
-			url.QueryEscape(issue.Type))
+	if investigationHref := investigateURL(issue.Namespace, issue.Resource, issue.Type, activeCtx); investigationHref != "/warroom" {
 		sb.WriteString(fmt.Sprintf(
 			`<a class="investigate-btn" href="%s">Investigate →</a>`,
-			investigateURL))
+			investigationHref))
 	}
 	sb.WriteString(`</div>`)
 	return sb.String()

--- a/pkg/store/fingerprint.go
+++ b/pkg/store/fingerprint.go
@@ -8,10 +8,22 @@ func Fingerprint(namespace, ownerKind, ownerName, issueType string) string {
 	return namespace + "/" + ownerKind + "/" + ownerName + "/" + issueType
 }
 
-// OwnerNameFromPod strips ReplicaSet/pod hash suffixes:
-// "fraud-detection-5fc85b778-8j6s5" -> "fraud-detection"
 func OwnerNameFromPod(podName string) string {
 	segments := strings.Split(podName, "-")
+
+	// Deployment pods end in:
+	// <replicaset-hash>-<five-character-pod-suffix>
+	//
+	// The final pod suffix may contain only letters, such as jxmtx.
+	if len(segments) >= 3 {
+		podSuffix := segments[len(segments)-1]
+		replicaSetHash := segments[len(segments)-2]
+
+		if looksLikePodSuffix(podSuffix) && looksLikeHash(replicaSetHash) {
+			return strings.Join(segments[:len(segments)-2], "-")
+		}
+	}
+
 	stripped := 0
 	for stripped < 2 && len(segments) > 1 {
 		last := segments[len(segments)-1]
@@ -21,10 +33,25 @@ func OwnerNameFromPod(podName string) string {
 		segments = segments[:len(segments)-1]
 		stripped++
 	}
+
 	if stripped == 0 {
 		return podName
 	}
 	return strings.Join(segments, "-")
+}
+
+func looksLikePodSuffix(s string) bool {
+	if len(s) != 5 {
+		return false
+	}
+
+	for _, r := range s {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'z')) {
+			return false
+		}
+	}
+
+	return true
 }
 
 // looksLikeHash reports whether s looks like a ReplicaSet/pod hash

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -3,6 +3,7 @@ package store
 import (
 	"database/sql"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -323,6 +324,8 @@ func (s *SQLiteStore) WriteSnapshot(cluster string, scanID string, d SnapshotDat
 }
 
 func (s *SQLiteStore) UpsertIncidents(cluster string, scanID string, incidents []IncidentData) error {
+	incidents = focusIncidentsByFingerprint(incidents)
+
 	tx, err := s.db.Begin()
 	if err != nil {
 		return err
@@ -330,7 +333,7 @@ func (s *SQLiteStore) UpsertIncidents(cluster string, scanID string, incidents [
 	defer tx.Rollback()
 
 	lookupStmt, err := tx.Prepare(
-		`SELECT id, current_restart_count, severity, status FROM incidents WHERE cluster=? AND fingerprint=?`,
+		`SELECT id, resource, current_restart_count, severity, status FROM incidents WHERE cluster=? AND fingerprint=?`,
 	)
 	if err != nil {
 		return err
@@ -346,6 +349,7 @@ func (s *SQLiteStore) UpsertIncidents(cluster string, scanID string, incidents [
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, 0)
 		ON CONFLICT(cluster, fingerprint) DO UPDATE SET
 			last_seen = excluded.last_seen,
+			resource = excluded.resource,
 			details_json = excluded.details_json,
 			severity = excluded.severity,
 			status = 'active',
@@ -362,8 +366,8 @@ func (s *SQLiteStore) UpsertIncidents(cluster string, scanID string, incidents [
 	for _, inc := range incidents {
 		var existingID int64
 		var prevRestart int
-		var prevSeverity, prevStatus string
-		lookupErr := lookupStmt.QueryRow(cluster, inc.Fingerprint).Scan(&existingID, &prevRestart, &prevSeverity, &prevStatus)
+		var prevResource, prevSeverity, prevStatus string
+		lookupErr := lookupStmt.QueryRow(cluster, inc.Fingerprint).Scan(&existingID, &prevResource, &prevRestart, &prevSeverity, &prevStatus)
 		if lookupErr != nil && lookupErr != sql.ErrNoRows {
 			return lookupErr
 		}
@@ -400,16 +404,43 @@ func (s *SQLiteStore) UpsertIncidents(cluster string, scanID string, incidents [
 				err = insertIncidentEvent(tx, incidentID, scanID, now, "REOPENED", "Reopened",
 					inc.RestartCount, inc.Severity, "active", "Incident reoccurred")
 			} else {
-				err = emitDriftEvents(tx, incidentID, scanID, now, prevSeverity, prevRestart, inc)
+				err = emitDriftEvents(tx, incidentID, scanID, now, prevSeverity, prevRestart, prevResource == inc.Resource, inc)
 			}
 		default:
-			err = emitDriftEvents(tx, incidentID, scanID, now, prevSeverity, prevRestart, inc)
+			err = emitDriftEvents(tx, incidentID, scanID, now, prevSeverity, prevRestart, prevResource == inc.Resource, inc)
 		}
 		if err != nil {
 			return err
 		}
 	}
 	return tx.Commit()
+}
+
+// focusIncidentsByFingerprint selects exactly one coherent observation for
+// each workload-scoped fingerprint. The highest restart count wins; resource
+// provides a stable tie-breaker so selection does not depend on scan order.
+func focusIncidentsByFingerprint(incidents []IncidentData) []IncidentData {
+	focused := make(map[string]IncidentData, len(incidents))
+	for _, inc := range incidents {
+		current, exists := focused[inc.Fingerprint]
+		if !exists ||
+			inc.RestartCount > current.RestartCount ||
+			(inc.RestartCount == current.RestartCount && inc.Resource < current.Resource) {
+			focused[inc.Fingerprint] = inc
+		}
+	}
+
+	fingerprints := make([]string, 0, len(focused))
+	for fingerprint := range focused {
+		fingerprints = append(fingerprints, fingerprint)
+	}
+	sort.Strings(fingerprints)
+
+	result := make([]IncidentData, 0, len(fingerprints))
+	for _, fingerprint := range fingerprints {
+		result = append(result, focused[fingerprint])
+	}
+	return result
 }
 
 // absorbRecentResolution checks whether the incident's most recent RESOLVED
@@ -446,7 +477,7 @@ func absorbRecentResolution(tx *sql.Tx, incidentID int64, now int64) (bool, erro
 // emitDriftEvents records SeverityChanged/RestartMilestone events for an
 // incident that is already (or was just flap-absorbed back to) active,
 // comparing against its previously stored severity/restart count.
-func emitDriftEvents(tx *sql.Tx, incidentID int64, scanID string, now int64, prevSeverity string, prevRestart int, inc IncidentData) error {
+func emitDriftEvents(tx *sql.Tx, incidentID int64, scanID string, now int64, prevSeverity string, prevRestart int, sameResource bool, inc IncidentData) error {
 	if prevSeverity != inc.Severity {
 		if err := insertIncidentEvent(tx, incidentID, scanID, now, "UPDATED", "SeverityChanged",
 			inc.RestartCount, inc.Severity, "active",
@@ -454,18 +485,20 @@ func emitDriftEvents(tx *sql.Tx, incidentID int64, scanID string, now int64, pre
 			return err
 		}
 	}
-	if milestone := highestMilestoneCrossed(prevRestart, inc.RestartCount); milestone > 0 {
-		var lastMilestone int
-		_ = tx.QueryRow(
-			`SELECT COALESCE(MAX(restart_count), 0) FROM incident_events
+	if sameResource {
+		if milestone := highestMilestoneCrossed(prevRestart, inc.RestartCount); milestone > 0 {
+			var lastMilestone int
+			_ = tx.QueryRow(
+				`SELECT COALESCE(MAX(restart_count), 0) FROM incident_events
 			 WHERE incident_id=? AND event_reason='RestartMilestone'`,
-			incidentID,
-		).Scan(&lastMilestone)
-		if lastMilestone < milestone {
-			if err := insertIncidentEvent(tx, incidentID, scanID, now, "UPDATED", "RestartMilestone",
-				inc.RestartCount, inc.Severity, "active",
-				fmt.Sprintf("Restart count exceeded %d", milestone)); err != nil {
-				return err
+				incidentID,
+			).Scan(&lastMilestone)
+			if lastMilestone < milestone {
+				if err := insertIncidentEvent(tx, incidentID, scanID, now, "UPDATED", "RestartMilestone",
+					inc.RestartCount, inc.Severity, "active",
+					fmt.Sprintf("Restart count exceeded %d", milestone)); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -226,6 +226,134 @@ func TestUpsertIncident(t *testing.T) {
 	}
 }
 
+func TestUpsertIncidentsGroupsByFingerprintDeterministically(t *testing.T) {
+	fp := "default/Deployment/fraud-detection/crash_loop"
+	low := IncidentData{
+		Fingerprint: fp, Namespace: "default",
+		Resource: "fraud-detection-bbbbbbbbb-zzzzz", IssueType: "crash_loop",
+		Severity: "warning", DetailsJSON: `{"pod":"low"}`, RestartCount: 7,
+	}
+	highLexical := IncidentData{
+		Fingerprint: fp, Namespace: "default",
+		Resource: "fraud-detection-ccccccccc-yyyyy", IssueType: "crash_loop",
+		Severity: "high", DetailsJSON: `{"pod":"high-lexical"}`, RestartCount: 12,
+	}
+	focus := IncidentData{
+		Fingerprint: fp, Namespace: "default",
+		Resource: "fraud-detection-aaaaaaaaa-xxxxx", IssueType: "crash_loop",
+		Severity: "critical", DetailsJSON: `{"pod":"focus"}`, RestartCount: 12,
+	}
+
+	for _, tc := range []struct {
+		name   string
+		inputs []IncidentData
+	}{
+		{name: "forward", inputs: []IncidentData{low, highLexical, focus}},
+		{name: "reverse", inputs: []IncidentData{focus, highLexical, low}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := openTestStore(t)
+			if err := s.UpsertIncidents("test-cluster", "scan-1", tc.inputs); err != nil {
+				t.Fatalf("UpsertIncidents: %v", err)
+			}
+
+			var count, restarts int
+			var resource, severity, details string
+			if err := s.db.QueryRow(
+				`SELECT COUNT(*), resource, current_restart_count, severity, details_json
+				 FROM incidents WHERE cluster=? AND fingerprint=?`,
+				"test-cluster", fp,
+			).Scan(&count, &resource, &restarts, &severity, &details); err != nil {
+				t.Fatalf("query focused incident: %v", err)
+			}
+			if count != 1 {
+				t.Fatalf("incident count = %d, want 1", count)
+			}
+			if resource != focus.Resource || restarts != focus.RestartCount ||
+				severity != focus.Severity || details != focus.DetailsJSON {
+				t.Fatalf("stored observation mixed focus pods: resource=%q restarts=%d severity=%q details=%q",
+					resource, restarts, severity, details)
+			}
+
+			events, err := s.GetIncidentTimeline("test-cluster", fp)
+			if err != nil {
+				t.Fatalf("GetIncidentTimeline: %v", err)
+			}
+			if len(events) != 1 || events[0].EventType != "DETECTED" {
+				t.Fatalf("events = %+v, want exactly one DETECTED", events)
+			}
+		})
+	}
+}
+
+func TestUpsertIncidentsFocusPodChangeSkipsCrossPodRestartMilestone(t *testing.T) {
+	s := openTestStore(t)
+	fp := "default/Deployment/fraud-detection/crash_loop"
+	original := IncidentData{
+		Fingerprint: fp, Namespace: "default",
+		Resource: "fraud-detection-aaaaaaaaa-aaaaa", IssueType: "crash_loop",
+		Severity: "critical", DetailsJSON: `{"pod":"original"}`, RestartCount: 1,
+	}
+	if err := s.UpsertIncidents("test-cluster", "scan-1", []IncidentData{original}); err != nil {
+		t.Fatalf("UpsertIncidents(original): %v", err)
+	}
+
+	replacement := original
+	replacement.Resource = "fraud-detection-bbbbbbbbb-bbbbb"
+	replacement.RestartCount = 110
+	replacement.DetailsJSON = `{"pod":"replacement"}`
+	if err := s.UpsertIncidents("test-cluster", "scan-2", []IncidentData{replacement}); err != nil {
+		t.Fatalf("UpsertIncidents(replacement): %v", err)
+	}
+
+	var resource, details string
+	var restarts int
+	if err := s.db.QueryRow(
+		`SELECT resource, current_restart_count, details_json FROM incidents
+		 WHERE cluster=? AND fingerprint=?`,
+		"test-cluster", fp,
+	).Scan(&resource, &restarts, &details); err != nil {
+		t.Fatalf("query focused incident: %v", err)
+	}
+	if resource != replacement.Resource || restarts != replacement.RestartCount || details != replacement.DetailsJSON {
+		t.Fatalf("focus pod was not updated coherently: resource=%q restarts=%d details=%q",
+			resource, restarts, details)
+	}
+
+	events, err := s.GetIncidentTimeline("test-cluster", fp)
+	if err != nil {
+		t.Fatalf("GetIncidentTimeline: %v", err)
+	}
+	if len(events) != 1 || events[0].EventReason != "Detected" {
+		t.Fatalf("focus pod change emitted an event (including PodReplaced or RestartMilestone): %+v", events)
+	}
+}
+
+func TestUpsertIncidentsUnchangedFocusPodEmitsRestartMilestone(t *testing.T) {
+	s := openTestStore(t)
+	inc := IncidentData{
+		Fingerprint: "default/Deployment/fraud-detection/crash_loop",
+		Namespace:   "default", Resource: "fraud-detection-aaaaaaaaa-aaaaa",
+		IssueType: "crash_loop", Severity: "critical", RestartCount: 90,
+	}
+	if err := s.UpsertIncidents("test-cluster", "scan-1", []IncidentData{inc}); err != nil {
+		t.Fatalf("UpsertIncidents(initial): %v", err)
+	}
+	inc.RestartCount = 110
+	if err := s.UpsertIncidents("test-cluster", "scan-2", []IncidentData{inc}); err != nil {
+		t.Fatalf("UpsertIncidents(updated): %v", err)
+	}
+
+	events, err := s.GetIncidentTimeline("test-cluster", inc.Fingerprint)
+	if err != nil {
+		t.Fatalf("GetIncidentTimeline: %v", err)
+	}
+	if len(events) != 2 || events[1].EventReason != "RestartMilestone" ||
+		events[1].Message != "Restart count exceeded 100" {
+		t.Fatalf("events = %+v, want DETECTED then valid RestartMilestone", events)
+	}
+}
+
 func TestResolveMissing(t *testing.T) {
 	s := openTestStore(t)
 
@@ -296,6 +424,10 @@ func TestOwnerNameFromPod(t *testing.T) {
 		{"stream-processor-66c474d5fd-9zpwq", "stream-processor"},
 		{"namespace", "namespace"},
 		{"nginx", "nginx"},
+		{"fraud-detection-7cddf79d98-jxmtx", "fraud-detection"},
+		{"fraud-detection-7cddf79d98-kbfzw", "fraud-detection"},
+		{"prometheus-0", "prometheus-0"},
+		{"storage-provisioner", "storage-provisioner"},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Group observations by fingerprint and select a deterministic Focus Pod using highest restart count with pod name as a tie-breaker.

Update the stored resource when focus changes while preventing cross-pod restart milestone comparisons and duplicate incident events.

Add coverage for workload grouping, focus selection, pod transitions, and owner-name derivation.
Present incidents using workload identity while treating the selected pod as the current Focus Pod.

Add scoped identity and observation sections, human-readable classifications, observational briefings, and improved incident-age formatting.

Preserve namespace findings, remove redundant workload evidence, improve section ordering, and separate pod phase from effective container state.

Correct Incidents and War Room links so namespace findings omit synthetic pod parameters while navigation and real cluster context remain preserved."