### PR TITLE
feat(warroom): improve prioritized operational triage

### DIFF
--- a/cmd/opscart-dashboard/incident.go
+++ b/cmd/opscart-dashboard/incident.go
@@ -42,9 +42,12 @@ type incidentsPageData struct {
 	Namespaces []string // distinct namespaces for filter dropdown
 
 	// Summary counts (across all matching, not just this page)
-	ActiveCount   int
-	ReopenedCount int
-	ResolvedCount int
+	ActiveCritical int
+	ActiveHigh     int
+	ActiveMedium   int
+	ActiveLow      int
+	ReopenedCount  int
+	ResolvedCount  int
 }
 
 func (srv *server) handleIncidentsPage(w http.ResponseWriter, r *http.Request) {
@@ -64,7 +67,7 @@ func (srv *server) handleIncidentsPage(w http.ResponseWriter, r *http.Request) {
 
 	sortBy := q.Get("sort")
 	if sortBy == "" {
-		sortBy = "severity"
+		sortBy = "priority"
 	}
 
 	f := store.IncidentFilter{
@@ -111,27 +114,33 @@ func (srv *server) handleIncidentsPage(w http.ResponseWriter, r *http.Request) {
 		data.TotalPages = int(math.Ceil(float64(total) / 50))
 	}
 
-	// Summary counts — query with status overrides for the strip
-	if ac, _, e := srv.db.QueryIncidents(store.IncidentFilter{Cluster: ctx, Status: "active", PerPage: 1}); e == nil {
-		_ = ac
-	}
-	// Simpler: get counts from a summary query
-	if all, allTotal, e := srv.db.QueryIncidents(store.IncidentFilter{
+	// Summary counts use the current non-status filters across active and
+	// resolved results, rather than labeling every active row critical.
+	if all, e := queryAllIncidentSummaries(srv.db, store.IncidentFilter{
 		Cluster: ctx, Text: f.Text, Namespace: f.Namespace,
 		IssueType: f.IssueType, Severity: f.Severity,
-		Status: "", PerPage: 200,
+		Status: "",
 	}); e == nil {
 		for _, inc := range all {
 			switch {
 			case inc.Status == "resolved":
 				data.ResolvedCount++
-			case inc.ReopenCount > 0:
-				data.ReopenedCount++
 			default:
-				data.ActiveCount++
+				switch inc.Severity {
+				case "critical":
+					data.ActiveCritical++
+				case "high":
+					data.ActiveHigh++
+				case "medium":
+					data.ActiveMedium++
+				case "low":
+					data.ActiveLow++
+				}
+				if inc.ReopenCount > 0 {
+					data.ReopenedCount++
+				}
 			}
 		}
-		_ = allTotal
 	}
 
 	// Distinct namespaces for dropdown
@@ -234,6 +243,7 @@ var getIncidentsTmpl = sync.OnceValue(func() *template.Template {
 				"isNamespaceScoped": func(issueType string) bool {
 					return issueType == "unprotected_namespace" || issueType == "idle_namespace"
 				},
+				"trendApplies": store.RestartTrendApplies,
 			}).
 			ParseFS(templateFS,
 				"templates/base.html",
@@ -252,4 +262,21 @@ func renderIncidents(w http.ResponseWriter, data incidentsPageData) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	w.Write(buf.Bytes())
+}
+
+func queryAllIncidentSummaries(db store.Store, filter store.IncidentFilter) ([]store.IncidentSummary, error) {
+	filter.PerPage = 200
+	filter.Page = 1
+	var all []store.IncidentSummary
+	for {
+		items, total, err := db.QueryIncidents(filter)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, items...)
+		if len(all) >= total || len(items) == 0 {
+			return all, nil
+		}
+		filter.Page++
+	}
 }

--- a/cmd/opscart-dashboard/incident_corrections_test.go
+++ b/cmd/opscart-dashboard/incident_corrections_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/opscart/opscart-k8s-watcher/pkg/store"
+)
+
+func TestIncidentSummaryCountsMixedSeverities(t *testing.T) {
+	rec := httptest.NewRecorder()
+	renderIncidents(rec, incidentsPageData{
+		ClusterName: "prod", ClusterParam: "prod", Filter: store.IncidentFilter{SortBy: "priority"},
+		ActiveCritical: 17, ActiveHigh: 1, ActiveMedium: 2, ResolvedCount: 2,
+		Incidents: []store.IncidentSummary{{
+			Fingerprint: "apps/Deployment/api/crash_loop", Namespace: "apps", Resource: "api-pod",
+			IssueType: "crash_loop", Severity: "critical", Status: "active", FirstSeen: time.Now(), LastSeen: time.Now(),
+		}},
+		Total: 1, Page: 1, PerPage: 50, TotalPages: 1,
+	})
+	body := rec.Body.String()
+	for _, want := range []string{"17</b> active critical", "1</b> active high", "2</b> active medium", "2</b> resolved"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("summary missing %q", want)
+		}
+	}
+	if !strings.Contains(body, "active first, then severity, newest first") {
+		t.Fatal("default ordering footer is inaccurate")
+	}
+}
+
+func TestIncidentTrendApplicabilityRendering(t *testing.T) {
+	rec := httptest.NewRecorder()
+	now := time.Now()
+	renderIncidents(rec, incidentsPageData{
+		ClusterName: "prod", ClusterParam: "prod", Filter: store.IncidentFilter{SortBy: "priority"},
+		Incidents: []store.IncidentSummary{
+			{Fingerprint: "apps/Deployment/api/crash_loop", Namespace: "apps", Resource: "api-pod", IssueType: "crash_loop", Severity: "critical", Status: "active", Trend: "stable", FirstSeen: now, LastSeen: now},
+			{Fingerprint: "monitoring/Namespace/monitoring/unprotected_namespace", Namespace: "monitoring", Resource: "namespace", IssueType: "unprotected_namespace", Severity: "high", Status: "active", Trend: "stable", FirstSeen: now, LastSeen: now},
+		},
+		Total: 2, Page: 1, PerPage: 50, TotalPages: 1,
+	})
+	body := rec.Body.String()
+	if strings.Count(body, "→ stable") != 1 {
+		t.Fatalf("stable restart trend rendered for a non-applicable finding")
+	}
+	if !strings.Contains(body, "Restart trend does not apply to this finding.") {
+		t.Fatal("non-applicable trend lacks accessible explanation")
+	}
+}
+
+func TestWarRoomCanonicalFilterQuery(t *testing.T) {
+	got, changed := canonicalWarRoomQuery(map[string][]string{
+		"cluster": {"real-context"}, "q": {""}, "severity": {""}, "type": {""}, "limit": {"12"},
+	})
+	if !changed || got.Encode() != "cluster=real-context" {
+		t.Fatalf("canonical query = %q, changed=%v", got.Encode(), changed)
+	}
+}
+
+func TestNamespaceInvestigationUsesEvaluateWording(t *testing.T) {
+	hints := investigationHints("unprotected_namespace", "", 0, nil, "monitoring")
+	if len(hints) == 0 || hints[0].Title != "Evaluate a default-deny NetworkPolicy" {
+		t.Fatalf("unexpected first hint: %+v", hints)
+	}
+	if hints[0].Command != "kubectl get networkpolicies -n monitoring" {
+		t.Fatalf("read-only command changed: %q", hints[0].Command)
+	}
+}

--- a/cmd/opscart-dashboard/investigation.go
+++ b/cmd/opscart-dashboard/investigation.go
@@ -139,7 +139,7 @@ func investigationHints(issueType string, stateReason string, restarts int32, po
 	case "unprotected_namespace":
 		hints = append(hints, investigationHint{
 			Confidence: "high",
-			Title:      "Apply a default-deny NetworkPolicy",
+			Title:      "Evaluate a default-deny NetworkPolicy",
 			Reason:     "No NetworkPolicy was detected; review the namespace's intended ingress and egress controls before applying a default-deny policy.",
 			Command:    fmt.Sprintf("kubectl get networkpolicies -n %s", namespace),
 		})

--- a/cmd/opscart-dashboard/investigation_test.go
+++ b/cmd/opscart-dashboard/investigation_test.go
@@ -384,7 +384,6 @@ func TestInvestigationWorkloadSectionsAndLabels(t *testing.T) {
 		"Recommended Investigation",
 		"Incident Timeline",
 		"Blast Radius",
-		"Recent Events",
 		"Related Resources",
 	)
 }
@@ -424,8 +423,21 @@ func TestInvestigationNamespaceSectionsAndEvidence(t *testing.T) {
 		"Namespace Finding",
 		"Recommended Investigation",
 		"Incident Timeline",
-		"Recent Events",
 	)
+}
+
+func TestInvestigationRecentEventsHiddenWhenEmpty(t *testing.T) {
+	empty := renderInvestigationBody(t, investigationPageData{Namespace: "default", PodName: "pod"})
+	if strings.Contains(empty, "<h2>Recent Events</h2>") {
+		t.Fatal("Recent Events section rendered without events")
+	}
+	withEvent := renderInvestigationBody(t, investigationPageData{
+		Namespace: "default", PodName: "pod",
+		Events: []investigationEvent{{Type: "Warning", Reason: "BackOff", Age: "1m", Count: 1, Message: "retrying"}},
+	})
+	if !strings.Contains(withEvent, "<h2>Recent Events</h2>") {
+		t.Fatal("Recent Events section missing when events exist")
+	}
 }
 
 func TestFirstDetectedLabelIncludesAbsoluteAndRelativeDate(t *testing.T) {

--- a/cmd/opscart-dashboard/templates/incidents.html
+++ b/cmd/opscart-dashboard/templates/incidents.html
@@ -82,6 +82,7 @@
 .inc-trend-accelerating{color:#f87171}
 .inc-trend-stable{color:var(--text-muted)}
 .inc-trend-recovering{color:#4ade80}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 
 /* arrow */
 .inc-arrow{color:var(--text-muted);font-size:.85rem;text-align:center}
@@ -123,7 +124,7 @@
 
   <!-- War Room callout -->
   <div class="inc-wr-banner">
-    <span>Need immediate triage? <a class="inc-wr-link" href="{{.WrHref}}">War Room shows the top incidents ranked by impact →</a></span>
+    <span>Need immediate triage? <a class="inc-wr-link" href="{{.WrHref}}">War Room shows the top incidents ranked by severity and restart count →</a></span>
     {{if .CriticalCount}}<span style="color:#f87171;font-weight:600">{{.CriticalCount}} critical active</span>{{end}}
   </div>
 
@@ -160,6 +161,7 @@
         <option value="reopened"{{if eq .Filter.Status "reopened"}} selected{{end}}>Reopened</option>
       </select>
       <select name="sort" class="inc-select" onchange="this.form.submit()">
+        <option value="priority"{{if eq .Filter.SortBy "priority"}} selected{{end}}>Sort: Priority</option>
         <option value="severity"{{if eq .Filter.SortBy "severity"}} selected{{end}}>Sort: Severity</option>
         <option value="first_seen"{{if eq .Filter.SortBy "first_seen"}} selected{{end}}>Sort: First detected</option>
         <option value="last_seen"{{if eq .Filter.SortBy "last_seen"}} selected{{end}}>Sort: Last seen</option>
@@ -174,7 +176,10 @@
 
   <!-- Summary strip -->
   <div class="inc-summary">
-    {{if .ActiveCount}}<span class="inc-sum-crit"><b>{{.ActiveCount}}</b> active critical</span>{{end}}
+    {{if .ActiveCritical}}<span class="inc-sum-crit"><b>{{.ActiveCritical}}</b> active critical</span>{{end}}
+    {{if .ActiveHigh}}<span class="inc-sum-reo"><b>{{.ActiveHigh}}</b> active high</span>{{end}}
+    {{if .ActiveMedium}}<span><b>{{.ActiveMedium}}</b> active medium</span>{{end}}
+    {{if .ActiveLow}}<span><b>{{.ActiveLow}}</b> active low</span>{{end}}
     {{if .ReopenedCount}}<span class="inc-sum-reo"><b>{{.ReopenedCount}}</b> reopened</span>{{end}}
     {{if .ResolvedCount}}<span class="inc-sum-res"><b>{{.ResolvedCount}}</b> resolved</span>{{end}}
     <span class="inc-total"><b style="color:var(--text)">{{.Total}}</b> incidents in memory{{if or .Filter.Text .Filter.Namespace .Filter.IssueType .Filter.Severity .Filter.Status}} matching filters{{end}}</span>
@@ -246,7 +251,9 @@
             {{if gt .RestartCount 0}}{{.RestartCount}}{{else}}<span class="inc-dash">—</span>{{end}}
           </td>
           <td>
-            {{if .Trend}}
+            {{if not (trendApplies .IssueType)}}
+              <span class="inc-dash" aria-hidden="true">—</span><span class="sr-only">Restart trend does not apply to this finding.</span>
+            {{else if .Trend}}
               <span class="inc-trend inc-trend-{{.Trend}}">
                 {{if eq .Trend "accelerating"}}↑ accelerating
                 {{else if eq .Trend "stable"}}→ stable
@@ -271,7 +278,10 @@
         Showing <b style="color:var(--text)">{{pageStart .Page .PerPage}}–{{pageEnd .Page .PerPage .Total}}</b>
         of <b style="color:var(--text)">{{.Total}}</b>
         {{if gt .Total 1}}incidents{{else}}incident{{end}}
-        · sorted by {{.Filter.SortBy}}, newest first
+        {{if eq .Filter.SortBy "priority"}}· active first, then severity, newest first
+        {{else if eq .Filter.SortBy "severity"}}· sorted critical to low, newest first
+        {{else if eq .Filter.SortBy "restarts"}}· sorted by restarts, highest first
+        {{else}}· sorted by {{.Filter.SortBy}}, newest first{{end}}
       </span>
       <div class="inc-pager-btns">
         {{if gt .Page 1}}

--- a/cmd/opscart-dashboard/templates/investigation.html
+++ b/cmd/opscart-dashboard/templates/investigation.html
@@ -445,11 +445,11 @@ spec:
 {{end}}
 {{end}}
 
+  {{if .Events}}
   <div class="inv-section">
     <div class="inv-section-hdr">
       <h2>Recent Events</h2>
     </div>
-    {{if .Events}}
     <div class="inv-events-wrap">
       <table class="inv-events-tbl">
         <thead>
@@ -474,10 +474,8 @@ spec:
         </tbody>
       </table>
     </div>
-    {{else}}
-    <div class="inv-empty">No recent events recorded for this {{if .NamespaceScoped}}namespace{{else}}pod{{end}}</div>
-    {{end}}
   </div>
+  {{end}}
 
   {{if not .NamespaceScoped}}
   <div class="inv-section">

--- a/cmd/opscart-dashboard/templates/warroom.html
+++ b/cmd/opscart-dashboard/templates/warroom.html
@@ -1,170 +1,80 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>War Room — {{.ClusterName}}</title>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 {{template "base" .}}
 <style>
-.wr-registry-link{display:flex;align-items:center;justify-content:space-between;background:rgba(99,102,241,.07);border:1px solid rgba(129,140,248,.2);border-radius:var(--radius-sm);padding:.65rem 1rem;margin-bottom:1.5rem;font-size:.8rem;color:var(--text-muted)}
-.wr-registry-link a{color:var(--primary-light);font-weight:600;text-decoration:none}
-.wr-registry-link a:hover{text-decoration:underline}
-.summary-bar{display:flex;gap:1rem;margin-bottom:2rem;flex-wrap:wrap}
-.summary-chip{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);padding:0.75rem 1.25rem;display:flex;align-items:center;gap:0.75rem;min-width:160px}
-.summary-chip.c{border-color:rgba(239,68,68,0.35)}
-.summary-chip.w{border-color:rgba(245,158,11,0.35)}
-.summary-chip.ok{border-color:rgba(16,185,129,0.35)}
-.summary-num{font-size:1.6rem;font-weight:800;line-height:1}
-.c .summary-num{color:var(--danger)}
-.w .summary-num{color:var(--warning)}
-.ok .summary-num{color:var(--success)}
-.summary-lbl{font-size:0.72rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;line-height:1.3}
-.wr-section{margin-bottom:2.5rem}
-.wr-section-hdr{display:flex;align-items:center;gap:0.75rem;margin-bottom:1rem;padding-bottom:0.75rem;border-bottom:1px solid var(--border)}
-.wr-section-hdr h2{font-size:1rem;font-weight:700}
-.cnt-chip{padding:3px 10px;border-radius:20px;font-size:0.7rem;font-weight:700}
-.cnt-chip.c{background:rgba(239,68,68,0.15);color:#f87171}
-.cnt-chip.w{background:rgba(245,158,11,0.15);color:#fbbf24}
-.wr-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(340px,1fr));gap:1rem}
-.wr-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:1.25rem;display:flex;flex-direction:column;gap:0.55rem;transition:border-color 0.2s;animation:fadeIn 0.3s ease both}
-.wr-card.c{border-color:rgba(239,68,68,0.3);background:rgba(239,68,68,0.025)}
-.wr-card.w{border-color:rgba(245,158,11,0.25);background:rgba(245,158,11,0.02)}
-.wr-card:hover{border-color:var(--primary)}
-.wr-type-crash-loop{border-left:3px solid rgba(239,68,68,0.6)}
-.wr-type-oomkilled{border-left:3px solid rgba(249,115,22,0.6)}
-.wr-type-image-pull-backoff{border-left:3px solid rgba(234,179,8,0.6)}
-.wr-type-privileged-container{border-left:3px solid rgba(139,92,246,0.6)}
-.wr-type-unprotected-namespace{border-left:3px solid rgba(59,130,246,0.6)}
-.wr-type-orphaned-pvc{border-left:3px solid rgba(100,116,139,0.5)}
-.wr-type-zero-replica{border-left:3px solid rgba(100,116,139,0.4)}
-.wr-type-icon{display:inline-flex;align-items:center;justify-content:center;
-  width:16px;height:16px;margin-right:2px;vertical-align:middle;flex-shrink:0}
-.wri-crash::before{content:"";display:block;width:14px;height:14px;
-  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%23f87171' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='23 4 23 10 17 10'/%3E%3Cpolyline points='1 20 1 14 7 14'/%3E%3Cpath d='M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15'/%3E%3C/svg%3E");
-  background-repeat:no-repeat;background-size:contain}
-.wri-oom::before{content:"";display:block;width:14px;height:14px;
-  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%23fb923c' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='4' y='4' width='16' height='16' rx='2'/%3E%3Crect x='9' y='9' width='6' height='6'/%3E%3Cline x1='9' y1='1' x2='9' y2='4'/%3E%3Cline x1='15' y1='1' x2='15' y2='4'/%3E%3Cline x1='9' y1='20' x2='9' y2='23'/%3E%3Cline x1='15' y1='20' x2='15' y2='23'/%3E%3Cline x1='20' y1='9' x2='23' y2='9'/%3E%3Cline x1='20' y1='14' x2='23' y2='14'/%3E%3Cline x1='1' y1='9' x2='4' y2='9'/%3E%3Cline x1='1' y1='14' x2='4' y2='14'/%3E%3C/svg%3E");
-  background-repeat:no-repeat;background-size:contain}
-.wri-image::before{content:"";display:block;width:14px;height:14px;
-  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%23eab308' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z'/%3E%3Cpolyline points='3.27 6.96 12 12.01 20.73 6.96'/%3E%3Cline x1='12' y1='22.08' x2='12' y2='12'/%3E%3C/svg%3E");
-  background-repeat:no-repeat;background-size:contain}
-.wri-priv::before{content:"";display:block;width:14px;height:14px;
-  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%23a78bfa' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z'/%3E%3Cline x1='12' y1='8' x2='12' y2='12'/%3E%3Cline x1='12' y1='16' x2='12.01' y2='16'/%3E%3C/svg%3E");
-  background-repeat:no-repeat;background-size:contain}
-.wri-netpol::before{content:"";display:block;width:14px;height:14px;
-  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%2360a5fa' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='3' y='11' width='18' height='11' rx='2' ry='2'/%3E%3Cpath d='M7 11V7a5 5 0 0 1 9.9-1'/%3E%3C/svg%3E");
-  background-repeat:no-repeat;background-size:contain}
-.wri-pvc::before{content:"";display:block;width:14px;height:14px;
-  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cellipse cx='12' cy='5' rx='9' ry='3'/%3E%3Cpath d='M21 12c0 1.66-4 3-9 3s-9-1.34-9-3'/%3E%3Cpath d='M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5'/%3E%3C/svg%3E");
-  background-repeat:no-repeat;background-size:contain}
-.wri-zero::before{content:"";display:block;width:14px;height:14px;
-  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='6' y='4' width='4' height='16'/%3E%3Crect x='14' y='4' width='4' height='16'/%3E%3C/svg%3E");
-  background-repeat:no-repeat;background-size:contain}
-.wri-default::before{content:"";display:block;width:14px;height:14px;
-  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cline x1='12' y1='8' x2='12' y2='12'/%3E%3Cline x1='12' y1='16' x2='12.01' y2='16'/%3E%3C/svg%3E");
-  background-repeat:no-repeat;background-size:contain}
-.wr-top{display:flex;align-items:center;gap:0.5rem;flex-wrap:wrap}
-.badge{padding:2px 8px;border-radius:20px;font-size:0.64rem;font-weight:700;letter-spacing:0.5px}
-.badge.c{background:rgba(239,68,68,0.15);color:#f87171}
-.badge.w{background:rgba(245,158,11,0.15);color:#fbbf24}
-.type-lbl{font-size:0.72rem;color:var(--text-muted)}
-.age-lbl{margin-left:auto;font-size:0.7rem;color:var(--text-muted);white-space:nowrap;background:rgba(255,255,255,0.05);padding:1px 7px;border-radius:4px}
-.wr-name{font-size:0.93rem;font-weight:700;color:var(--text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.wr-ns{font-size:0.73rem;color:var(--text-muted)}
-.wr-reason{font-size:0.78rem;color:var(--text-secondary);line-height:1.55;display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden}
-.wr-cmd{display:flex;align-items:center;gap:0.5rem;background:rgba(0,0,0,0.3);border:1px solid var(--border);border-radius:var(--radius-xs);padding:0.5rem 0.75rem;margin-top:auto}
-.wr-cmd code{font-family:'Consolas','Monaco',monospace;font-size:0.7rem;color:var(--primary-light);flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.investigate-btn{display:inline-flex;align-items:center;margin-top:0.75rem;padding:0.4rem 1rem;background:var(--primary-bg);color:var(--primary-light);border-radius:var(--radius-sm);font-size:0.78rem;font-weight:600;text-decoration:none;transition:background .15s}
-.investigate-btn:hover{background:rgba(99,102,241,0.2)}
-.copy-btn{background:transparent;border:1px solid var(--border);border-radius:4px;color:var(--text-muted);cursor:pointer;font-size:0.64rem;padding:2px 7px;white-space:nowrap;transition:all 0.15s;flex-shrink:0}
-.copy-btn:hover{background:var(--surface-hover);color:var(--text)}
-.all-clear-box{background:var(--surface);border:1px solid rgba(16,185,129,0.25);border-radius:var(--radius);padding:2.5rem;text-align:center;color:var(--text-muted)}
-.all-clear-box .icon{font-size:2.5rem;margin-bottom:0.5rem}
-.footer{text-align:center;padding:1.5rem 0;color:var(--text-muted);font-size:0.75rem;border-top:1px solid var(--border);margin-top:1rem}
-@media(max-width:640px){.wr-grid{grid-template-columns:1fr}.summary-bar{flex-direction:column}}
+.wr-header-actions{display:flex;flex-direction:column;align-items:flex-end;gap:.65rem}
+.wr-back{display:inline-flex;align-items:center;gap:.45rem;padding:.42rem .75rem;border-radius:var(--radius-sm);border:1px solid rgba(129,140,248,.28);background:rgba(99,102,241,.07);color:var(--primary-light);font-size:.76rem;font-weight:600;text-decoration:none;transition:background .15s,border-color .15s}
+.wr-back:hover{background:rgba(99,102,241,.16);border-color:rgba(129,140,248,.5)}
+.wr-back:focus-visible,.toolbar input:focus-visible,.toolbar select:focus-visible,.reset-link:focus-visible{outline:2px solid var(--primary-light);outline-offset:2px}
+.briefing{display:flex;align-items:flex-start;gap:.8rem;background:rgba(99,102,241,.07);border:1px solid rgba(129,140,248,.22);border-radius:var(--radius);padding:1rem 1.15rem;margin-bottom:1rem;color:var(--text-secondary);font-size:.86rem}
+.briefing svg{flex:0 0 auto;color:var(--primary-light);margin-top:2px}
+.summary-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:.8rem;margin-bottom:1rem}
+.summary-card{display:flex;align-items:center;gap:.8rem;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);padding:.85rem 1rem}
+.summary-icon{width:34px;height:34px;display:grid;place-items:center;border-radius:8px;flex:0 0 auto}.summary-icon.red{color:#f87171;background:rgba(239,68,68,.1)}.summary-icon.amber{color:#fbbf24;background:rgba(245,158,11,.1)}.summary-icon.indigo{color:#a5b4fc;background:rgba(99,102,241,.12)}.summary-icon.blue{color:#60a5fa;background:rgba(59,130,246,.1)}
+.summary-num{font-size:1.35rem;font-weight:800;line-height:1.05}.summary-label{font-size:.68rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;margin-top:.2rem}
+.toolbar{display:grid;grid-template-columns:minmax(220px,1fr) 150px minmax(180px,220px) 120px auto;gap:.65rem;align-items:center;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:.8rem;margin-bottom:.75rem}.toolbar.has-reset{grid-template-columns:minmax(220px,1fr) 150px minmax(180px,220px) 120px auto auto}
+.toolbar input,.toolbar select{width:100%;height:40px;background:rgba(0,0,0,.22);border:1px solid var(--border);border-radius:var(--radius-xs);color:var(--text);padding:0 .7rem;font:inherit;font-size:.77rem}.toolbar input::placeholder{color:var(--text-muted)}
+.toolbar select option{background:var(--surface)}.reset-link{color:var(--primary-light);font-size:.75rem;text-decoration:none;white-space:nowrap}.reset-link:hover{text-decoration:underline}
+.toolbar-apply,.toolbar-reset{height:40px;display:inline-flex;align-items:center;justify-content:center;border-radius:var(--radius-xs);font:inherit;font-size:.76rem;font-weight:700;cursor:pointer;text-decoration:none;transition:background .15s,border-color .15s,color .15s,opacity .15s}.toolbar-apply{min-width:80px;border:1px solid var(--primary);background:var(--primary);color:#fff}.toolbar-apply:hover{background:var(--primary-light);border-color:var(--primary-light)}.toolbar-reset{min-width:72px;border:1px solid var(--border);background:transparent;color:var(--text-secondary)}.toolbar-reset:hover{border-color:var(--primary-light);color:var(--text)}.toolbar-apply:focus-visible,.toolbar-reset:focus-visible{outline:2px solid var(--primary-light);outline-offset:2px}.toolbar-apply:disabled,.toolbar-reset[aria-disabled="true"]{opacity:.42;cursor:not-allowed;pointer-events:none}
+.registry-row{display:flex;align-items:center;justify-content:space-between;gap:1rem;margin:0 0 1.25rem;color:var(--text-muted);font-size:.76rem}.registry-row a{color:var(--primary-light);font-weight:600;text-decoration:none}.registry-row a:hover{text-decoration:underline}
+.wr-section{margin-bottom:2rem}.wr-section-hdr{display:flex;align-items:center;justify-content:space-between;gap:.75rem;margin-bottom:.8rem;padding-bottom:.65rem;border-bottom:1px solid var(--border)}.wr-section-hdr h2{font-size:1rem;font-weight:700}.ranking-note{font-size:.72rem;color:var(--text-muted)}
+.wr-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:1rem}
+.wr-card{position:relative;min-width:0;background:var(--surface);border:1px solid var(--border);border-left:3px solid rgba(239,68,68,.58);border-radius:var(--radius);padding:.9rem;display:flex;flex-direction:column;gap:.32rem;min-height:260px;transition:border-color .15s,background .15s}
+.wr-card:hover{border-color:rgba(129,140,248,.42);border-left-color:rgba(239,68,68,.8)}
+.wr-card.featured{border-color:rgba(239,68,68,.42);border-left:4px solid var(--danger);background:linear-gradient(90deg,rgba(239,68,68,.055),var(--surface) 70%)}
+.wr-top{display:flex;align-items:center;gap:.45rem;flex-wrap:wrap}.rank-badge{display:inline-flex;align-items:center;justify-content:center;min-width:27px;height:22px;border-radius:6px;background:rgba(255,255,255,.06);color:var(--text-secondary);font-size:.68rem;font-weight:700}
+.badge{padding:2px 8px;border-radius:20px;font-size:.62rem;font-weight:750;letter-spacing:.05em}.badge.c{background:rgba(239,68,68,.14);color:#f87171}.badge.w{background:rgba(245,158,11,.14);color:#fbbf24}
+.wr-name{font-size:.96rem;font-weight:750;color:var(--text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.wr-focus{font-size:.71rem;color:var(--text-secondary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.wr-ns{font-size:.7rem;color:var(--text-muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.wr-reason{font-size:.74rem;color:var(--text-muted);line-height:1.4}.wr-evidence{display:grid;grid-template-columns:minmax(0,1.6fr) repeat(2,minmax(64px,.7fr));gap:.45rem;margin:.12rem 0}.wr-evidence div{min-width:0;background:rgba(0,0,0,.13);border-radius:6px;padding:.35rem .45rem}.wr-evidence span{display:block;color:var(--text-muted);font-size:.57rem;text-transform:uppercase;letter-spacing:.05em}.wr-evidence strong{display:block;color:var(--text-secondary);font-size:.69rem;margin-top:.1rem;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.wr-actions{display:flex;align-items:center;gap:.5rem;margin-top:auto;padding-top:.3rem;border-top:1px solid rgba(51,65,85,.55);min-width:0}.wr-cmd{display:flex;align-items:center;gap:.4rem;background:rgba(0,0,0,.3);border:1px solid var(--border);border-radius:var(--radius-xs);padding:.42rem .5rem;min-width:0;flex:1}.wr-cmd code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.66rem;color:var(--primary-light);flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.copy-btn{background:transparent;border:1px solid var(--border);border-radius:4px;color:var(--text-muted);cursor:pointer;font-size:.64rem;padding:2px 7px;white-space:nowrap}.copy-btn:hover{background:var(--surface-hover);color:var(--text)}
+.investigate-btn{display:inline-flex;align-items:center;align-self:flex-start;margin-top:.2rem;padding:.38rem .8rem;background:var(--primary-bg);color:var(--primary-light);border-radius:var(--radius-sm);font-size:.75rem;font-weight:600;text-decoration:none}.investigate-btn:hover{background:rgba(99,102,241,.2)}
+.posture-list{display:flex;flex-direction:column;gap:.7rem}.posture-card{width:100%;min-height:0;border-left-color:var(--warning);background:rgba(245,158,11,.025);display:grid;grid-template-columns:minmax(180px,.8fr) minmax(300px,1.5fr);align-items:center;column-gap:1rem}.posture-card .wr-top{grid-column:1/-1}.posture-card .wr-evidence,.posture-card .wr-actions{grid-column:1/-1}.posture-card .wr-name,.posture-card .wr-ns,.posture-card .wr-reason{min-width:0}.posture-card .investigate-btn{margin:0;align-self:center}
+.empty-state{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:1.7rem;text-align:center;color:var(--text-muted);font-size:.82rem}
+.wri-crash::before,.wri-oom::before,.wri-image::before,.wri-priv::before,.wri-netpol::before,.wri-default::before{content:"";display:block;width:14px;height:14px;background-repeat:no-repeat;background-size:contain}
+.wri-crash::before{background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23f87171' stroke-width='2'%3E%3Cpath d='M23 4v6h-6M1 20v-6h6M3.5 9a9 9 0 0114.9-3.4L23 10M1 14l4.6 4.4A9 9 0 0020.5 15'/%3E%3C/svg%3E")}.wri-oom::before{background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23fb923c' stroke-width='2'%3E%3Crect x='4' y='4' width='16' height='16' rx='2'/%3E%3Crect x='9' y='9' width='6' height='6'/%3E%3C/svg%3E")}.wri-image::before{background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23eab308' stroke-width='2'%3E%3Cpath d='M21 16V8l-9-5-9 5v8l9 5 9-5zM3 8l9 5 9-5M12 13v8'/%3E%3C/svg%3E")}.wri-priv::before{background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23a78bfa' stroke-width='2'%3E%3Cpath d='M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10zM12 8v4M12 16h.01'/%3E%3C/svg%3E")}.wri-netpol::before{background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23fbbf24' stroke-width='2'%3E%3Crect x='3' y='11' width='18' height='10' rx='2'/%3E%3Cpath d='M7 11V7a5 5 0 019.9-1'/%3E%3C/svg%3E")}.wri-default::before{background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpath d='M12 8v4M12 16h.01'/%3E%3C/svg%3E")}
+.footer{text-align:center;padding:1.5rem 0;color:var(--text-muted);font-size:.72rem;border-top:1px solid var(--border)}
+@media(min-width:1500px){.wr-grid{grid-template-columns:repeat(4,minmax(0,1fr))}}
+@media(max-width:1099px){.summary-grid{grid-template-columns:repeat(2,1fr)}.toolbar,.toolbar.has-reset{grid-template-columns:1fr 1fr}.toolbar .search-field{grid-column:1/-1}.wr-grid{grid-template-columns:repeat(2,minmax(0,1fr))}.posture-card{grid-template-columns:1fr 1fr}.posture-card .wr-cmd{grid-column:1/-1}}
+@media(max-width:719px){.page-hdr{display:block}.wr-header-actions{align-items:flex-start;margin-top:.8rem}.summary-grid,.toolbar,.toolbar.has-reset,.wr-grid{grid-template-columns:1fr}.toolbar .search-field{grid-column:span 1}.registry-row{align-items:flex-start;flex-direction:column}.posture-card{display:flex}.wr-actions{align-items:stretch;flex-direction:column}.investigate-btn{align-self:stretch;justify-content:center}}
 </style>
 </head>
-<body>
-<div class="layout">
+<body><div class="layout">
 {{.Sidebar}}
 <main class="main">
-  <div class="page-hdr">
-    <div>
-      <h1>War Room</h1>
-      <p>{{.ClusterName}} &mdash; {{.StatusDesc}}</p>
-    </div>
-    <div class="page-meta">
-      <div>Last scanned: <strong id="wr-age">just now</strong></div>
-      <a class="back-link" href="{{.DashURL}}">← Back to Dashboard</a>
-    </div>
-  </div>
+<header class="page-hdr"><div><h1>War Room</h1><p>{{.ClusterName}} &mdash; {{.StatusDesc}}</p></div><div class="wr-header-actions"><div class="page-meta">Last scanned: <strong id="wr-age">just now</strong></div><a class="wr-back" href="{{.DashURL}}"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m15 18-6-6 6-6"/><path d="M9 12h10"/></svg>Back to Overview</a></div></header>
 
-  <div class="summary-bar">
-    <div class="summary-chip {{.CritChipClass}}">
-      <div class="summary-num">{{len .Critical}}</div>
-      <div class="summary-lbl">Critical<br>Issues</div>
-    </div>
-    <div class="summary-chip {{.WarnChipClass}}">
-      <div class="summary-num">{{len .Warnings}}</div>
-      <div class="summary-lbl">Warnings</div>
-    </div>
-  </div>
+<section class="briefing" aria-label="Operational Briefing"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M12 8v4M12 16h.01"/></svg><div><strong>Operational Briefing</strong><br>{{.Briefing}}</div></section>
 
-    {{if .TotalIssues}}
-    <div class="wr-registry-link">
-      <span>Ranked by severity · restart count</span>
-      <a href="{{.IncidentsHref}}">View all {{.TotalIssues}} incidents in registry →</a>
-    </div>
-    {{end}}
+<section class="summary-grid" aria-label="War Room summary">
+<div class="summary-card"><div class="summary-icon red"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M12 9v4M12 17h.01"/><path d="M10.3 3.4 2.5 17a2 2 0 001.7 3h15.6a2 2 0 001.7-3L13.7 3.4a2 2 0 00-3.4 0z"/></svg></div><div><div class="summary-num">{{.ActiveCritical}}</div><div class="summary-label">Critical Incidents</div></div></div>
+<div class="summary-card"><div class="summary-icon amber"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 21h18M5 21V7l7-4 7 4v14M9 9h.01M15 9h.01M9 13h.01M15 13h.01"/></svg></div><div><div class="summary-num">{{.NamespaceFindings}}</div><div class="summary-label">Namespace Findings</div></div></div>
+<div class="summary-card"><div class="summary-icon indigo"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="4" width="18" height="14" rx="2"/><path d="M8 22h8M12 18v4"/></svg></div><div><div class="summary-num">{{.AffectedWorkloads}}</div><div class="summary-label">Affected Workloads</div></div></div>
+<div class="summary-card"><div class="summary-icon blue"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg></div><div><div class="summary-num">{{if .HasOldestActive}}{{.OldestActive}}d{{else}}—{{end}}</div><div class="summary-label">Oldest Active</div></div></div>
+</section>
 
-    <div class="wr-section">
-      <div class="wr-section-hdr">
-        <h2>🔴 Critical Issues</h2>
-      <span class="cnt-chip c">{{len .Critical}}</span>
-    </div>
-    {{if eq (len .Critical) 0}}
-    <div class="all-clear-box">
-      <div class="icon">✅</div>
-      <div>No crash-looping, OOMKilled, or ImagePullBackOff pods detected</div>
-    </div>
-    {{else}}
-    <div class="wr-grid">
-      {{range .Critical}}{{renderCard . $.ActiveCtx}}{{end}}
-    </div>
-    {{end}}
-  </div>
+<form class="toolbar{{if .FilterActive}} has-reset{{end}}" method="get" action="/warroom">
+{{if .ActiveCtx}}<input type="hidden" name="cluster" value="{{.ActiveCtx}}">{{end}}
+<input class="search-field" type="search" name="q" value="{{.Query}}" placeholder="Search workload, pod, or namespace" aria-label="Search workload, pod, or namespace">
+<select name="severity" aria-label="Severity filter"><option value="">All severities</option><option value="critical"{{if eq .Severity "critical"}} selected{{end}}>Critical</option><option value="high"{{if eq .Severity "high"}} selected{{end}}>High</option></select>
+<select name="type" aria-label="Classification filter"><option value="">All classifications</option>{{range .Classifications}}<option value="{{.Value}}"{{if eq $.Type .Value}} selected{{end}}>{{.Label}}</option>{{end}}</select>
+<select name="limit" aria-label="Result limit"><option value="12"{{if eq .Limit 12}} selected{{end}}>Top 12</option><option value="25"{{if eq .Limit 25}} selected{{end}}>Top 25</option><option value="50"{{if eq .Limit 50}} selected{{end}}>Top 50</option></select>
+<button type="submit" class="toolbar-apply">Apply</button>{{if .FilterActive}}<a class="toolbar-reset" href="{{.ResetURL}}">Reset</a>{{end}}
+</form>
+<div class="registry-row"><span>{{.ShowingStatus}}</span><a href="{{.IncidentsHref}}">View all {{.TotalIssues}} incidents in registry →</a></div>
 
-  <div class="wr-section">
-    <div class="wr-section-hdr">
-      <h2>🟡 Warnings</h2>
-      <span class="cnt-chip w">{{len .Warnings}}</span>
-    </div>
-    {{if eq (len .Warnings) 0}}
-    <div class="all-clear-box">
-      <div class="icon">✅</div>
-      <div>No unprotected namespaces, orphaned PVCs, or zero-replica workloads detected</div>
-    </div>
-    {{else}}
-    <div class="wr-grid">
-      {{range .Warnings}}{{renderCard . $.ActiveCtx}}{{end}}
-    </div>
-    {{end}}
-  </div>
+<section class="wr-section"><div class="wr-section-hdr"><h2>Prioritized Incidents</h2><span class="ranking-note">Ranked by severity · restart count</span></div>
+{{if .Critical}}<div class="wr-grid">{{range .Critical}}{{renderCard . $.ActiveCtx}}{{end}}</div>{{else}}<div class="empty-state">No workload incidents match the current filters.</div>{{end}}
+</section>
 
-  <div class="footer">OpsCart FinOps Engine &middot; War Room &middot; Suggestions only &mdash; verify with owners before acting</div>
-</main>
-</div>
-<script>
-(function(){
-  var TS={{.ScannedAtMs}},el=document.getElementById('wr-age'),sb=document.getElementById('wr-age-sb');
-  function upd(){
-    var s=Math.floor((Date.now()-TS)/1000);
-    var t=s<5?'just now':s<60?s+'s ago':Math.floor(s/60)+'m ago';
-    if(el)el.textContent=t;if(sb)sb.textContent=t;
-  }
-  setInterval(upd,1000);upd();
-})();
-</script>
-</body>
-</html>
+<section class="wr-section"><div class="wr-section-hdr"><h2>Namespace Posture Findings</h2><span class="ranking-note">{{len .Warnings}} finding{{if ne (len .Warnings) 1}}s{{end}}</span></div>
+{{if .Warnings}}<div class="posture-list">{{range .Warnings}}{{renderCard . $.ActiveCtx}}{{end}}</div>{{else}}<div class="empty-state">No namespace posture findings match the current filters.</div>{{end}}
+</section>
+
+{{if .TotalIssues}}<div class="registry-row" style="justify-content:flex-end;margin-top:.5rem"><a href="{{.IncidentsHref}}">View all {{.TotalIssues}} incidents in registry →</a></div>{{end}}
+
+<div class="footer">OpsCart War Room &middot; Suggestions only &mdash; verify with owners before acting</div>
+</main></div>
+<script>(function(){var TS={{.ScannedAtMs}},el=document.getElementById('wr-age');function upd(){var s=Math.floor((Date.now()-TS)/1000);el.textContent=s<5?'just now':s<60?s+'s ago':Math.floor(s/60)+'m ago'}setInterval(upd,1000);upd()})();</script>
+</body></html>

--- a/cmd/opscart-dashboard/version.go
+++ b/cmd/opscart-dashboard/version.go
@@ -1,3 +1,3 @@
 package main
 
-const Version = "v1.10.0"
+const Version = "v1.10.1"

--- a/cmd/opscart-dashboard/warroom.go
+++ b/cmd/opscart-dashboard/warroom.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/opscart/opscart-k8s-watcher/pkg/analyzer"
+	"github.com/opscart/opscart-k8s-watcher/pkg/store"
 )
 
 // handleWarRoom returns up to 5 critical issues: crash-looping pods, unexpected
@@ -41,29 +42,58 @@ func (srv *server) handleWarRoom(w http.ResponseWriter, r *http.Request) {
 // ── War Room helpers ──────────────────────────────────────────────────────────
 
 type warRoomIssue struct {
-	Severity     string `json:"severity"`
-	Type         string `json:"type"`
-	Namespace    string `json:"namespace"`
-	Resource     string `json:"resource"`
-	Message      string `json:"message"`
-	AgeDays      int    `json:"age_days,omitempty"`
-	KubectlCmd   string `json:"kubectl_cmd,omitempty"`
-	RestartCount int    `json:"restart_count,omitempty"`
+	Severity       string `json:"severity"`
+	Type           string `json:"type"`
+	Namespace      string `json:"namespace"`
+	Resource       string `json:"resource"`
+	Message        string `json:"message"`
+	AgeDays        int    `json:"age_days,omitempty"`
+	KubectlCmd     string `json:"kubectl_cmd,omitempty"`
+	RestartCount   int    `json:"restart_count,omitempty"`
+	Classification string `json:"classification,omitempty"`
+	Container      string `json:"container,omitempty"`
+	WorkloadKind   string `json:"workload_kind,omitempty"`
+	WorkloadName   string `json:"workload_name,omitempty"`
+	Rank           int    `json:"rank,omitempty"`
 }
 
 type warRoomPageData struct {
-	ClusterName   string
-	ActiveCtx     string
-	StatusDesc    string
-	DashURL       string
-	CritChipClass string
-	WarnChipClass string
-	Critical      []warRoomIssue
-	Warnings      []warRoomIssue
-	ScannedAtMs   int64
-	Sidebar       template.HTML
-	TotalIssues   int
-	IncidentsHref string
+	ClusterName        string
+	ActiveCtx          string
+	StatusDesc         string
+	DashURL            string
+	Critical           []warRoomIssue
+	Warnings           []warRoomIssue
+	ScannedAtMs        int64
+	Sidebar            template.HTML
+	TotalIssues        int
+	IncidentsHref      string
+	ResetURL           string
+	Query              string
+	Severity           string
+	Type               string
+	Limit              int
+	FilterActive       bool
+	Classifications    []warRoomFilterOption
+	ShowingStatus      string
+	Briefing           string
+	ActiveCritical     int
+	AffectedWorkloads  int
+	OldestActive       int
+	HasOldestActive    bool
+	HighestRestarts    int
+	HasHighestRestarts bool
+	NamespaceFindings  int
+}
+
+type warRoomFilterOption struct {
+	Value string
+	Label string
+}
+
+type warRoomStats struct {
+	activeCritical, affectedWorkloads, oldest, highestRestarts, namespaceFindings int
+	hasOldest, hasHighestRestarts                                                 bool
 }
 
 func collectWarRoomIssues(scan *clusterScan, limit int) []warRoomIssue {
@@ -75,14 +105,15 @@ func collectWarRoomIssues(scan *clusterScan, limit int) []warRoomIssue {
 			if pod.Kind == analyzer.StalePodZombie {
 				itype := zombieTypeForStatus(pod.Status)
 				issues = append(issues, warRoomIssue{
-					Severity:     "critical",
-					Type:         itype,
-					Namespace:    pod.Namespace,
-					Resource:     pod.Name,
-					Message:      fmt.Sprintf("%s — %d restarts, %d days old", pod.Status, pod.RestartCount, pod.AgeDays),
-					AgeDays:      pod.AgeDays,
-					KubectlCmd:   kubectlCmdForIssue(itype, pod.Name, pod.Namespace),
-					RestartCount: int(pod.RestartCount),
+					Severity:       "critical",
+					Type:           itype,
+					Namespace:      pod.Namespace,
+					Resource:       pod.Name,
+					Message:        fmt.Sprintf("%s — %d restarts, %d days old", pod.Status, pod.RestartCount, pod.AgeDays),
+					AgeDays:        pod.AgeDays,
+					KubectlCmd:     kubectlCmdForIssue(itype, pod.Name, pod.Namespace),
+					RestartCount:   int(pod.RestartCount),
+					Classification: classificationForIssue(itype),
 				})
 			}
 		}
@@ -92,13 +123,19 @@ func collectWarRoomIssues(scan *clusterScan, limit int) []warRoomIssue {
 	if scan.secAudit != nil {
 		for _, issue := range scan.secAudit.Issues {
 			if issue.Type == "privileged_container" && issue.Severity == "critical" {
+				podName, containerName := issue.Name, ""
+				if parts := strings.SplitN(issue.Name, "/", 2); len(parts) == 2 {
+					podName, containerName = parts[0], parts[1]
+				}
 				issues = append(issues, warRoomIssue{
-					Severity:   "critical",
-					Type:       "privileged_container",
-					Namespace:  issue.Namespace,
-					Resource:   issue.Name,
-					Message:    issue.Description,
-					KubectlCmd: fmt.Sprintf("kubectl describe pod %s -n %s", issue.Name, issue.Namespace),
+					Severity:       "critical",
+					Type:           "privileged_container",
+					Namespace:      issue.Namespace,
+					Resource:       podName,
+					Message:        issue.Description,
+					KubectlCmd:     fmt.Sprintf("kubectl describe pod %s -n %s", podName, issue.Namespace),
+					Classification: classificationForIssue("privileged_container"),
+					Container:      containerName,
 				})
 			}
 		}
@@ -109,17 +146,29 @@ func collectWarRoomIssues(scan *clusterScan, limit int) []warRoomIssue {
 		for _, ns := range scan.netAudit.UnprotectedNamespaces {
 			if ns.RiskLevel == "HIGH" {
 				issues = append(issues, warRoomIssue{
-					Severity:   "high",
-					Type:       "unprotected_namespace",
-					Namespace:  ns.Name,
-					Resource:   "namespace",
-					Message:    fmt.Sprintf("No NetworkPolicy — %d pods exposed", ns.PodCount),
-					KubectlCmd: fmt.Sprintf("kubectl get networkpolicies -n %s", ns.Name),
+					Severity:       "high",
+					Type:           "unprotected_namespace",
+					Namespace:      ns.Name,
+					Resource:       "namespace",
+					Message:        fmt.Sprintf("%d pods in namespace", ns.PodCount),
+					KubectlCmd:     fmt.Sprintf("kubectl get networkpolicies -n %s", ns.Name),
+					Classification: "Missing default-deny NetworkPolicy",
 				})
 			}
 		}
 	}
-	// Sort: critical first, then by restart count descending (highest impact first)
+	// 4. Idle/abandoned namespaces are posture findings, not workloads.
+	if scan.wasteAudit != nil {
+		for _, ns := range scan.wasteAudit.AbandonedNamespaces {
+			issues = append(issues, warRoomIssue{
+				Severity: "high", Type: "idle_namespace", Namespace: ns.Name,
+				Resource: "namespace", Message: ns.Reason, AgeDays: ns.AgeDays,
+				KubectlCmd:     fmt.Sprintf("kubectl get pods -n %s", ns.Name),
+				Classification: "Idle namespace",
+			})
+		}
+	}
+	// Sort: critical first, then by restart count descending.
 	severityOrder := map[string]int{"critical": 0, "high": 1, "medium": 2, "low": 3}
 	sort.SliceStable(issues, func(i, j int) bool {
 		si := severityOrder[issues[i].Severity]
@@ -140,6 +189,14 @@ func collectWarRoomIssues(scan *clusterScan, limit int) []warRoomIssue {
 // ── War Room page ─────────────────────────────────────────────────────────────
 
 func (srv *server) handleWarRoomPage(w http.ResponseWriter, r *http.Request) {
+	if canonical, changed := canonicalWarRoomQuery(r.URL.Query()); changed {
+		target := "/warroom"
+		if encoded := canonical.Encode(); encoded != "" {
+			target += "?" + encoded
+		}
+		http.Redirect(w, r, target, http.StatusSeeOther)
+		return
+	}
 	ctx := srv.activeCtx(r)
 	state := srv.getState(ctx)
 
@@ -158,18 +215,37 @@ func (srv *server) handleWarRoomPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	fmt.Fprint(w, renderWarRoomPage(scan, ctx, srv.clusterList))
+	fmt.Fprint(w, renderWarRoomPageWithFilters(scan, ctx, srv.clusterList, r.URL.Query()))
 }
 
 func renderWarRoomPage(scan *clusterScan, activeCtx string, clusterList []string) string {
+	return renderWarRoomPageWithFilters(scan, activeCtx, clusterList, nil)
+}
+
+func renderWarRoomPageWithFilters(scan *clusterScan, activeCtx string, clusterList []string, query url.Values) string {
 	allIssues := collectWarRoomIssues(scan, 0)
-	var critical, warnings []warRoomIssue
-	for _, issue := range allIssues {
-		if issue.Severity == "critical" {
-			critical = append(critical, issue)
-		} else {
+	for i := range allIssues {
+		enrichWarRoomIdentity(&allIssues[i], scan)
+	}
+	stats := warRoomStatsFor(allIssues)
+	qText := strings.TrimSpace(query.Get("q"))
+	severity := strings.ToLower(strings.TrimSpace(query.Get("severity")))
+	issueType := strings.TrimSpace(query.Get("type"))
+	limit := parseWarRoomLimit(query.Get("limit"))
+	filtered := filterWarRoomIssues(allIssues, qText, severity, issueType)
+	var incidents, warnings []warRoomIssue
+	for _, issue := range filtered {
+		if isNamespaceFinding(issue) {
 			warnings = append(warnings, issue)
+		} else {
+			incidents = append(incidents, issue)
 		}
+	}
+	if len(incidents) > limit {
+		incidents = incidents[:limit]
+	}
+	for i := range incidents {
+		incidents[i].Rank = i + 1
 	}
 
 	scannedAt := time.Now()
@@ -179,36 +255,37 @@ func renderWarRoomPage(scan *clusterScan, activeCtx string, clusterList []string
 		clusterName = scan.report.ClusterName
 	}
 
-	q := ""
+	clusterQ := ""
 	if activeCtx != "" {
-		q = "?cluster=" + url.QueryEscape(activeCtx)
+		clusterQ = "?cluster=" + url.QueryEscape(activeCtx)
 	}
-	// Cap War Room at top 20 — full registry is in Incidents
-	if len(critical) > 20 {
-		critical = critical[:20]
-	}
-	critChipClass := "ok"
-	if len(critical) > 0 {
-		critChipClass = "c"
-	}
-	warnChipClass := "ok"
+	filterActive := qText != "" || severity != "" || issueType != "" || limit != 12
+	classifications := uniqueClassifications(allIssues)
+	status := fmt.Sprintf("Showing %d prioritized incident%s", len(incidents), plural(len(incidents)))
 	if len(warnings) > 0 {
-		warnChipClass = "w"
+		status += fmt.Sprintf(" · %d namespace finding%s", len(warnings), plural(len(warnings)))
 	}
+	briefing := buildWarRoomBriefing(stats)
 
 	data := warRoomPageData{
 		ClusterName:   clusterName,
 		ActiveCtx:     activeCtx,
-		StatusDesc:    fmt.Sprintf("%d issue(s) detected", len(critical)+len(warnings)),
-		DashURL:       "/" + q,
-		CritChipClass: critChipClass,
-		WarnChipClass: warnChipClass,
-		Critical:      critical,
+		StatusDesc:    fmt.Sprintf("%d issue(s) detected", len(allIssues)),
+		DashURL:       "/" + clusterQ,
+		Critical:      incidents,
 		Warnings:      warnings,
 		ScannedAtMs:   scannedAt.UnixMilli(),
 		Sidebar:       template.HTML(buildSidebar("warroom", activeCtx, clusterName, clusterList, countCriticalIssues(scan))),
-		TotalIssues:   len(critical) + len(warnings),
-		IncidentsHref: "/incidents" + q,
+		TotalIssues:   len(allIssues),
+		IncidentsHref: withWarRoomQuery("/incidents", activeCtx, qText, severity, issueType, limit),
+		ResetURL:      "/warroom" + clusterQ,
+		Query:         qText, Severity: severity, Type: issueType, Limit: limit,
+		FilterActive: filterActive, Classifications: classifications,
+		ShowingStatus: status, Briefing: briefing,
+		ActiveCritical: stats.activeCritical, AffectedWorkloads: stats.affectedWorkloads,
+		OldestActive: stats.oldest, HasOldestActive: stats.hasOldest,
+		HighestRestarts: stats.highestRestarts, HasHighestRestarts: stats.hasHighestRestarts,
+		NamespaceFindings: stats.namespaceFindings,
 	}
 
 	var buf strings.Builder
@@ -217,6 +294,226 @@ func renderWarRoomPage(scan *clusterScan, activeCtx string, clusterList []string
 		return ""
 	}
 	return buf.String()
+}
+
+func canonicalWarRoomQuery(query url.Values) (url.Values, bool) {
+	canonical := make(url.Values, len(query))
+	for key, values := range query {
+		canonical[key] = append([]string(nil), values...)
+	}
+	changed := false
+	for _, key := range []string{"q", "severity", "type"} {
+		if values, exists := canonical[key]; exists && strings.TrimSpace(firstValue(values)) == "" {
+			canonical.Del(key)
+			changed = true
+		}
+	}
+	if values, exists := canonical["limit"]; exists {
+		raw := firstValue(values)
+		if raw == "12" || (raw != "25" && raw != "50") {
+			canonical.Del("limit")
+			changed = true
+		}
+	}
+	return canonical, changed
+}
+
+func firstValue(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+func parseWarRoomLimit(raw string) int {
+	switch raw {
+	case "25":
+		return 25
+	case "50":
+		return 50
+	default:
+		return 12
+	}
+}
+
+func isNamespaceFinding(issue warRoomIssue) bool {
+	return issue.Type == "unprotected_namespace" || issue.Type == "idle_namespace"
+}
+
+func classificationForIssue(issueType string) string {
+	switch issueType {
+	case "crash_loop":
+		return "CrashLoopBackOff"
+	case "oomkilled":
+		return "OOMKilled"
+	case "image_pull_backoff":
+		return "ImagePullBackOff"
+	case "probe_failure":
+		return "Probe failure"
+	case "privileged_container":
+		return "Privileged container"
+	case "unprotected_namespace":
+		return "Missing default-deny NetworkPolicy"
+	case "idle_namespace":
+		return "Idle namespace"
+	default:
+		return issueType
+	}
+}
+
+func enrichWarRoomIdentity(issue *warRoomIssue, scan *clusterScan) {
+	if issue.Classification == "" {
+		issue.Classification = classificationForIssue(issue.Type)
+	}
+	if isNamespaceFinding(*issue) {
+		issue.WorkloadKind, issue.WorkloadName = "Namespace", issue.Namespace
+		return
+	}
+	owner := store.OwnerNameFromPod(issue.Resource)
+	issue.WorkloadKind, issue.WorkloadName = "Pod", issue.Resource
+	if scan == nil {
+		if owner != issue.Resource {
+			issue.WorkloadKind, issue.WorkloadName = "Deployment", owner
+		}
+		return
+	}
+	for _, workload := range scan.AllWorkloads {
+		if workload.Namespace != issue.Namespace {
+			continue
+		}
+		if workload.Name == owner {
+			issue.WorkloadKind, issue.WorkloadName = workload.Kind, owner
+			return
+		}
+		if strings.HasPrefix(issue.Resource, workload.Name+"-") {
+			switch workload.Kind {
+			case "StatefulSet":
+				// OwnerNameFromPod deliberately retains StatefulSet ordinals.
+				issue.WorkloadKind, issue.WorkloadName = workload.Kind, owner
+			case "DaemonSet":
+				issue.WorkloadKind, issue.WorkloadName = workload.Kind, workload.Name
+			}
+			return
+		}
+	}
+	if owner != issue.Resource {
+		issue.WorkloadKind, issue.WorkloadName = "Deployment", owner
+	}
+}
+
+func filterWarRoomIssues(issues []warRoomIssue, query, severity, issueType string) []warRoomIssue {
+	needle := strings.ToLower(query)
+	var filtered []warRoomIssue
+	for _, issue := range issues {
+		if severity != "" && issue.Severity != severity {
+			continue
+		}
+		if issueType != "" && issue.Type != issueType {
+			continue
+		}
+		if needle != "" {
+			haystack := strings.ToLower(strings.Join([]string{
+				issue.WorkloadKind, issue.WorkloadName, issue.Resource, issue.Namespace,
+				issue.Classification, issue.Container,
+			}, " "))
+			if !strings.Contains(haystack, needle) {
+				continue
+			}
+		}
+		filtered = append(filtered, issue)
+	}
+	return filtered
+}
+
+func uniqueClassifications(issues []warRoomIssue) []warRoomFilterOption {
+	labels := map[string]string{}
+	for _, issue := range issues {
+		labels[issue.Type] = issue.Classification
+	}
+	var options []warRoomFilterOption
+	for value, label := range labels {
+		options = append(options, warRoomFilterOption{Value: value, Label: label})
+	}
+	sort.Slice(options, func(i, j int) bool { return options[i].Label < options[j].Label })
+	return options
+}
+
+func warRoomStatsFor(issues []warRoomIssue) warRoomStats {
+	stats := warRoomStats{}
+	workloads := map[string]bool{}
+	for _, issue := range issues {
+		if issue.AgeDays > 0 && (!stats.hasOldest || issue.AgeDays > stats.oldest) {
+			stats.oldest, stats.hasOldest = issue.AgeDays, true
+		}
+		if isNamespaceFinding(issue) {
+			stats.namespaceFindings++
+			continue
+		}
+		if issue.Severity == "critical" {
+			stats.activeCritical++
+		}
+		if issue.WorkloadName != "" {
+			workloads[issue.Namespace+"\x00"+issue.WorkloadKind+"\x00"+issue.WorkloadName] = true
+		}
+		if issue.RestartCount > 0 && (!stats.hasHighestRestarts || issue.RestartCount > stats.highestRestarts) {
+			stats.highestRestarts, stats.hasHighestRestarts = issue.RestartCount, true
+		}
+	}
+	stats.affectedWorkloads = len(workloads)
+	return stats
+}
+
+func buildWarRoomBriefing(stats warRoomStats) string {
+	briefing := fmt.Sprintf("%d critical incident%s require attention across %d workload%s.",
+		stats.activeCritical, plural(stats.activeCritical), stats.affectedWorkloads, plural(stats.affectedWorkloads))
+	var facts []string
+	if stats.hasOldest {
+		facts = append(facts, fmt.Sprintf("the oldest active incident is %d day%s old", stats.oldest, plural(stats.oldest)))
+	}
+	if stats.hasHighestRestarts {
+		facts = append(facts, fmt.Sprintf("the highest observed restart count is %s", formatCount(stats.highestRestarts)))
+	}
+	if len(facts) > 0 {
+		briefing += " " + strings.ToUpper(facts[0][:1]) + facts[0][1:]
+		if len(facts) > 1 {
+			briefing += "; " + facts[1]
+		}
+		briefing += "."
+	}
+	return briefing
+}
+
+func plural(count int) string {
+	if count == 1 {
+		return ""
+	}
+	return "s"
+}
+
+func formatCount(count int) string {
+	s := fmt.Sprintf("%d", count)
+	for i := len(s) - 3; i > 0; i -= 3 {
+		s = s[:i] + "," + s[i:]
+	}
+	return s
+}
+
+func withWarRoomQuery(path, activeCtx, query, severity, issueType string, limit int) string {
+	values := url.Values{}
+	if activeCtx != "" {
+		values.Set("cluster", activeCtx)
+	}
+	if query != "" {
+		values.Set("q", query)
+	}
+	if severity != "" {
+		values.Set("severity", severity)
+	}
+	if issueType != "" {
+		values.Set("type", issueType)
+	}
+	values.Set("limit", fmt.Sprintf("%d", limit))
+	return path + "?" + values.Encode()
 }
 
 var warRoomTmplOnce sync.Once
@@ -236,40 +533,71 @@ func getWarRoomTmpl() *template.Template {
 }
 
 func renderWarRoomCard(issue warRoomIssue, activeCtx string) string {
+	if issue.Severity == "" {
+		issue.Severity = "critical"
+	}
+	if issue.Classification == "" {
+		issue.Classification = classificationForIssue(issue.Type)
+	}
 	sc := "c"
-	bl := "CRITICAL"
-	if issue.Severity == "warning" {
+	bl := strings.ToUpper(issue.Severity)
+	if issue.Severity != "critical" {
 		sc = "w"
-		bl = "WARNING"
 	}
 
-	icon, label := warRoomTypeLabel(issue.Type)
-
-	age := ""
-	if issue.AgeDays > 0 {
-		age = fmt.Sprintf(`<span class="age-lbl">%dd</span>`, issue.AgeDays)
+	cardClass := ""
+	if issue.Rank == 1 {
+		cardClass = " featured"
 	}
-
-	name := issue.Resource
-	if len(name) > 38 {
-		name = name[:37] + "…"
+	if isNamespaceFinding(issue) {
+		cardClass += " posture-card"
 	}
-
-	reason := issue.Message
-	if len(reason) > 320 {
-		reason = reason[:317] + "…"
+	identity := issue.WorkloadKind + "/" + issue.WorkloadName
+	if isNamespaceFinding(issue) {
+		identity = "Namespace/" + issue.Namespace
+	} else if issue.WorkloadKind == "" {
+		owner := store.OwnerNameFromPod(issue.Resource)
+		if owner != issue.Resource {
+			identity = "Deployment/" + owner
+		} else {
+			identity = "Pod/" + issue.Resource
+		}
 	}
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf(`<div class="wr-card %s %s">`, sc, "wr-type-"+strings.ReplaceAll(issue.Type, "_", "-")))
-	sb.WriteString(fmt.Sprintf(`<div class="wr-top"><span class="badge %s">%s</span><span class="type-lbl"><span class="wr-type-icon %s"></span>%s</span>%s</div>`,
-		sc, bl, icon, label, age))
-	sb.WriteString(fmt.Sprintf(`<div class="wr-name">%s</div>`, name))
-	sb.WriteString(fmt.Sprintf(`<div class="wr-ns">ns: %s</div>`, issue.Namespace))
-	sb.WriteString(fmt.Sprintf(`<div class="wr-reason">%s</div>`, reason))
+	sb.WriteString(fmt.Sprintf(`<article class="wr-card %s %s%s">`, sc, "wr-type-"+strings.ReplaceAll(issue.Type, "_", "-"), cardClass))
+	sb.WriteString(`<div class="wr-top">`)
+	if issue.Rank > 0 {
+		sb.WriteString(fmt.Sprintf(`<span class="rank-badge">#%d</span>`, issue.Rank))
+	}
+	sb.WriteString(fmt.Sprintf(`<span class="badge %s">%s</span></div>`, sc, template.HTMLEscapeString(bl)))
+	sb.WriteString(fmt.Sprintf(`<div class="wr-name" title="%s">%s</div>`, template.HTMLEscapeString(identity), template.HTMLEscapeString(identity)))
+	if !isNamespaceFinding(issue) {
+		sb.WriteString(fmt.Sprintf(`<div class="wr-focus" title="Focus Pod: %s">Focus Pod: %s</div>`, template.HTMLEscapeString(issue.Resource), template.HTMLEscapeString(issue.Resource)))
+		if issue.Container != "" {
+			sb.WriteString(fmt.Sprintf(`<div class="wr-focus" title="Container: %s">Container: %s</div>`, template.HTMLEscapeString(issue.Container), template.HTMLEscapeString(issue.Container)))
+		}
+	}
+	sb.WriteString(fmt.Sprintf(`<div class="wr-ns" title="Namespace: %s">Namespace: %s</div>`, template.HTMLEscapeString(issue.Namespace), template.HTMLEscapeString(issue.Namespace)))
+	activeFor, restarts := "—", "—"
+	if issue.AgeDays > 0 {
+		activeFor = fmt.Sprintf("%dd", issue.AgeDays)
+	}
+	if issue.RestartCount > 0 {
+		restarts = formatCount(issue.RestartCount)
+	}
+	sb.WriteString(`<div class="wr-evidence">`)
+	sb.WriteString(fmt.Sprintf(`<div><span>Classification</span><strong title="%s">%s</strong></div>`, template.HTMLEscapeString(issue.Classification), template.HTMLEscapeString(issue.Classification)))
+	sb.WriteString(fmt.Sprintf(`<div><span>Active For</span><strong>%s</strong></div>`, activeFor))
+	sb.WriteString(fmt.Sprintf(`<div><span>Restarts</span><strong>%s</strong></div>`, restarts))
+	sb.WriteString(`</div>`)
+	if isNamespaceFinding(issue) && issue.Message != "" {
+		sb.WriteString(fmt.Sprintf(`<div class="wr-reason">%s</div>`, template.HTMLEscapeString(issue.Message)))
+	}
+	sb.WriteString(`<footer class="wr-actions">`)
 	sb.WriteString(`<div class="wr-cmd">`)
-	sb.WriteString(fmt.Sprintf(`<code>%s</code>`, issue.KubectlCmd))
-	sb.WriteString(`<button class="copy-btn" onclick="var b=this,c=this.previousElementSibling.textContent;navigator.clipboard.writeText(c).then(function(){b.textContent='✓';setTimeout(function(){b.textContent='Copy'},1500)})">Copy</button>`)
+	sb.WriteString(fmt.Sprintf(`<code title="%s">%s</code>`, template.HTMLEscapeString(issue.KubectlCmd), template.HTMLEscapeString(issue.KubectlCmd)))
+	sb.WriteString(`<button class="copy-btn" onclick="var b=this,c=this.previousElementSibling.textContent;navigator.clipboard.writeText(c).then(function(){b.textContent='Copied';setTimeout(function(){b.textContent='Copy'},1500)})">Copy</button>`)
 	sb.WriteString(`</div>`)
 	// Investigate button — links to investigation page
 	if investigationHref := investigateURL(issue.Namespace, issue.Resource, issue.Type, activeCtx); investigationHref != "/warroom" {
@@ -277,7 +605,7 @@ func renderWarRoomCard(issue warRoomIssue, activeCtx string) string {
 			`<a class="investigate-btn" href="%s">Investigate →</a>`,
 			investigationHref))
 	}
-	sb.WriteString(`</div>`)
+	sb.WriteString(`</footer></article>`)
 	return sb.String()
 }
 

--- a/cmd/opscart-dashboard/warroom_redesign_test.go
+++ b/cmd/opscart-dashboard/warroom_redesign_test.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/opscart/opscart-k8s-watcher/pkg/analyzer"
+	"github.com/opscart/opscart-k8s-watcher/pkg/models"
+)
+
+func TestWarRoomWorkloadIdentity(t *testing.T) {
+	scan := &clusterScan{AllWorkloads: []models.WorkloadRef{
+		{Name: "stream-processor", Kind: "Deployment", Namespace: "apps"},
+		{Name: "node-agent", Kind: "DaemonSet", Namespace: "ops"},
+		{Name: "prometheus", Kind: "StatefulSet", Namespace: "monitoring"},
+	}}
+	tests := []struct {
+		name, pod, namespace, wantIdentity string
+	}{
+		{"deployment", "stream-processor-66c474d5fd-9zpwq", "apps", "Deployment/stream-processor"},
+		{"daemonset", "node-agent-8j6s5", "ops", "DaemonSet/node-agent"},
+		{"statefulset ordinal", "prometheus-0", "monitoring", "StatefulSet/prometheus-0"},
+		{"bare pod", "storage-provisioner", "kube-system", "Pod/storage-provisioner"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := warRoomIssue{Severity: "critical", Type: "crash_loop", Resource: tt.pod, Namespace: tt.namespace}
+			enrichWarRoomIdentity(&issue, scan)
+			card := renderWarRoomCard(issue, "prod")
+			if !strings.Contains(card, tt.wantIdentity) {
+				t.Fatalf("card missing identity %q: %s", tt.wantIdentity, card)
+			}
+			if !strings.Contains(card, "Focus Pod: "+tt.pod) {
+				t.Fatalf("card missing Focus Pod subtitle: %s", card)
+			}
+		})
+	}
+}
+
+func TestNamespacePostureEvidenceAndIdentity(t *testing.T) {
+	scan := &clusterScan{
+		netAudit:   &analyzer.NetworkPolicyAudit{UnprotectedNamespaces: []analyzer.NamespaceNetworkStatus{{Name: "monitoring", RiskLevel: "HIGH", PodCount: 8}}},
+		wasteAudit: &analyzer.WasteAudit{AbandonedNamespaces: []analyzer.AbandonedNamespace{{Name: "batch", AgeDays: 30, PodCount: 0, Reason: "No pods found. Namespace is 30 days old with zero workloads"}}},
+	}
+	issues := collectWarRoomIssues(scan, 0)
+	body := renderWarRoomPage(scan, "prod", []string{"prod"})
+	for _, want := range []string{
+		"Namespace/monitoring", "Missing default-deny NetworkPolicy", "8 pods in namespace",
+		"kubectl get networkpolicies -n monitoring", "Namespace/batch",
+		"No pods found. Namespace is 30 days old with zero workloads",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("page missing %q", want)
+		}
+	}
+	for _, forbidden := range []string{"pods exposed", "pod=namespace", "every pod can reach", "critical infrastructure exposed"} {
+		if strings.Contains(strings.ToLower(body), forbidden) {
+			t.Errorf("page contains unsupported wording %q", forbidden)
+		}
+	}
+	if len(issues) != 2 {
+		t.Fatalf("got %d posture issues, want 2", len(issues))
+	}
+}
+
+func TestWarRoomSearchAndFilters(t *testing.T) {
+	issues := []warRoomIssue{
+		{Severity: "critical", Type: "crash_loop", Namespace: "payments", Resource: "checkout-7cddf79d98-jxmtx", WorkloadKind: "Deployment", WorkloadName: "checkout", Classification: "CrashLoopBackOff", Container: "api"},
+		{Severity: "high", Type: "unprotected_namespace", Namespace: "monitoring", Resource: "namespace", WorkloadKind: "Namespace", WorkloadName: "monitoring", Classification: "Missing default-deny NetworkPolicy"},
+	}
+	tests := []struct{ name, q, severity, issueType string }{
+		{"workload", "checkout", "", ""},
+		{"focus pod", "7cddf79d98-jxmtx", "", ""},
+		{"namespace", "payments", "", ""},
+		{"classification", "crashloopbackoff", "", ""},
+		{"container", "api", "", ""},
+		{"severity", "", "critical", ""},
+		{"classification filter", "", "", "crash_loop"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterWarRoomIssues(issues, tt.q, tt.severity, tt.issueType)
+			if len(got) != 1 || got[0].Type != "crash_loop" {
+				t.Fatalf("unexpected filtered results: %+v", got)
+			}
+		})
+	}
+}
+
+func TestWarRoomFilteringOccursBeforeLimit(t *testing.T) {
+	var pods []analyzer.StalePod
+	for i := 0; i < 13; i++ {
+		pods = append(pods, analyzer.StalePod{Name: fmt.Sprintf("worker-%02d-7cddf79d98-jxmtx", i), Namespace: "apps", Kind: analyzer.StalePodZombie, Status: "CrashLoopBackOff", RestartCount: int32(100 - i)})
+	}
+	scan := &clusterScan{wasteAudit: &analyzer.WasteAudit{StalePods: pods}}
+	body := renderWarRoomPageWithFilters(scan, "prod", []string{"prod"}, url.Values{"q": {"worker-12"}, "limit": {"12"}})
+	if !strings.Contains(body, "worker-12") || !strings.Contains(body, "Showing 1 prioritized incident") {
+		t.Fatalf("search was applied after the first 12 results")
+	}
+}
+
+func TestWarRoomLimitsAndInvalidDefault(t *testing.T) {
+	for raw, want := range map[string]int{"12": 12, "25": 25, "50": 50, "": 12, "999": 12, "bad": 12} {
+		if got := parseWarRoomLimit(raw); got != want {
+			t.Errorf("parseWarRoomLimit(%q) = %d, want %d", raw, got, want)
+		}
+	}
+}
+
+func TestWarRoomRankingAndOrdinals(t *testing.T) {
+	scan := &clusterScan{
+		wasteAudit: &analyzer.WasteAudit{StalePods: []analyzer.StalePod{
+			{Name: "low-restarts", Namespace: "apps", Kind: analyzer.StalePodZombie, Status: "CrashLoopBackOff", RestartCount: 2},
+			{Name: "high-restarts", Namespace: "apps", Kind: analyzer.StalePodZombie, Status: "CrashLoopBackOff", RestartCount: 50},
+		}},
+		netAudit: &analyzer.NetworkPolicyAudit{UnprotectedNamespaces: []analyzer.NamespaceNetworkStatus{{Name: "posture", RiskLevel: "HIGH"}}},
+	}
+	issues := collectWarRoomIssues(scan, 0)
+	if issues[0].Resource != "high-restarts" || issues[1].Resource != "low-restarts" || issues[2].Severity != "high" {
+		t.Fatalf("ranking changed from severity then restart count: %+v", issues)
+	}
+	body := renderWarRoomPage(scan, "prod", []string{"prod"})
+	if strings.Index(body, "#1") > strings.Index(body, "#2") || !strings.Contains(body, "Ranked by severity · restart count") ||
+		!strings.Contains(body, "wr-card c wr-type-crash-loop featured") {
+		t.Fatalf("ordinal badges or ranking label are incorrect")
+	}
+}
+
+func TestWarRoomBriefingDeduplicatesWorkloadsAndOmitsUnavailable(t *testing.T) {
+	issues := []warRoomIssue{
+		{Severity: "critical", Type: "crash_loop", Namespace: "apps", WorkloadKind: "Deployment", WorkloadName: "api"},
+		{Severity: "critical", Type: "privileged_container", Namespace: "apps", WorkloadKind: "Deployment", WorkloadName: "api"},
+		{Severity: "high", Type: "unprotected_namespace", Namespace: "apps", WorkloadKind: "Namespace", WorkloadName: "apps"},
+	}
+	stats := warRoomStatsFor(issues)
+	if stats.affectedWorkloads != 1 || stats.namespaceFindings != 1 {
+		t.Fatalf("unexpected deduplicated stats: %+v", stats)
+	}
+	briefing := buildWarRoomBriefing(stats)
+	if strings.Contains(briefing, "oldest") || strings.Contains(briefing, "restart count") {
+		t.Fatalf("briefing did not omit unavailable facts: %q", briefing)
+	}
+}
+
+func TestWarRoomBackToOverviewAndResponsiveLayout(t *testing.T) {
+	body := renderWarRoomPage(&clusterScan{}, "real/context", []string{"real/context"})
+	for _, want := range []string{
+		"Back to Overview", `href="/?cluster=real%2Fcontext"`,
+		"@media(min-width:1500px){.wr-grid{grid-template-columns:repeat(4,minmax(0,1fr))}}",
+		"@media(max-width:1099px)", "grid-template-columns:repeat(2,minmax(0,1fr))",
+		"@media(max-width:719px)", ".wr-grid{grid-template-columns:1fr}",
+		".wr-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr))",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("page missing %q", want)
+		}
+	}
+	if strings.Contains(body, ".wr-card.featured{grid-column") {
+		t.Fatal("featured card still spans grid columns")
+	}
+	if strings.Contains(body, "cluster=current-context") {
+		t.Fatal("page leaked synthetic current-context")
+	}
+	empty := renderWarRoomPage(&clusterScan{}, "", []string{""})
+	if strings.Contains(empty, "cluster=current-context") || strings.Contains(empty, `name="cluster" value="current-context"`) {
+		t.Fatal("empty context emitted synthetic cluster query")
+	}
+}
+
+func TestWarRoomDenseEqualCardsAndResetVisibility(t *testing.T) {
+	scan := &clusterScan{wasteAudit: &analyzer.WasteAudit{StalePods: []analyzer.StalePod{
+		{Name: "api-7cddf79d98-jxmtx", Namespace: "apps", Kind: analyzer.StalePodZombie, Status: "CrashLoopBackOff", RestartCount: 8, AgeDays: 2},
+		{Name: "worker-7cddf79d98-kbfzw", Namespace: "apps", Kind: analyzer.StalePodZombie, Status: "CrashLoopBackOff", RestartCount: 4, AgeDays: 1},
+	}}}
+	body := renderWarRoomPage(scan, "prod", []string{"prod"})
+	for _, want := range []string{
+		`class="wr-card c wr-type-crash-loop featured"`,
+		`class="wr-card c wr-type-crash-loop"`,
+		`class="wr-evidence"`, "Classification", "Active For", "Restarts",
+		`<footer class="wr-actions">`, `title="Focus Pod: api-7cddf79d98-jxmtx"`,
+		`min-height:260px`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("dense card rendering missing %q", want)
+		}
+	}
+	if strings.Contains(body, `<a class="toolbar-reset"`) || strings.Contains(body, `class="toolbar has-reset"`) {
+		t.Fatal("unfiltered toolbar rendered or reserved space for Reset")
+	}
+
+	filtered := renderWarRoomPageWithFilters(scan, "prod", []string{"prod"}, url.Values{"q": {"api"}})
+	if !strings.Contains(filtered, `class="toolbar has-reset"`) ||
+		!strings.Contains(filtered, `<a class="toolbar-reset"`) {
+		t.Fatal("active filter did not render full-height Reset control")
+	}
+}

--- a/helm/opscart-watcher/values-oauth2-proxy-example.yaml
+++ b/helm/opscart-watcher/values-oauth2-proxy-example.yaml
@@ -33,7 +33,7 @@
 replicaCount: 1
 image:
   repository: ghcr.io/opscart/opscart-dashboard
-  tag: v1.10.0
+  tag: v1.10.1
 
 persistence:
   enabled: true

--- a/helm/opscart-watcher/values.yaml
+++ b/helm/opscart-watcher/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: ghcr.io/opscart/opscart-dashboard
-  tag: "v1.10.0"
+  tag: "v1.10.1"
   # For local development with a locally-built image (e.g. minikube):
   # the image must be loaded under the EXACT repository:tag rendered by
   # this chart — kubelet does no fuzzy matching with pullPolicy Never.

--- a/pkg/store/incident_ordering_corrections_test.go
+++ b/pkg/store/incident_ordering_corrections_test.go
@@ -1,0 +1,72 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+func TestQueryIncidentsDefaultPriorityOrdering(t *testing.T) {
+	s := openTestStore(t)
+	now := time.Now()
+	high := IncidentData{Fingerprint: "monitoring/Namespace/monitoring/unprotected_namespace", Namespace: "monitoring", Resource: "namespace", IssueType: "unprotected_namespace", Severity: "high"}
+	criticalNew := IncidentData{Fingerprint: "apps/Deployment/api/crash_loop", Namespace: "apps", Resource: "api-new", IssueType: "crash_loop", Severity: "critical"}
+	criticalOld := IncidentData{Fingerprint: "apps/Deployment/worker/crash_loop", Namespace: "apps", Resource: "api-old", IssueType: "crash_loop", Severity: "critical"}
+	resolved := IncidentData{Fingerprint: "apps/Deployment/resolved/crash_loop", Namespace: "apps", Resource: "resolved", IssueType: "crash_loop", Severity: "critical"}
+	insertRawIncident(t, s, "test-cluster", high, "active", now, now)
+	insertRawIncident(t, s, "test-cluster", criticalOld, "active", now.Add(-2*time.Hour), now)
+	insertRawIncident(t, s, "test-cluster", criticalNew, "active", now.Add(-time.Hour), now)
+	insertRawIncident(t, s, "test-cluster", resolved, "resolved", now.Add(time.Hour), now)
+
+	items, _, err := s.QueryIncidents(IncidentFilter{Cluster: "test-cluster", SortBy: "priority"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"api-new", "api-old", "namespace", "resolved"}
+	for i, resource := range want {
+		if items[i].Resource != resource {
+			t.Fatalf("order[%d] = %q, want %q; items=%+v", i, items[i].Resource, resource, items)
+		}
+	}
+}
+
+func TestRestartTrendApplicability(t *testing.T) {
+	for _, issueType := range []string{
+		"crash_loop",
+		"oomkilled",
+		"oom_killed",
+		"probe_failure",
+	} {
+		if !RestartTrendApplies(issueType) {
+			t.Errorf("%s should support restart trend", issueType)
+		}
+	}
+
+	for _, issueType := range []string{
+		"image_pull_backoff",
+		"unprotected_namespace",
+		"idle_namespace",
+		"privileged_container",
+		"orphaned_pvc",
+		"zero_replica",
+	} {
+		if RestartTrendApplies(issueType) {
+			t.Errorf("%s must not support restart trend", issueType)
+		}
+	}
+}
+
+func TestQueryIncidentsStaticFindingHasNoTrend(t *testing.T) {
+	s := openTestStore(t)
+	now := time.Now()
+	finding := IncidentData{Fingerprint: "monitoring/Namespace/monitoring/unprotected_namespace", Namespace: "monitoring", Resource: "namespace", IssueType: "unprotected_namespace", Severity: "high", RestartCount: 10}
+	id := insertRawIncident(t, s, "test-cluster", finding, "active", now.Add(-24*time.Hour), now)
+	insertRawEvent(t, s, id, "DETECTED", "Detected", 1, now.Add(-2*time.Hour))
+	insertRawEvent(t, s, id, "UPDATED", "RestartMilestone", 10, now.Add(-time.Hour))
+	items, _, err := s.QueryIncidents(IncidentFilter{Cluster: "test-cluster", SortBy: "priority"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 || items[0].Trend != "" {
+		t.Fatalf("static finding received restart trend: %+v", items)
+	}
+}

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -863,26 +863,36 @@ func inClause(ids []int64) (string, []any) {
 func orderByClause(sortBy string, desc bool) string {
 	col := "last_seen"
 	switch sortBy {
+	case "priority", "":
+		return `CASE status WHEN 'active' THEN 0 ELSE 1 END ASC,
+			CASE severity
+				WHEN 'critical' THEN 0
+				WHEN 'high' THEN 1
+				WHEN 'medium' THEN 2
+				WHEN 'low' THEN 3
+				ELSE 4
+			END ASC,
+			first_seen DESC, fingerprint ASC`
 	case "severity":
-		col = `CASE severity
+		return `CASE severity
 			WHEN 'critical' THEN 0
 			WHEN 'high' THEN 1
 			WHEN 'medium' THEN 2
 			WHEN 'low' THEN 3
 			ELSE 4
-		END`
+		END ASC, first_seen DESC, fingerprint ASC`
 	case "first_seen":
 		col = "first_seen"
 	case "restarts":
 		col = "current_restart_count"
-	case "last_seen", "":
+	case "last_seen":
 		col = "last_seen"
 	}
 	dir := "ASC"
 	if desc {
 		dir = "DESC"
 	}
-	return col + " " + dir + ", id " + dir
+	return col + " " + dir + ", fingerprint ASC"
 }
 
 // trendEvent is one DETECTED/RestartMilestone event, used by deriveTrend.
@@ -959,17 +969,30 @@ func (s *SQLiteStore) batchTrendEvents(ids []int64) (map[int64][]trendEvent, err
 	return out, rows.Err()
 }
 
-// deriveTrend classifies an active incident's restart trajectory as
+// restartTrendApplies identifies findings backed by a pod restart series.
+// Namespace posture, security/configuration, and unattached-resource findings
+// have no meaningful restart trajectory and must not be labeled "stable".
+func RestartTrendApplies(issueType string) bool {
+	switch issueType {
+	case "crash_loop", "oomkilled", "oom_killed", "probe_failure":
+		return true
+	default:
+		return false
+	}
+}
+
+// deriveTrend classifies an active, restart-applicable incident's trajectory as
 // "accelerating" or "stable" from its two most recent milestone-relevant
 // events (DETECTED and RestartMilestone) — the cheapest points in the
 // journal that carry both a restart count and a timestamp.
 //
-// Heuristic: lifetimeRate is total restarts/day since first_seen. recentRate
-// is restarts/day between the two most recent events. If recentRate exceeds
-// lifetimeRate by more than 25%, the incident is "accelerating" (restarting
-// faster than its own history predicts). Otherwise — including incidents
-// with fewer than two such events, or whose most recent event is more than
-// 24h old (no recent movement to compare) — it is "stable".
+// Heuristic: lifetimeRate is current restart count divided by active age in
+// days (with a one-day minimum). recentRate is the restart delta per day
+// between the two newest DETECTED/RestartMilestone journal points (with a
+// one-hour minimum interval). A recent rate greater than 125% of lifetime rate
+// is "accelerating". Otherwise it is "stable"; fewer than two points or a
+// latest point older than 24 hours are also "stable" because no acceleration
+// can be established from the available restart series.
 //
 // This intentionally approximates a 48h window with whatever two events
 // happen to exist rather than sampling restart_count on a fixed schedule,
@@ -1133,7 +1156,7 @@ func (s *SQLiteStore) QueryIncidents(f IncidentFilter) ([]IncidentSummary, int, 
 			LastSeen:     time.Unix(r.lastSeen, 0),
 			RestartCount: r.restartCount,
 		}
-		if r.status == "active" {
+		if r.status == "active" && RestartTrendApplies(r.issueType) {
 			summary.Trend = deriveTrend(trendInputs[r.id], r.restartCount, r.firstSeen)
 		}
 		items = append(items, summary)
@@ -1147,7 +1170,8 @@ func (s *SQLiteStore) QueryIncidents(f IncidentFilter) ([]IncidentSummary, int, 
 func (s *SQLiteStore) countAccelerating(cluster string) (int, error) {
 	rows, err := s.db.Query(
 		`SELECT id, current_restart_count, first_seen FROM incidents
-		 WHERE cluster = ? AND status = 'active'`,
+		 WHERE cluster = ? AND status = 'active'
+		   AND issue_type IN ('crash_loop','oomkilled','oom_killed','probe_failure')`,
 		cluster,
 	)
 	if err != nil {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -103,7 +103,7 @@ type IncidentFilter struct {
 	Severity   string // exact, empty = all
 	Status     string // "active" | "resolved" | "reopened" | "" (all)
 	SinceFirst time.Time
-	SortBy     string // "severity" | "first_seen" | "last_seen" | "restarts"
+	SortBy     string // "priority" | "severity" | "first_seen" | "last_seen" | "restarts"
 	SortDesc   bool
 	Page       int // 1-based
 	PerPage    int // default 50, cap 200
@@ -121,7 +121,7 @@ type IncidentSummary struct {
 	FirstSeen    time.Time
 	LastSeen     time.Time
 	RestartCount int
-	Trend        string // "accelerating" | "stable" | "recovering" | ""
+	Trend        string // restart-series trend: "accelerating" | "stable" | ""
 }
 
 // MemoryScoreboard summarizes a cluster's operational memory: how much


### PR DESCRIPTION
Redesign the War Room with workload-first incident cards, an evidence-backed operational briefing, responsive filtering, compact summary metrics, and separate namespace posture findings.

Correct default incident ordering so active Critical findings precede High findings, and restrict restart trends to findings with meaningful restart-series evidence.

Improve namespace investigation wording, navigation, empty states, and read-only investigation guidance.