### PR TITLE
Fix/canonical oma provenance

### DIFF
--- a/cmd/opscart-dashboard/main_test.go
+++ b/cmd/opscart-dashboard/main_test.go
@@ -227,6 +227,9 @@ func TestHandleOverviewPage_CursorSetAfterQuery(t *testing.T) {
 	}
 	defer sqlDB.Close()
 	wrapped := &sinceCapturingStore{Store: sqlDB}
+	if err := sqlDB.WriteScanHistory("test-ctx", "seed", store.ScanMeta{Success: true}); err != nil {
+		t.Fatalf("WriteScanHistory: %v", err)
+	}
 
 	srv := newServer([]string{"test-ctx"}, wrapped, 90, true)
 
@@ -247,6 +250,11 @@ func TestHandleOverviewPage_CursorSetAfterQuery(t *testing.T) {
 	resp := rec.Result()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, rec.Body.String())
+	}
+	for _, want := range []string{"Earliest retained observation:", "Configured retention:", "90 days", "Storage:", "Persistent"} {
+		if !strings.Contains(rec.Body.String(), want) {
+			t.Errorf("Overview Operational Memory card missing %q", want)
+		}
 	}
 
 	// The query must have used the cursor from the incoming cookie, proving

--- a/cmd/opscart-dashboard/server.go
+++ b/cmd/opscart-dashboard/server.go
@@ -186,6 +186,21 @@ func (srv *server) handleOverviewPage(w http.ResponseWriter, r *http.Request) {
 
 	since := readLastViewedCursor(r)
 	data := buildOverviewData(scan, ctx, srv.clusterList, srv.db, since)
+	if srv.db != nil {
+		if earliest, err := store.GetEarliestRetainedObservation(srv.db, ctx); err == nil && !earliest.IsZero() {
+			data.EarliestRetainedObservation = earliest.Local().Format("2006-01-02 15:04 MST")
+		}
+	}
+	if srv.retentionDays <= 0 {
+		data.ConfiguredRetention = "Forever"
+	} else {
+		data.ConfiguredRetention = fmt.Sprintf("%d days", srv.retentionDays)
+	}
+	if srv.dbPersistent {
+		data.StorageMode = "Persistent"
+	} else {
+		data.StorageMode = "Ephemeral"
+	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
@@ -633,8 +648,11 @@ type overviewPageData struct {
 	SecurityScoreDeltaText string
 
 	// Memory scoreboard + cluster-wide recent activity
-	Scoreboard   *store.MemoryScoreboard
-	RecentEvents []changeLine
+	Scoreboard                  *store.MemoryScoreboard
+	RecentEvents                []changeLine
+	EarliestRetainedObservation string
+	ConfiguredRetention         string
+	StorageMode                 string
 
 	// What's changed since this browser last loaded the Overview page
 	ChangesSinceLastView []changeLine

--- a/cmd/opscart-dashboard/templates/overview.html
+++ b/cmd/opscart-dashboard/templates/overview.html
@@ -247,6 +247,9 @@
       <div>No operational memory yet</div>
     </div>
     {{end}}
+    <div class="mem-line">Earliest retained observation: <strong>{{if .EarliestRetainedObservation}}{{.EarliestRetainedObservation}}{{else}}—{{end}}</strong></div>
+    <div class="mem-line">Configured retention: <strong>{{.ConfiguredRetention}}</strong></div>
+    <div class="mem-line">Storage: <strong>{{.StorageMode}}</strong></div>
   </div>
 </div>
 </div>

--- a/cmd/opscart-scan/emergency.go
+++ b/cmd/opscart-scan/emergency.go
@@ -21,13 +21,25 @@ import (
 // any was found for its fingerprint.
 type enrichedIssue struct {
 	models.EmergencyIssue
-	FirstDetected string    // formatDuration(time since first seen); "" when no history
-	ReopenCount   int       // retained for lifecycle consumers; Emergency does not render aggregates
-	firstSeenAt   time.Time // raw form of FirstDetected, used only to pick a group's representative
+	FirstDetected     string    // formatDuration(time since first seen); "" when no history
+	ReopenCount       int       // retained for lifecycle consumers; Emergency does not render aggregates
+	firstSeenAt       time.Time // raw form of FirstDetected, used only to pick a group's representative
+	atHistoryBoundary bool
 }
 
 func runEmergencyScan(clusterContext string) error {
 	fmt.Printf("\n🔍 Cluster: %s\n", clusterContext)
+	if selectedDBPath != "" {
+		fmt.Printf("OMA database: %s\n", selectedDBPath)
+	} else {
+		fmt.Println("OMA database: —")
+	}
+	earliest, _ := store.GetEarliestRetainedObservation(opStore, clusterContext)
+	if earliest.IsZero() {
+		fmt.Printf("Earliest retained observation for cluster %s: —\n", clusterContext)
+	} else {
+		fmt.Printf("Earliest retained observation for cluster %s: %s\n", clusterContext, earliest.Local().Format("2006-01-02 15:04:05 MST"))
+	}
 	s, err := scanner.NewScanner(clusterContext)
 	if err != nil {
 		return fmt.Errorf("connecting to cluster: %w", err)
@@ -441,24 +453,13 @@ func persistFindings(db store.Store, clusterContext, scanID string, issues []mod
 // scan loop uses (cmd/opscart-dashboard/scan.go), so history lines up
 // across both tools when pointed at the same --db-path.
 func incidentFingerprint(issue models.EmergencyIssue) string {
-	return store.Fingerprint(issue.Namespace, "Workload", store.OwnerNameFromPod(issue.Name), canonicalIssueType(issue.Reason))
+	return store.Fingerprint(issue.Namespace, "Workload", store.OwnerNameFromPod(issue.Name), store.CanonicalIssueType(issue.Reason))
 }
 
+// canonicalIssueType remains as a package-local compatibility shim for the
+// scanner's classification helpers; the shared store function is authoritative.
 func canonicalIssueType(reason string) string {
-	switch {
-	case strings.Contains(reason, "ProbeFailure"):
-		return "probe_failure"
-	case strings.Contains(reason, "OOMKilled"):
-		return "oomkilled"
-	case strings.Contains(reason, "CrashLoopBackOff"):
-		return "crash_loop"
-	case reason == "ImagePullBackOff" || reason == "ErrImagePull":
-		return "image_pull_backoff"
-	case reason == "HighRestartCount":
-		return "high_restart_count"
-	default:
-		return reason
-	}
+	return store.CanonicalIssueType(reason)
 }
 
 // semanticIssueFamily normalizes only explicitly equivalent historical
@@ -491,7 +492,7 @@ func findingMemoryIdentity(issue models.EmergencyIssue) memoryIdentity {
 	return memoryIdentity{
 		namespace: issue.Namespace,
 		owner:     store.OwnerNameFromPod(issue.Name),
-		family:    semanticIssueFamily(canonicalIssueType(issue.Reason)),
+		family:    semanticIssueFamily(store.CanonicalIssueType(issue.Reason)),
 	}
 }
 
@@ -548,7 +549,7 @@ func mapIssuesToIncidents(issues []models.EmergencyIssue) []store.IncidentData {
 			Fingerprint:  incidentFingerprint(issue),
 			Namespace:    issue.Namespace,
 			Resource:     issue.Name,
-			IssueType:    canonicalIssueType(issue.Reason),
+			IssueType:    store.CanonicalIssueType(issue.Reason),
 			Severity:     issue.Severity,
 			DetailsJSON:  string(details),
 			RestartCount: issue.Restarts,
@@ -584,6 +585,7 @@ func enrichIssues(db store.Store, clusterContext string, issues []models.Emergen
 		ids = append(ids, rec.ID)
 	}
 	reopenCounts, _ := db.BatchGetReopenCounts(ids)
+	earliest, _ := store.GetEarliestRetainedObservation(db, clusterContext)
 
 	for i, fingerprint := range fingerprints {
 		rec, ok := history[fingerprint]
@@ -593,9 +595,11 @@ func enrichIssues(db store.Store, clusterContext string, issues []models.Emergen
 		enriched[i].FirstDetected = formatDuration(time.Since(rec.FirstSeen))
 		enriched[i].ReopenCount = reopenCounts[rec.ID]
 		enriched[i].firstSeenAt = rec.FirstSeen
+		enriched[i].atHistoryBoundary = store.AtObservationBoundary(rec.FirstSeen, earliest)
 		if legacyFirstSeen := aliases[findingMemoryIdentity(issues[i])]; !legacyFirstSeen.IsZero() && legacyFirstSeen.Before(rec.FirstSeen) {
 			enriched[i].FirstDetected = formatDuration(time.Since(legacyFirstSeen))
 			enriched[i].firstSeenAt = legacyFirstSeen
+			enriched[i].atHistoryBoundary = store.AtObservationBoundary(legacyFirstSeen, earliest)
 		}
 	}
 	return enriched
@@ -993,9 +997,12 @@ func printGroupedIssue(w io.Writer, issues []enrichedIssue) {
 	fmt.Fprintf(w, "  └─ Pods: %s\n", strings.Join(pods, ", "))
 	fmt.Fprintf(w, "  └─ %s\n", groupDetailLine(key, issues, rep))
 	if rep.FirstDetected != "" {
-		fmt.Fprintf(w, "  └─ First detected: %s ago (%s)\n", rep.FirstDetected, rep.Name)
+		fmt.Fprintf(w, "  └─ First observed by this OMA: %s ago (%s)\n", rep.FirstDetected, rep.Name)
+		if rep.atHistoryBoundary {
+			fmt.Fprintln(w, "  └─ Present when this OMA history began; earlier duration is unknown.")
+		}
 	} else {
-		fmt.Fprintln(w, "  └─ First detected: —")
+		fmt.Fprintln(w, "  └─ First observed by this OMA: —")
 	}
 	fmt.Fprintln(w)
 }
@@ -1021,9 +1028,12 @@ func printEnrichedIssue(w io.Writer, issue enrichedIssue) {
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "  └─ %s\n", issue.Message)
 	if issue.FirstDetected != "" {
-		fmt.Fprintf(w, "  └─ First detected: %s ago\n", issue.FirstDetected)
+		fmt.Fprintf(w, "  └─ First observed by this OMA: %s ago\n", issue.FirstDetected)
+		if issue.atHistoryBoundary {
+			fmt.Fprintln(w, "  └─ Present when this OMA history began; earlier duration is unknown.")
+		}
 	} else {
-		fmt.Fprintln(w, "  └─ First detected: —")
+		fmt.Fprintln(w, "  └─ First observed by this OMA: —")
 	}
 	fmt.Fprintln(w)
 }

--- a/cmd/opscart-scan/emergency_classify_test.go
+++ b/cmd/opscart-scan/emergency_classify_test.go
@@ -312,7 +312,7 @@ func TestClassifyPod_OOMKilledMerge_PrintsCorrectly(t *testing.T) {
 	if !strings.Contains(out, "Container termination state reports OOMKilled; the pod is currently in CrashLoopBackOff.") {
 		t.Errorf("missing observational message, got:\n%s", out)
 	}
-	if !strings.Contains(out, "First detected: 14h ago") {
+	if !strings.Contains(out, "First observed by this OMA: 14h ago") {
 		t.Errorf("missing enrichment line, got:\n%s", out)
 	}
 }

--- a/cmd/opscart-scan/emergency_test.go
+++ b/cmd/opscart-scan/emergency_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"database/sql"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -279,8 +280,8 @@ func TestEnrichIssues_PreExistingIncident(t *testing.T) {
 	var buf bytes.Buffer
 	printEnrichedIssue(&buf, enriched[0])
 	out := buf.String()
-	if !strings.Contains(out, "First detected: 5d ago") {
-		t.Errorf("output missing 'First detected: 5d ago' line, got:\n%s", out)
+	if !strings.Contains(out, "First observed by this OMA: 5d ago") {
+		t.Errorf("output missing OMA first-observed line, got:\n%s", out)
 	}
 	if strings.Contains(out, "Reopened:") {
 		t.Errorf("Emergency output must not render recurrence aggregates, got:\n%s", out)
@@ -317,8 +318,8 @@ func TestEnrichIssues_BrandNewIncident(t *testing.T) {
 	var buf bytes.Buffer
 	printEnrichedIssue(&buf, enriched[0])
 	out := buf.String()
-	if !strings.Contains(out, "First detected: 0s ago") {
-		t.Errorf("output missing 'First detected: 0s ago' line, got:\n%s", out)
+	if !strings.Contains(out, "First observed by this OMA: 0s ago") {
+		t.Errorf("output missing OMA first-observed line, got:\n%s", out)
 	}
 	if strings.Contains(out, "Reopened:") {
 		t.Errorf("brand-new incident should not print a Reopened line, got:\n%s", out)
@@ -355,7 +356,7 @@ func TestEnrichIssues_NullStore_NoEnrichment(t *testing.T) {
 	if got.String() != want.String() {
 		t.Errorf("stateless output diverges from plain (unenriched) output:\ngot:\n%s\nwant:\n%s", got.String(), want.String())
 	}
-	if !strings.Contains(got.String(), "First detected: —") || strings.Contains(got.String(), "Reopened") {
+	if !strings.Contains(got.String(), "First observed by this OMA: —") || strings.Contains(got.String(), "Reopened") {
 		t.Errorf("stateless output should show unknown incident age and no recurrence aggregate, got:\n%s", got.String())
 	}
 }
@@ -384,10 +385,10 @@ func TestEmergencyMcoreProbeFailureUsesCanonicalFirstSeen(t *testing.T) {
 	var buf bytes.Buffer
 	printEmergencyIssuesEnriched(&buf, enriched)
 	out := buf.String()
-	if !strings.Contains(out, "First detected: 12d ago") {
+	if !strings.Contains(out, "First observed by this OMA: 12d ago") {
 		t.Fatalf("canonical incident first_seen was not rendered:\n%s", out)
 	}
-	if strings.Contains(out, "First detected: 0s") {
+	if strings.Contains(out, "First observed by this OMA: 0s") {
 		t.Fatalf("pod age leaked into incident age:\n%s", out)
 	}
 }
@@ -599,6 +600,52 @@ func TestApplyCriticalDebounce_ResolvedIncidentNotResurrected(t *testing.T) {
 
 	if got[0].Severity != "medium" || got[0].Reason != "HighRestartCount" {
 		t.Errorf("resolved incident was incorrectly resurrected: %+v", got[0])
+	}
+}
+
+func TestApplyCriticalDebounce_ActiveCanonicalBeatsOlderResolvedLegacyAlias(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "aliases.db")
+	sqlStore, err := store.OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalFP := store.Fingerprint("auth", "Workload", "token-service", "crash_loop")
+	if err := sqlStore.UpsertIncidents("opscart", "canonical", []store.IncidentData{{
+		Fingerprint: canonicalFP, Namespace: "auth", Resource: "token-service-current",
+		IssueType: "crash_loop", Severity: "critical", RestartCount: 40,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sqlStore.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	rawDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().Unix()
+	if _, err := rawDB.Exec(`UPDATE incidents SET first_seen=? WHERE cluster=? AND fingerprint=?`, now-3600, "opscart", canonicalFP); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rawDB.Exec(`INSERT INTO incidents
+		(fingerprint,cluster,namespace,resource,issue_type,severity,first_seen,last_seen,status,last_scan_id,current_restart_count,missing_scans)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`, "auth/Workload/token-service/CrashLoopBackOff", "opscart", "auth", "token-service-old", "CrashLoopBackOff", "critical", now-86400, now-7200, "resolved", "legacy", 20, 3); err != nil {
+		t.Fatal(err)
+	}
+	if err := rawDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	sqlStore, err = store.OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqlStore.Close()
+	live := []enrichedIssue{issue("auth", "token-service-7cddf79d98-jxmtx", "medium", "HighRestartCount", "Container app has restarted 41 times", 41)}
+	got := applyCriticalDebounce(sqlStore, "opscart", live)
+	if len(got) != 1 || got[0].Severity != "critical" || got[0].Reason != "CrashLoopBackOff" {
+		t.Fatalf("active canonical crash loop was not preserved: %+v", got)
 	}
 }
 

--- a/cmd/opscart-scan/store_init.go
+++ b/cmd/opscart-scan/store_init.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	stateless bool
-	dbPath    string
+	stateless      bool
+	dbPath         string
+	selectedDBPath string
 
 	// opStore is the operational memory store, initialized once in main()
 	// before any subcommand runs, and shared package-wide (same threading
@@ -40,6 +41,7 @@ func defaultScanDBPath() (string, error) {
 // crashing the CLI.
 func initStore() store.Store {
 	if stateless {
+		selectedDBPath = ""
 		return &store.NullStore{}
 	}
 
@@ -58,6 +60,7 @@ func initStore() store.Store {
 		log.Printf("store: persistence disabled (%v)", err)
 		return &store.NullStore{}
 	}
+	selectedDBPath = path
 	log.Printf("opscart-scan: operational memory at %s", path)
 	return sqlDB
 }

--- a/pkg/store/fingerprint.go
+++ b/pkg/store/fingerprint.go
@@ -5,7 +5,7 @@ import "strings"
 // Fingerprint builds a stable, human-readable incident identity.
 // Pod-name suffixes are stripped by the caller passing ownerName.
 func Fingerprint(namespace, ownerKind, ownerName, issueType string) string {
-	return namespace + "/" + ownerKind + "/" + ownerName + "/" + issueType
+	return namespace + "/" + ownerKind + "/" + ownerName + "/" + CanonicalIssueType(issueType)
 }
 
 func OwnerNameFromPod(podName string) string {

--- a/pkg/store/issue_type.go
+++ b/pkg/store/issue_type.go
@@ -1,0 +1,63 @@
+package store
+
+import "strings"
+
+// CanonicalIssueType returns the durable issue type used by new writes.
+// Unknown issue types are intentionally preserved verbatim.
+func CanonicalIssueType(issueType string) string {
+	switch issueType {
+	case "CrashLoopBackOff", "crash_loop":
+		return "crash_loop"
+	case "ProbeFailure", "CrashLoopBackOff (ProbeFailure)", "probe_failure":
+		return "probe_failure"
+	case "OOMKilled", "oom_killed", "CrashLoopBackOff (OOMKilled)", "oomkilled":
+		return "oomkilled"
+	case "ImagePullBackOff", "ErrImagePull", "image_pull", "image_pull_backoff":
+		return "image_pull_backoff"
+	case "HighRestartCount", "high_restart_count":
+		return "high_restart_count"
+	default:
+		return issueType
+	}
+}
+
+func issueTypeAliases(issueType string) []string {
+	switch CanonicalIssueType(issueType) {
+	case "crash_loop":
+		return []string{"crash_loop", "CrashLoopBackOff"}
+	case "probe_failure":
+		return []string{"probe_failure", "ProbeFailure", "CrashLoopBackOff (ProbeFailure)"}
+	case "oomkilled":
+		return []string{"oomkilled", "oom_killed", "OOMKilled", "CrashLoopBackOff (OOMKilled)"}
+	case "image_pull_backoff":
+		return []string{"image_pull_backoff", "ImagePullBackOff", "ErrImagePull", "image_pull"}
+	case "high_restart_count":
+		return []string{"high_restart_count", "HighRestartCount"}
+	default:
+		return []string{issueType}
+	}
+}
+
+func normalizeFingerprint(fingerprint string) string {
+	parts := strings.Split(fingerprint, "/")
+	if len(parts) == 0 {
+		return fingerprint
+	}
+	parts[len(parts)-1] = CanonicalIssueType(parts[len(parts)-1])
+	return strings.Join(parts, "/")
+}
+
+func fingerprintAliases(fingerprint string) []string {
+	parts := strings.Split(fingerprint, "/")
+	if len(parts) == 0 {
+		return []string{fingerprint}
+	}
+	aliases := issueTypeAliases(parts[len(parts)-1])
+	out := make([]string, 0, len(aliases))
+	for _, alias := range aliases {
+		copyParts := append([]string(nil), parts...)
+		copyParts[len(copyParts)-1] = alias
+		out = append(out, strings.Join(copyParts, "/"))
+	}
+	return out
+}

--- a/pkg/store/issue_type_test.go
+++ b/pkg/store/issue_type_test.go
@@ -186,6 +186,59 @@ func TestEarliestRetainedObservationFallsBackToIncidents(t *testing.T) {
 	}
 }
 
+func TestGetMemoryProvenanceSelectsEarliestClusterHistory(t *testing.T) {
+	tests := []struct {
+		name          string
+		scanAge       time.Duration
+		incidentAge   time.Duration
+		wantAge       time.Duration
+		wantSource    string
+		wantNoHistory bool
+	}{
+		{name: "incident history older than scan history", scanAge: 24 * time.Hour, incidentAge: 10 * 24 * time.Hour, wantAge: 10 * 24 * time.Hour, wantSource: MemoryProvenanceIncidents},
+		{name: "scan history older than incident history", scanAge: 10 * 24 * time.Hour, incidentAge: 24 * time.Hour, wantAge: 10 * 24 * time.Hour, wantSource: MemoryProvenanceScanHistory},
+		{name: "only incident history", incidentAge: 5 * 24 * time.Hour, wantAge: 5 * 24 * time.Hour, wantSource: MemoryProvenanceIncidents},
+		{name: "only scan history", scanAge: 5 * 24 * time.Hour, wantAge: 5 * 24 * time.Hour, wantSource: MemoryProvenanceScanHistory},
+		{name: "no history", wantNoHistory: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := openTestStore(t)
+			now := time.Now().Truncate(time.Second)
+			if tt.scanAge > 0 {
+				if _, err := s.db.Exec(`INSERT INTO scan_history (scan_id,cluster,scanned_at,success) VALUES (?,?,?,1)`, "target-scan", "target", now.Add(-tt.scanAge).Unix()); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tt.incidentAge > 0 {
+				if _, err := s.db.Exec(`INSERT INTO incidents
+					(fingerprint,cluster,namespace,resource,issue_type,severity,first_seen,last_seen,status,current_restart_count,missing_scans)
+					VALUES (?,?,?,?,?,?,?,?,?,?,?)`, "ns/Workload/api/crash_loop", "target", "ns", "api", "crash_loop", "critical", now.Add(-tt.incidentAge).Unix(), now.Unix(), "active", 0, 0); err != nil {
+					t.Fatal(err)
+				}
+			}
+			// Older data belonging to another cluster must never influence target.
+			if _, err := s.db.Exec(`INSERT INTO scan_history (scan_id,cluster,scanned_at,success) VALUES (?,?,?,1)`, "other-scan", "other", now.Add(-30*24*time.Hour).Unix()); err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := s.GetMemoryProvenance("target")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tt.wantNoHistory {
+				if got != nil {
+					t.Fatalf("provenance=%+v, want no history", got)
+				}
+				return
+			}
+			if got == nil || got.Source != tt.wantSource || !got.EarliestRetainedObservation.Equal(now.Add(-tt.wantAge)) {
+				t.Fatalf("provenance=%+v, want time=%v source=%q", got, now.Add(-tt.wantAge), tt.wantSource)
+			}
+		})
+	}
+}
+
 func TestRestartTrendApplicabilityUsesCanonicalFamilies(t *testing.T) {
 	for _, issueType := range []string{"crash_loop", "CrashLoopBackOff", "probe_failure", "ProbeFailure", "oomkilled", "OOMKilled"} {
 		if !RestartTrendApplies(issueType) {

--- a/pkg/store/issue_type_test.go
+++ b/pkg/store/issue_type_test.go
@@ -1,0 +1,200 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCanonicalIssueTypeAliasesAndFingerprint(t *testing.T) {
+	tests := map[string]string{
+		"CrashLoopBackOff": "crash_loop", "ProbeFailure": "probe_failure",
+		"CrashLoopBackOff (ProbeFailure)": "probe_failure", "OOMKilled": "oomkilled",
+		"oom_killed": "oomkilled", "CrashLoopBackOff (OOMKilled)": "oomkilled",
+		"ImagePullBackOff": "image_pull_backoff", "ErrImagePull": "image_pull_backoff",
+		"image_pull": "image_pull_backoff", "HighRestartCount": "high_restart_count",
+		"custom_type": "custom_type",
+	}
+	for input, want := range tests {
+		if got := CanonicalIssueType(input); got != want {
+			t.Errorf("CanonicalIssueType(%q) = %q, want %q", input, got, want)
+		}
+		if got := Fingerprint("ns", "Workload", "api", input); got != "ns/Workload/api/"+want {
+			t.Errorf("Fingerprint(%q) = %q", input, got)
+		}
+	}
+}
+
+func TestLegacyAliasReuseChoosesEarliestAndPreservesTimeline(t *testing.T) {
+	s := openTestStore(t)
+	cluster := "legacy-cluster"
+	now := time.Now().Unix()
+	legacyFP := "prod/Workload/api/CrashLoopBackOff"
+	newerFP := "prod/Workload/api/crash_loop"
+	res, err := s.db.Exec(`INSERT INTO incidents
+		(fingerprint,cluster,namespace,resource,issue_type,severity,first_seen,last_seen,status,last_scan_id,current_restart_count,missing_scans)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`, legacyFP, cluster, "prod", "api-old", "CrashLoopBackOff", "critical", now-86400, now-100, "active", "old", 10, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyID, _ := res.LastInsertId()
+	if err := insertIncidentEventTxForTest(s, legacyID, "legacy", now-86400); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.Exec(`INSERT INTO incidents
+		(fingerprint,cluster,namespace,resource,issue_type,severity,first_seen,last_seen,status,last_scan_id,current_restart_count,missing_scans)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`, newerFP, cluster, "prod", "api-new", "crash_loop", "critical", now-3600, now-100, "active", "old", 20, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	inc := IncidentData{Fingerprint: legacyFP, Namespace: "prod", Resource: "api-live", IssueType: "CrashLoopBackOff", Severity: "critical", RestartCount: 11}
+	if err := s.UpsertIncidents(cluster, "scan-new", []IncidentData{inc}); err != nil {
+		t.Fatal(err)
+	}
+
+	rec, err := s.GetIncidentHistory(cluster, newerFP)
+	if err != nil || rec == nil {
+		t.Fatalf("history: %+v, %v", rec, err)
+	}
+	if rec.FirstSeen.Unix() != now-86400 {
+		t.Fatalf("first_seen = %v", rec.FirstSeen)
+	}
+	timeline, err := s.GetIncidentTimeline(cluster, newerFP)
+	if err != nil || len(timeline) != 1 || timeline[0].EventType != "DETECTED" {
+		t.Fatalf("timeline was not preserved or another DETECTED was emitted: %+v, %v", timeline, err)
+	}
+	var legacyScan, duplicateScan string
+	if err := s.db.QueryRow(`SELECT last_scan_id FROM incidents WHERE fingerprint=?`, legacyFP).Scan(&legacyScan); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.db.QueryRow(`SELECT last_scan_id FROM incidents WHERE fingerprint=?`, newerFP).Scan(&duplicateScan); err != nil {
+		t.Fatal(err)
+	}
+	if legacyScan != "scan-new" || duplicateScan != "old" {
+		t.Fatalf("selected=%q duplicate=%q", legacyScan, duplicateScan)
+	}
+
+	items, total, err := s.QueryIncidents(IncidentFilter{Cluster: cluster, IssueType: "crash_loop"})
+	if err != nil || total != 2 || len(items) != 2 {
+		t.Fatalf("alias filter: total=%d items=%d err=%v", total, len(items), err)
+	}
+	_, total, err = s.QueryIncidents(IncidentFilter{Cluster: cluster, Text: "crash_loop"})
+	if err != nil || total != 2 {
+		t.Fatalf("alias text filter: total=%d err=%v", total, err)
+	}
+}
+
+func TestSemanticAliasSelectionPrefersActiveThenEarliest(t *testing.T) {
+	tests := []struct {
+		name            string
+		legacyStatus    string
+		canonicalStatus string
+		wantFingerprint string
+		wantFirstAge    int64
+	}{
+		{"newer active canonical beats older resolved legacy", "resolved", "active", "prod/Workload/api/crash_loop", 3600},
+		{"older active legacy beats newer active canonical", "active", "active", "prod/Workload/api/CrashLoopBackOff", 86400},
+		{"earliest resolved alias wins when none active", "resolved", "resolved", "prod/Workload/api/CrashLoopBackOff", 86400},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := openTestStore(t)
+			cluster := "selection"
+			now := time.Now().Unix()
+			legacyFP := "prod/Workload/api/CrashLoopBackOff"
+			canonicalFP := "prod/Workload/api/crash_loop"
+			ids := make(map[string]int64)
+			for _, row := range []struct {
+				fp, issueType, status string
+				firstAge              int64
+			}{{legacyFP, "CrashLoopBackOff", tt.legacyStatus, 86400}, {canonicalFP, "crash_loop", tt.canonicalStatus, 3600}} {
+				res, err := s.db.Exec(`INSERT INTO incidents
+					(fingerprint,cluster,namespace,resource,issue_type,severity,first_seen,last_seen,status,last_scan_id,current_restart_count,missing_scans)
+					VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`, row.fp, cluster, "prod", "api", row.issueType, "critical", now-row.firstAge, now, row.status, "old", 10, 0)
+				if err != nil {
+					t.Fatal(err)
+				}
+				ids[row.fp], _ = res.LastInsertId()
+				if _, err := s.db.Exec(`INSERT INTO incident_events
+					(incident_id,scan_id,occurred_at,event_type,event_reason,message)
+					VALUES (?,?,?,?,?,?)`, ids[row.fp], "seed", now-row.firstAge, "DETECTED", "Detected", row.fp); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			rec, err := s.GetIncidentHistory(cluster, canonicalFP)
+			if err != nil || rec == nil || rec.Status != map[string]string{legacyFP: tt.legacyStatus, canonicalFP: tt.canonicalStatus}[tt.wantFingerprint] || rec.FirstSeen.Unix() != now-tt.wantFirstAge {
+				t.Fatalf("history=%+v err=%v", rec, err)
+			}
+			batch, err := s.BatchGetIncidentHistory(cluster, []string{canonicalFP})
+			if err != nil || batch[canonicalFP] == nil || batch[canonicalFP].ID != ids[tt.wantFingerprint] {
+				t.Fatalf("batch=%+v err=%v", batch, err)
+			}
+			timeline, err := s.GetIncidentTimeline(cluster, canonicalFP)
+			if err != nil || len(timeline) != 1 || timeline[0].Message != tt.wantFingerprint {
+				t.Fatalf("timeline=%+v err=%v", timeline, err)
+			}
+
+			if err := s.UpsertIncidents(cluster, "selected", []IncidentData{{Fingerprint: canonicalFP, Namespace: "prod", Resource: "api", IssueType: "crash_loop", Severity: "critical", RestartCount: 11}}); err != nil {
+				t.Fatal(err)
+			}
+			var selectedScan string
+			if err := s.db.QueryRow(`SELECT last_scan_id FROM incidents WHERE id=?`, ids[tt.wantFingerprint]).Scan(&selectedScan); err != nil || selectedScan != "selected" {
+				t.Fatalf("selected last_scan_id=%q err=%v", selectedScan, err)
+			}
+		})
+	}
+}
+
+func insertIncidentEventTxForTest(s *SQLiteStore, id int64, scanID string, at int64) error {
+	_, err := s.db.Exec(`INSERT INTO incident_events
+		(incident_id,scan_id,occurred_at,event_type,event_reason,restart_count,severity,state,message)
+		VALUES (?,?,?,?,?,?,?,?,?)`, id, scanID, at, "DETECTED", "Detected", 10, "critical", "active", "legacy")
+	return err
+}
+
+func TestEarliestRetainedObservationIsClusterScopedAndBoundary(t *testing.T) {
+	s := openTestStore(t)
+	now := time.Now().Unix()
+	if _, err := s.db.Exec(`INSERT INTO scan_history (scan_id,cluster,scanned_at,success) VALUES
+		('failed','a',?,0),('success','a',?,1),('other','b',?,1)`, now-9000, now-5000, now-10000); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.GetEarliestRetainedObservation("a")
+	if err != nil || got.Unix() != now-5000 {
+		t.Fatalf("got=%v err=%v", got, err)
+	}
+	unknown, err := s.GetEarliestRetainedObservation("unknown")
+	if err != nil || !unknown.IsZero() {
+		t.Fatalf("unknown=%v err=%v", unknown, err)
+	}
+	if !AtObservationBoundary(got.Add(5*time.Minute), got) || AtObservationBoundary(got.Add(5*time.Minute+time.Second), got) {
+		t.Fatal("five-minute boundary is not inclusive and exact")
+	}
+}
+
+func TestEarliestRetainedObservationFallsBackToIncidents(t *testing.T) {
+	s := openTestStore(t)
+	now := time.Now().Unix()
+	if _, err := s.db.Exec(`INSERT INTO incidents
+		(fingerprint,cluster,namespace,resource,issue_type,severity,first_seen,last_seen,status,current_restart_count,missing_scans)
+		VALUES ('ns/Workload/api/crash_loop','fallback','ns','api','crash_loop','critical',?,?, 'active',0,0)`, now-7200, now); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.GetEarliestRetainedObservation("fallback")
+	if err != nil || got.Unix() != now-7200 {
+		t.Fatalf("fallback=%v err=%v", got, err)
+	}
+}
+
+func TestRestartTrendApplicabilityUsesCanonicalFamilies(t *testing.T) {
+	for _, issueType := range []string{"crash_loop", "CrashLoopBackOff", "probe_failure", "ProbeFailure", "oomkilled", "OOMKilled"} {
+		if !RestartTrendApplies(issueType) {
+			t.Errorf("%q should support restart trends", issueType)
+		}
+	}
+	for _, issueType := range []string{"image_pull_backoff", "ImagePullBackOff", "high_restart_count"} {
+		if RestartTrendApplies(issueType) {
+			t.Errorf("%q must not support restart trends", issueType)
+		}
+	}
+}

--- a/pkg/store/null.go
+++ b/pkg/store/null.go
@@ -24,6 +24,10 @@ func (NullStore) WriteScanHistory(cluster string, scanID string, meta ScanMeta) 
 	return nil
 }
 
+func (NullStore) GetMemoryProvenance(cluster string) (*MemoryProvenance, error) {
+	return nil, nil
+}
+
 func (NullStore) GetOverviewTrend(cluster string) (*OverviewTrend, error) {
 	return &OverviewTrend{HasHistory: false}, nil
 }

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -653,30 +653,45 @@ func (s *SQLiteStore) WriteScanHistory(cluster string, scanID string, meta ScanM
 	return err
 }
 
-// GetEarliestRetainedObservation returns cluster-scoped OMA provenance.
-// Successful scans are authoritative; incident history is the fallback for
-// databases whose retained scan history is unavailable.
-func (s *SQLiteStore) GetEarliestRetainedObservation(cluster string) (time.Time, error) {
-	var unix sql.NullInt64
+// GetMemoryProvenance returns the earliest cluster-scoped retained timestamp
+// across successful scans and incident history.
+func (s *SQLiteStore) GetMemoryProvenance(cluster string) (*MemoryProvenance, error) {
+	var scanUnix, incidentUnix sql.NullInt64
 	if err := s.db.QueryRow(
 		`SELECT MIN(scanned_at) FROM scan_history WHERE cluster = ? AND success = 1`,
 		cluster,
-	).Scan(&unix); err != nil {
-		return time.Time{}, err
-	}
-	if unix.Valid {
-		return time.Unix(unix.Int64, 0), nil
+	).Scan(&scanUnix); err != nil {
+		return nil, err
 	}
 	if err := s.db.QueryRow(
 		`SELECT MIN(first_seen) FROM incidents WHERE cluster = ?`,
 		cluster,
-	).Scan(&unix); err != nil {
+	).Scan(&incidentUnix); err != nil {
+		return nil, err
+	}
+
+	switch {
+	case scanUnix.Valid && (!incidentUnix.Valid || scanUnix.Int64 <= incidentUnix.Int64):
+		return &MemoryProvenance{
+			EarliestRetainedObservation: time.Unix(scanUnix.Int64, 0),
+			Source:                      MemoryProvenanceScanHistory,
+		}, nil
+	case incidentUnix.Valid:
+		return &MemoryProvenance{
+			EarliestRetainedObservation: time.Unix(incidentUnix.Int64, 0),
+			Source:                      MemoryProvenanceIncidents,
+		}, nil
+	default:
+		return nil, nil
+	}
+}
+
+func (s *SQLiteStore) GetEarliestRetainedObservation(cluster string) (time.Time, error) {
+	provenance, err := s.GetMemoryProvenance(cluster)
+	if err != nil || provenance == nil {
 		return time.Time{}, err
 	}
-	if !unix.Valid {
-		return time.Time{}, nil
-	}
-	return time.Unix(unix.Int64, 0), nil
+	return provenance.EarliestRetainedObservation, nil
 }
 
 type snapshotRow struct {

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -373,6 +373,10 @@ func (s *SQLiteStore) WriteSnapshot(cluster string, scanID string, d SnapshotDat
 }
 
 func (s *SQLiteStore) UpsertIncidents(cluster string, scanID string, incidents []IncidentData) error {
+	for i := range incidents {
+		incidents[i].IssueType = CanonicalIssueType(incidents[i].IssueType)
+		incidents[i].Fingerprint = normalizeFingerprint(incidents[i].Fingerprint)
+	}
 	incidents = focusIncidentsByFingerprint(incidents)
 
 	tx, err := s.db.Begin()
@@ -380,14 +384,6 @@ func (s *SQLiteStore) UpsertIncidents(cluster string, scanID string, incidents [
 		return err
 	}
 	defer tx.Rollback()
-
-	lookupStmt, err := tx.Prepare(
-		`SELECT id, resource, current_restart_count, severity, status FROM incidents WHERE cluster=? AND fingerprint=?`,
-	)
-	if err != nil {
-		return err
-	}
-	defer lookupStmt.Close()
 
 	upsertStmt, err := tx.Prepare(`
 		INSERT INTO incidents (
@@ -415,15 +411,31 @@ func (s *SQLiteStore) UpsertIncidents(cluster string, scanID string, incidents [
 	for _, inc := range incidents {
 		var existingID int64
 		var prevRestart int
-		var prevResource, prevSeverity, prevStatus string
-		lookupErr := lookupStmt.QueryRow(cluster, inc.Fingerprint).Scan(&existingID, &prevResource, &prevRestart, &prevSeverity, &prevStatus)
+		var prevFingerprint, prevResource, prevSeverity, prevStatus string
+		aliases := fingerprintAliases(inc.Fingerprint)
+		placeholders := strings.TrimRight(strings.Repeat("?,", len(aliases)), ",")
+		lookupArgs := make([]any, 0, len(aliases)+1)
+		lookupArgs = append(lookupArgs, cluster)
+		for _, alias := range aliases {
+			lookupArgs = append(lookupArgs, alias)
+		}
+		lookupErr := tx.QueryRow(fmt.Sprintf(
+			`SELECT id, fingerprint, resource, current_restart_count, severity, status
+			 FROM incidents WHERE cluster=? AND fingerprint IN (%s)
+			 ORDER BY CASE status WHEN 'active' THEN 0 ELSE 1 END ASC,
+			          first_seen ASC, id ASC LIMIT 1`, placeholders,
+		), lookupArgs...).Scan(&existingID, &prevFingerprint, &prevResource, &prevRestart, &prevSeverity, &prevStatus)
 		if lookupErr != nil && lookupErr != sql.ErrNoRows {
 			return lookupErr
 		}
 		isNew := lookupErr == sql.ErrNoRows
+		writeFingerprint := inc.Fingerprint
+		if !isNew {
+			writeFingerprint = prevFingerprint
+		}
 
 		res, err := upsertStmt.Exec(
-			inc.Fingerprint, cluster, inc.Namespace, inc.Resource, inc.IssueType,
+			writeFingerprint, cluster, inc.Namespace, inc.Resource, inc.IssueType,
 			inc.Severity, now, now, inc.DetailsJSON, scanID, inc.RestartCount,
 		)
 		if err != nil {
@@ -641,6 +653,32 @@ func (s *SQLiteStore) WriteScanHistory(cluster string, scanID string, meta ScanM
 	return err
 }
 
+// GetEarliestRetainedObservation returns cluster-scoped OMA provenance.
+// Successful scans are authoritative; incident history is the fallback for
+// databases whose retained scan history is unavailable.
+func (s *SQLiteStore) GetEarliestRetainedObservation(cluster string) (time.Time, error) {
+	var unix sql.NullInt64
+	if err := s.db.QueryRow(
+		`SELECT MIN(scanned_at) FROM scan_history WHERE cluster = ? AND success = 1`,
+		cluster,
+	).Scan(&unix); err != nil {
+		return time.Time{}, err
+	}
+	if unix.Valid {
+		return time.Unix(unix.Int64, 0), nil
+	}
+	if err := s.db.QueryRow(
+		`SELECT MIN(first_seen) FROM incidents WHERE cluster = ?`,
+		cluster,
+	).Scan(&unix); err != nil {
+		return time.Time{}, err
+	}
+	if !unix.Valid {
+		return time.Time{}, nil
+	}
+	return time.Unix(unix.Int64, 0), nil
+}
+
 type snapshotRow struct {
 	ScannedAt      int64
 	IncidentScore  int
@@ -777,12 +815,20 @@ func (s *SQLiteStore) GetIncidentHistory(cluster string, fingerprint string) (*I
 	var firstSeen, lastSeen int64
 	var status, detailsJSON sql.NullString
 
-	err := s.db.QueryRow(
+	aliases := fingerprintAliases(fingerprint)
+	placeholders := strings.TrimRight(strings.Repeat("?,", len(aliases)), ",")
+	args := make([]any, 0, len(aliases)+1)
+	args = append(args, cluster)
+	for _, alias := range aliases {
+		args = append(args, alias)
+	}
+	err := s.db.QueryRow(fmt.Sprintf(
 		`SELECT first_seen, last_seen, status, details_json
 		 FROM incidents
-		 WHERE cluster = ? AND fingerprint = ?`,
-		cluster, fingerprint,
-	).Scan(&firstSeen, &lastSeen, &status, &detailsJSON)
+		 WHERE cluster = ? AND fingerprint IN (%s)
+		 ORDER BY CASE status WHEN 'active' THEN 0 ELSE 1 END ASC,
+		          first_seen ASC, id ASC LIMIT 1`, placeholders,
+	), args...).Scan(&firstSeen, &lastSeen, &status, &detailsJSON)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -792,7 +838,7 @@ func (s *SQLiteStore) GetIncidentHistory(cluster string, fingerprint string) (*I
 	}
 
 	return &IncidentRecord{
-		Fingerprint: fingerprint,
+		Fingerprint: normalizeFingerprint(fingerprint),
 		FirstSeen:   time.Unix(firstSeen, 0),
 		LastSeen:    time.Unix(lastSeen, 0),
 		Status:      status.String,
@@ -801,14 +847,24 @@ func (s *SQLiteStore) GetIncidentHistory(cluster string, fingerprint string) (*I
 }
 
 func (s *SQLiteStore) GetIncidentTimeline(cluster string, fingerprint string) ([]IncidentEvent, error) {
-	rows, err := s.db.Query(`
+	aliases := fingerprintAliases(fingerprint)
+	placeholders := strings.TrimRight(strings.Repeat("?,", len(aliases)), ",")
+	args := make([]any, 0, len(aliases)+1)
+	args = append(args, cluster)
+	for _, alias := range aliases {
+		args = append(args, alias)
+	}
+	rows, err := s.db.Query(fmt.Sprintf(`
 		SELECT e.occurred_at, e.event_type, e.event_reason, e.restart_count,
 			e.severity, e.state, e.message
 		FROM incident_events e
-		JOIN incidents i ON i.id = e.incident_id
-		WHERE i.cluster = ? AND i.fingerprint = ?
+		WHERE e.incident_id = (
+			SELECT id FROM incidents WHERE cluster = ? AND fingerprint IN (%s)
+			ORDER BY CASE status WHEN 'active' THEN 0 ELSE 1 END ASC,
+			         first_seen ASC, id ASC LIMIT 1
+		)
 		ORDER BY e.occurred_at ASC, e.id ASC
-	`, cluster, fingerprint)
+	`, placeholders), args...)
 	if err != nil {
 		return nil, err
 	}
@@ -846,10 +902,23 @@ func (s *SQLiteStore) BatchGetIncidentHistory(cluster string, fingerprints []str
 		return out, nil
 	}
 
-	placeholders := make([]string, len(fingerprints))
-	args := make([]any, 0, len(fingerprints)+1)
+	requested := make(map[string][]string, len(fingerprints))
+	var allAliases []string
+	seenAlias := make(map[string]bool)
+	for _, fp := range fingerprints {
+		canonical := normalizeFingerprint(fp)
+		requested[canonical] = append(requested[canonical], fp)
+		for _, alias := range fingerprintAliases(fp) {
+			if !seenAlias[alias] {
+				seenAlias[alias] = true
+				allAliases = append(allAliases, alias)
+			}
+		}
+	}
+	placeholders := make([]string, len(allAliases))
+	args := make([]any, 0, len(allAliases)+1)
 	args = append(args, cluster)
-	for i, fp := range fingerprints {
+	for i, fp := range allAliases {
 		placeholders[i] = "?"
 		args = append(args, fp)
 	}
@@ -857,7 +926,9 @@ func (s *SQLiteStore) BatchGetIncidentHistory(cluster string, fingerprints []str
 	rows, err := s.db.Query(fmt.Sprintf(
 		`SELECT id, fingerprint, first_seen, last_seen, status, details_json
 		 FROM incidents
-		 WHERE cluster = ? AND fingerprint IN (%s)`,
+		 WHERE cluster = ? AND fingerprint IN (%s)
+		 ORDER BY CASE status WHEN 'active' THEN 0 ELSE 1 END ASC,
+		          first_seen ASC, id ASC`,
 		strings.Join(placeholders, ","),
 	), args...)
 	if err != nil {
@@ -872,13 +943,21 @@ func (s *SQLiteStore) BatchGetIncidentHistory(cluster string, fingerprints []str
 		if err := rows.Scan(&id, &fingerprint, &firstSeen, &lastSeen, &status, &detailsJSON); err != nil {
 			return nil, err
 		}
-		out[fingerprint] = &IncidentRecord{
+		canonical := normalizeFingerprint(fingerprint)
+		if _, chosen := out[canonical]; chosen {
+			continue
+		}
+		record := &IncidentRecord{
 			ID:          id,
-			Fingerprint: fingerprint,
+			Fingerprint: canonical,
 			FirstSeen:   time.Unix(firstSeen, 0),
 			LastSeen:    time.Unix(lastSeen, 0),
 			Status:      status.String,
 			DetailsJSON: detailsJSON.String,
+		}
+		out[canonical] = record
+		for _, original := range requested[canonical] {
+			out[original] = record
 		}
 	}
 	return out, rows.Err()
@@ -1022,8 +1101,8 @@ func (s *SQLiteStore) batchTrendEvents(ids []int64) (map[int64][]trendEvent, err
 // Namespace posture, security/configuration, and unattached-resource findings
 // have no meaningful restart trajectory and must not be labeled "stable".
 func RestartTrendApplies(issueType string) bool {
-	switch issueType {
-	case "crash_loop", "oomkilled", "oom_killed", "probe_failure":
+	switch CanonicalIssueType(issueType) {
+	case "crash_loop", "oomkilled", "probe_failure":
 		return true
 	default:
 		return false
@@ -1090,16 +1169,24 @@ func (s *SQLiteStore) QueryIncidents(f IncidentFilter) ([]IncidentSummary, int, 
 
 	if f.Text != "" {
 		like := "%" + f.Text + "%"
-		where = append(where, "(resource LIKE ? OR namespace LIKE ? OR issue_type LIKE ?)")
+		aliases := issueTypeAliases(f.Text)
+		where = append(where, "(resource LIKE ? OR namespace LIKE ? OR issue_type LIKE ? OR issue_type IN ("+
+			strings.TrimRight(strings.Repeat("?,", len(aliases)), ",")+"))")
 		args = append(args, like, like, like)
+		for _, alias := range aliases {
+			args = append(args, alias)
+		}
 	}
 	if f.Namespace != "" {
 		where = append(where, "namespace = ?")
 		args = append(args, f.Namespace)
 	}
 	if f.IssueType != "" {
-		where = append(where, "issue_type = ?")
-		args = append(args, f.IssueType)
+		aliases := issueTypeAliases(f.IssueType)
+		where = append(where, "issue_type IN ("+strings.TrimRight(strings.Repeat("?,", len(aliases)), ",")+")")
+		for _, alias := range aliases {
+			args = append(args, alias)
+		}
 	}
 	if f.Severity != "" {
 		where = append(where, "severity = ?")
@@ -1194,10 +1281,10 @@ func (s *SQLiteStore) QueryIncidents(f IncidentFilter) ([]IncidentSummary, int, 
 	items := make([]IncidentSummary, 0, len(raws))
 	for _, r := range raws {
 		summary := IncidentSummary{
-			Fingerprint:  r.fingerprint,
+			Fingerprint:  normalizeFingerprint(r.fingerprint),
 			Namespace:    r.namespace,
 			Resource:     r.resource,
-			IssueType:    r.issueType,
+			IssueType:    CanonicalIssueType(r.issueType),
 			Severity:     r.severity,
 			Status:       r.status,
 			ReopenCount:  reopenCounts[r.id],
@@ -1220,7 +1307,7 @@ func (s *SQLiteStore) countAccelerating(cluster string) (int, error) {
 	rows, err := s.db.Query(
 		`SELECT id, current_restart_count, first_seen FROM incidents
 		 WHERE cluster = ? AND status = 'active'
-		   AND issue_type IN ('crash_loop','oomkilled','oom_killed','probe_failure')`,
+		   AND issue_type IN ('crash_loop','CrashLoopBackOff','oomkilled','oom_killed','OOMKilled','CrashLoopBackOff (OOMKilled)','probe_failure','ProbeFailure','CrashLoopBackOff (ProbeFailure)')`,
 		cluster,
 	)
 	if err != nil {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -9,6 +9,7 @@ type Store interface {
 	UpsertIncidents(cluster string, scanID string, incidents []IncidentData) error
 	ResolveMissing(cluster string, scanID string) (resolved int, err error)
 	WriteScanHistory(cluster string, scanID string, meta ScanMeta) error
+	GetMemoryProvenance(cluster string) (*MemoryProvenance, error)
 	GetOverviewTrend(cluster string) (*OverviewTrend, error)
 	GetLatestSnapshot(cluster string) (*SnapshotData, error)
 	GetIncidentHistory(cluster string, fingerprint string) (*IncidentRecord, error)
@@ -23,16 +24,32 @@ type Store interface {
 	Close() error
 }
 
-// GetEarliestRetainedObservation queries provenance when the selected store
-// supports it. Stateless and other stores report no retained history.
+const (
+	MemoryProvenanceScanHistory = "scan_history"
+	MemoryProvenanceIncidents   = "incidents"
+)
+
+// MemoryProvenance identifies the beginning of a cluster's retained OMA
+// history and the table that supplied that earliest timestamp.
+type MemoryProvenance struct {
+	EarliestRetainedObservation time.Time
+	Source                      string
+}
+
+// GetMemoryProvenance queries provenance when the selected store supports it.
+// Stateless and other stores report no retained history.
+func GetMemoryProvenance(s Store, cluster string) (*MemoryProvenance, error) {
+	return s.GetMemoryProvenance(cluster)
+}
+
+// GetEarliestRetainedObservation is the timestamp-only compatibility helper
+// used by existing presentation callers.
 func GetEarliestRetainedObservation(s Store, cluster string) (time.Time, error) {
-	type provenanceStore interface {
-		GetEarliestRetainedObservation(string) (time.Time, error)
+	provenance, err := GetMemoryProvenance(s, cluster)
+	if err != nil || provenance == nil {
+		return time.Time{}, err
 	}
-	if p, ok := s.(provenanceStore); ok {
-		return p.GetEarliestRetainedObservation(cluster)
-	}
-	return time.Time{}, nil
+	return provenance.EarliestRetainedObservation, nil
 }
 
 // AtObservationBoundary reports whether an incident was first seen within

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -23,6 +23,28 @@ type Store interface {
 	Close() error
 }
 
+// GetEarliestRetainedObservation queries provenance when the selected store
+// supports it. Stateless and other stores report no retained history.
+func GetEarliestRetainedObservation(s Store, cluster string) (time.Time, error) {
+	type provenanceStore interface {
+		GetEarliestRetainedObservation(string) (time.Time, error)
+	}
+	if p, ok := s.(provenanceStore); ok {
+		return p.GetEarliestRetainedObservation(cluster)
+	}
+	return time.Time{}, nil
+}
+
+// AtObservationBoundary reports whether an incident was first seen within
+// five minutes either side of the earliest retained OMA observation.
+func AtObservationBoundary(firstSeen, earliest time.Time) bool {
+	if firstSeen.IsZero() || earliest.IsZero() {
+		return false
+	}
+	delta := firstSeen.Sub(earliest)
+	return delta >= -5*time.Minute && delta <= 5*time.Minute
+}
+
 type SnapshotData struct {
 	ScannedAt      time.Time
 	IncidentScore  int


### PR DESCRIPTION
Canonicalize equivalent issue types across dashboard and CLI incident
fingerprints while preserving compatibility with existing OMA history.

Prefer active semantic aliases during reconciliation and preserve the
earliest active first-seen timestamp without migrating legacy rows.

Add cluster-scoped earliest-retained-observation provenance to the
Emergency CLI and Overview operational-memory card, with explicit
history-boundary wording and separate Kubernetes resource ages.

Add regression coverage for aliases, duplicate reconciliation, restart
trend applicability, provenance isolation, and emergency reporting.