### PR TITLE
feat(investigation): add on-demand container log preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ No competitor in this space — Grafana, Lens, k9s — can produce any of this, 
 - OpsCart Assessment: what the pattern means and estimated investigation time, including whether the restart rate is accelerating
 - Incident Timeline: an operational journal — first detected, restart milestones, severity changes, resolved/reoccurred — persisted across pod restarts
 - Evidence: severity, first detected, restart count, state, age, owner
+- Container Logs (optional): bounded current/previous logs for one selected container at a time, fetched live and never persisted
 - Blast Radius: replicas down, sibling pod health, services routing to the workload, ingress exposure, namespace-wide health, and a customer-impact heuristic (internal vs. possible external traffic)
 - Recommended Investigation: numbered steps with High / Medium / Low confidence and specific kubectl commands
 - Recent Events: last 10 events filtered to this pod
@@ -233,7 +234,7 @@ Namespace-level findings (unprotected namespaces, idle namespaces) get their own
 | **User** | Non-root (UID 65534) |
 | **Binary** | `CGO_ENABLED=0`, statically compiled, `-trimpath` |
 | **CVE scan** | 0 vulnerabilities (Trivy) |
-| **Cluster permissions** | Read-only ClusterRole (`get`, `list` only) |
+| **Cluster permissions** | Read-only ClusterRole (`get`, `list`); optional `get` on `pods/log` when log preview is enabled |
 | **Mutations** | None — never modifies cluster state |
 | **External calls** | None — no telemetry, no phone-home |
 | **Authentication** | Basic auth on by default, no disable path — env var, Secret, or auto-generated password |

--- a/cmd/opscart-dashboard/investigation.go
+++ b/cmd/opscart-dashboard/investigation.go
@@ -44,17 +44,20 @@ type investigationPageData struct {
 	Clusters      []sidebarCluster
 
 	// Pod identity
-	PodName         string
-	Namespace       string
-	IssueType       string // crash_loop, image_pull_backoff, oomkilled, privileged_container, probe_failure...
-	Severity        string
-	OwnerKind       string // Deployment / StatefulSet / Job / (none)
-	OwnerName       string
-	ContainerName   string // set when the finding is container-scoped (e.g. privileged_container); empty otherwis
-	WorkloadLabel   string
-	TrackingLabel   string
-	PodAge          string
-	DescribeCommand string
+	PodName          string
+	Namespace        string
+	IssueType        string // crash_loop, image_pull_backoff, oomkilled, privileged_container, probe_failure...
+	Severity         string
+	OwnerKind        string // Deployment / StatefulSet / Job / (none)
+	OwnerName        string
+	ContainerName    string // set when the finding is container-scoped (e.g. privileged_container); empty otherwis
+	LogContainers    []investigationLogContainer
+	LogsAvailable    bool
+	DefaultLogSource string
+	WorkloadLabel    string
+	TrackingLabel    string
+	PodAge           string
+	DescribeCommand  string
 
 	// Status
 	Phase         string
@@ -235,11 +238,21 @@ func investigationHints(issueType string, stateReason string, restarts int32, po
 			Confidence: "high",
 			Title:      "Confirm privileged mode is actually required",
 			Reason:     "Most workloads do not need privileged: true — verify with the owning team.",
+			Command: fmt.Sprintf(
+				"kubectl get pod %s -n %s -o jsonpath='{range .spec.containers[*]}{.name}{\"\\tprivileged=\"}{.securityContext.privileged}{\"\\n\"}{end}'",
+				pod.Name,
+				pod.Namespace,
+			),
 		})
 		hints = append(hints, investigationHint{
 			Confidence: "medium",
 			Title:      "Replace with specific capabilities",
 			Reason:     "Use securityContext.capabilities.add for specific needs instead of full privileged access.",
+			Command: fmt.Sprintf(
+				"kubectl get pod %s -n %s -o jsonpath='{range .spec.containers[*]}{.name}{\"\\tadd=\"}{.securityContext.capabilities.add}{\"\\tdrop=\"}{.securityContext.capabilities.drop}{\"\\n\"}{end}'",
+				pod.Name,
+				pod.Namespace,
+			),
 		})
 	case "probe_failure":
 		hints = append(hints, investigationHint{
@@ -275,7 +288,7 @@ func investigationHints(issueType string, stateReason string, restarts int32, po
 }
 
 // resolveOwner walks Pod → ReplicaSet → Deployment (or returns the direct owner).
-func resolveOwner(clientset *kubernetes.Clientset, pod *corev1.Pod) (kind, name string) {
+func resolveOwner(clientset kubernetes.Interface, pod *corev1.Pod) (kind, name string) {
 	if len(pod.OwnerReferences) == 0 {
 		return "", ""
 	}
@@ -295,7 +308,7 @@ func resolveOwner(clientset *kubernetes.Clientset, pod *corev1.Pod) (kind, name 
 }
 
 // podEvents returns the last n events for a specific pod, newest first.
-func podEvents(clientset *kubernetes.Clientset, namespace, podName string, n int) []investigationEvent {
+func podEvents(clientset kubernetes.Interface, namespace, podName string, n int) []investigationEvent {
 	evList, err := clientset.CoreV1().Events(namespace).List(context.TODO(), metav1.ListOptions{
 		FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=Pod", podName),
 	})
@@ -393,7 +406,7 @@ func referencedResources(pod *corev1.Pod) (cms, secrets, pvcs []string) {
 }
 
 // blastRadiusSiblings returns all pods owned by the same workload.
-func blastRadiusSiblings(clientset *kubernetes.Clientset, namespace, ownerKind, ownerName string) (pods []blastRadiusPod, healthy, total int) {
+func blastRadiusSiblings(clientset kubernetes.Interface, namespace, ownerKind, ownerName string) (pods []blastRadiusPod, healthy, total int) {
 	if ownerName == "" {
 		return
 	}
@@ -443,7 +456,7 @@ func blastRadiusSiblings(clientset *kubernetes.Clientset, namespace, ownerKind, 
 }
 
 // blastRadiusServices returns services whose selector matches the pod's labels.
-func blastRadiusServices(clientset *kubernetes.Clientset, namespace string, podLabels map[string]string) []blastRadiusService {
+func blastRadiusServices(clientset kubernetes.Interface, namespace string, podLabels map[string]string) []blastRadiusService {
 	list, err := clientset.CoreV1().Services(namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return nil
@@ -467,7 +480,7 @@ func blastRadiusServices(clientset *kubernetes.Clientset, namespace string, podL
 }
 
 // blastRadiusSharedConfig finds other Deployments in the namespace sharing CMs or Secrets with this pod.
-func blastRadiusSharedConfig(clientset *kubernetes.Clientset, namespace, selfName string, cms, secrets []string) []blastSharedDep {
+func blastRadiusSharedConfig(clientset kubernetes.Interface, namespace, selfName string, cms, secrets []string) []blastSharedDep {
 	if len(cms) == 0 && len(secrets) == 0 {
 		return nil
 	}
@@ -503,7 +516,7 @@ func blastRadiusSharedConfig(clientset *kubernetes.Clientset, namespace, selfNam
 }
 
 // blastIngresses finds Ingress rules that route to any of the given service names.
-func blastIngresses(clientset *kubernetes.Clientset, namespace string, serviceNames []string) []blastIngressRule {
+func blastIngresses(clientset kubernetes.Interface, namespace string, serviceNames []string) []blastIngressRule {
 	if len(serviceNames) == 0 {
 		return nil
 	}
@@ -539,7 +552,7 @@ func blastIngresses(clientset *kubernetes.Clientset, namespace string, serviceNa
 
 // blastNamespaceHealth counts healthy vs total pods per workload in the namespace,
 // excluding the pod under investigation.
-func blastNamespaceHealth(clientset *kubernetes.Clientset, namespace, excludeOwnerName string) (workloads []blastNamespacePod, healthy, total int) {
+func blastNamespaceHealth(clientset kubernetes.Interface, namespace, excludeOwnerName string) (workloads []blastNamespacePod, healthy, total int) {
 	list, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return
@@ -770,7 +783,7 @@ func (srv *server) handleInvestigationPage(w http.ResponseWriter, r *http.Reques
 	}
 
 	// Live cluster data — fresh client, not scan cache
-	clientset, err := kubeClient(ctx)
+	clientset, err := srv.kubeClientFor(ctx)
 	if err != nil {
 		log.Printf("investigation: kube client: %v", err)
 		http.Error(w, "cluster connection failed", http.StatusBadGateway)
@@ -830,6 +843,9 @@ func (srv *server) handleInvestigationPage(w http.ResponseWriter, r *http.Reques
 			}
 		}
 	}
+	populateInvestigationLogContainers(&data, pod)
+	data.LogsAvailable = srv.logsEnabled && len(data.LogContainers) > 0 &&
+		isActiveInvestigationTarget(scan, namespace, podName, issueType)
 
 	// Owner, events, related resources, hints
 	data.OwnerKind, data.OwnerName = resolveOwner(clientset, pod)

--- a/cmd/opscart-dashboard/investigation_logs.go
+++ b/cmd/opscart-dashboard/investigation_logs.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	investigationLogTailLines int64 = 200
+	investigationLogMaxBytes  int64 = 256 * 1024
+)
+
+type kubeClientFactory func(string) (kubernetes.Interface, error)
+
+type podLogReaderFunc func(context.Context, kubernetes.Interface, string, string, *corev1.PodLogOptions) ([]byte, error)
+
+type investigationLogContainer struct {
+	Name              string
+	Restarts          int32
+	PreviousAvailable bool
+	Selected          bool
+}
+
+func logPreviewEnabledFromEnv() bool {
+	raw := strings.TrimSpace(os.Getenv("OPSCART_LOGS_ENABLED"))
+	if raw == "" {
+		return false
+	}
+	enabled, err := strconv.ParseBool(raw)
+	if err != nil {
+		log.Printf("logs: invalid OPSCART_LOGS_ENABLED value %q; log preview disabled", raw)
+		return false
+	}
+	return enabled
+}
+
+func readPodLogs(ctx context.Context, clientset kubernetes.Interface, namespace, podName string, options *corev1.PodLogOptions) ([]byte, error) {
+	return clientset.CoreV1().Pods(namespace).GetLogs(podName, options).DoRaw(ctx)
+}
+
+func (srv *server) configuredCluster(ctx string) bool {
+	for _, configured := range srv.clusterList {
+		if configured == ctx {
+			return true
+		}
+	}
+	return false
+}
+
+func isActiveInvestigationTarget(scan *clusterScan, namespace, podName, issueType string) bool {
+	if scan == nil {
+		return false
+	}
+	for _, issue := range collectWarRoomIssues(scan, 0) {
+		issuePod := strings.SplitN(issue.Resource, "/", 2)[0]
+		if issue.Namespace == namespace && issuePod == podName && issue.Type == issueType {
+			return true
+		}
+	}
+	return false
+}
+
+func validInvestigationLogType(issueType string) bool {
+	switch issueType {
+	case "crash_loop", "image_pull_backoff", "oomkilled", "privileged_container", "probe_failure":
+		return true
+	default:
+		return false
+	}
+}
+
+func writeInvestigationLogError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
+}
+
+// handleInvestigationLogs returns a bounded live preview for one container
+// belonging to the active issue being investigated. Log bodies are returned
+// directly to the browser and are never sent to the incident store.
+func (srv *server) handleInvestigationLogs(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeInvestigationLogError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if !srv.logsEnabled {
+		writeInvestigationLogError(w, http.StatusNotFound, "container log preview is disabled")
+		return
+	}
+
+	ctxName := srv.activeCtx(r)
+	namespace := r.URL.Query().Get("ns")
+	podName := r.URL.Query().Get("pod")
+	containerName := r.URL.Query().Get("container")
+	issueType := r.URL.Query().Get("type")
+	previousValue := r.URL.Query().Get("previous")
+	previous := previousValue == "true"
+
+	if !srv.configuredCluster(ctxName) {
+		writeInvestigationLogError(w, http.StatusBadRequest, "invalid cluster")
+		return
+	}
+	if len(validation.IsDNS1123Label(namespace)) > 0 ||
+		len(validation.IsDNS1123Subdomain(podName)) > 0 ||
+		len(validation.IsDNS1123Label(containerName)) > 0 ||
+		(previousValue != "" && previousValue != "true" && previousValue != "false") ||
+		!validInvestigationLogType(issueType) {
+		writeInvestigationLogError(w, http.StatusBadRequest, "invalid log request")
+		return
+	}
+
+	state := srv.getState(ctxName)
+	state.mu.RLock()
+	scan := state.scan
+	state.mu.RUnlock()
+	if !isActiveInvestigationTarget(scan, namespace, podName, issueType) {
+		writeInvestigationLogError(w, http.StatusNotFound, "active investigation target not found")
+		return
+	}
+
+	clientset, err := srv.kubeClientFor(ctxName)
+	if err != nil {
+		log.Printf("investigation logs: kube client: %v", err)
+		writeInvestigationLogError(w, http.StatusBadGateway, "cluster connection failed")
+		return
+	}
+	requestCtx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+	pod, err := clientset.CoreV1().Pods(namespace).Get(requestCtx, podName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			writeInvestigationLogError(w, http.StatusNotFound, "pod not found")
+			return
+		}
+		if requestCtx.Err() == context.DeadlineExceeded {
+			writeInvestigationLogError(w, http.StatusGatewayTimeout, "pod lookup timed out")
+			return
+		}
+		log.Printf("investigation logs: getting pod %s/%s: %v", namespace, podName, err)
+		writeInvestigationLogError(w, http.StatusBadGateway, "pod lookup failed")
+		return
+	}
+
+	containerFound := false
+	for _, container := range pod.Spec.Containers {
+		if container.Name == containerName {
+			containerFound = true
+			break
+		}
+	}
+	if !containerFound {
+		writeInvestigationLogError(w, http.StatusNotFound, "container not found")
+		return
+	}
+	if previous {
+		previousAvailable := false
+		for _, status := range pod.Status.ContainerStatuses {
+			if status.Name == containerName && status.RestartCount > 0 {
+				previousAvailable = true
+				break
+			}
+		}
+		if !previousAvailable {
+			writeInvestigationLogError(w, http.StatusConflict, "previous logs are unavailable for this container")
+			return
+		}
+	}
+
+	options := &corev1.PodLogOptions{
+		Container:  containerName,
+		Previous:   previous,
+		TailLines:  int64Pointer(investigationLogTailLines),
+		LimitBytes: int64Pointer(investigationLogMaxBytes),
+		Timestamps: true,
+	}
+	logBytes, err := srv.podLogReader(requestCtx, clientset, namespace, podName, options)
+	if err != nil {
+		if requestCtx.Err() == context.DeadlineExceeded {
+			writeInvestigationLogError(w, http.StatusGatewayTimeout, "log request timed out")
+			return
+		}
+		log.Printf("investigation logs: reading %s/%s container %s: %v", namespace, podName, containerName, err)
+		writeInvestigationLogError(w, http.StatusBadGateway, "logs could not be read")
+		return
+	}
+
+	source := "current"
+	if previous {
+		source = "previous"
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"pod":        podName,
+		"container":  containerName,
+		"source":     source,
+		"tail_lines": investigationLogTailLines,
+		"logs":       string(logBytes),
+	})
+}
+
+func populateInvestigationLogContainers(data *investigationPageData, pod *corev1.Pod) {
+	restartsByName := make(map[string]int32, len(pod.Status.ContainerStatuses))
+	for _, status := range pod.Status.ContainerStatuses {
+		restartsByName[status.Name] = status.RestartCount
+	}
+
+	selectedName := data.ContainerName
+	selectedExists := false
+	for _, container := range pod.Spec.Containers {
+		if container.Name == selectedName {
+			selectedExists = true
+			break
+		}
+	}
+	if !selectedExists && len(pod.Spec.Containers) > 0 {
+		selectedName = pod.Spec.Containers[0].Name
+	}
+	data.ContainerName = selectedName
+	data.DefaultLogSource = "current"
+	data.LogContainers = make([]investigationLogContainer, 0, len(pod.Spec.Containers))
+	for _, container := range pod.Spec.Containers {
+		restarts := restartsByName[container.Name]
+		selected := container.Name == selectedName
+		data.LogContainers = append(data.LogContainers, investigationLogContainer{
+			Name:              container.Name,
+			Restarts:          restarts,
+			PreviousAvailable: restarts > 0,
+			Selected:          selected,
+		})
+		if selected && restarts > 0 {
+			data.DefaultLogSource = "previous"
+		}
+	}
+}
+
+func int64Pointer(value int64) *int64 {
+	return &value
+}

--- a/cmd/opscart-dashboard/investigation_logs_test.go
+++ b/cmd/opscart-dashboard/investigation_logs_test.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/opscart/opscart-k8s-watcher/pkg/analyzer"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func activeCrashLoopScan(podName, namespace string) *clusterScan {
+	return &clusterScan{
+		wasteAudit: &analyzer.WasteAudit{
+			StalePods: []analyzer.StalePod{
+				{
+					Name:         podName,
+					Namespace:    namespace,
+					Kind:         analyzer.StalePodZombie,
+					Status:       "CrashLoopBackOff",
+					RestartCount: 4,
+				},
+			},
+		},
+	}
+}
+
+func multiContainerInvestigationPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "fraud-detection-abc123",
+			Namespace:         "payments",
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app", Image: "example/app:1.0"},
+				{Name: "istio-proxy", Image: "example/proxy:1.0"},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:         "app",
+					RestartCount: 4,
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+					},
+				},
+				{Name: "istio-proxy", RestartCount: 0, Ready: true},
+			},
+		},
+	}
+}
+
+func newContainerLogTestServer(t *testing.T) *server {
+	t.Helper()
+	srv := newTestServer()
+	srv.logsEnabled = true
+	clientset := fake.NewSimpleClientset(multiContainerInvestigationPod())
+	srv.kubeClientFor = func(string) (kubernetes.Interface, error) {
+		return clientset, nil
+	}
+	state := srv.getState(bogusClusterCtx)
+	state.scan = activeCrashLoopScan("fraud-detection-abc123", "payments")
+	return srv
+}
+
+func TestHandleInvestigationLogsSelectsOneContainerAndSource(t *testing.T) {
+	tests := []struct {
+		name              string
+		container         string
+		previous          bool
+		expectedSource    string
+		expectedLogOutput string
+	}{
+		{
+			name:              "previous app container",
+			container:         "app",
+			previous:          true,
+			expectedSource:    "previous",
+			expectedLogOutput: "2026-08-12T10:00:00Z app failed to connect\n",
+		},
+		{
+			name:              "current istio sidecar",
+			container:         "istio-proxy",
+			previous:          false,
+			expectedSource:    "current",
+			expectedLogOutput: "2026-08-12T10:00:00Z proxy ready\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newContainerLogTestServer(t)
+			srv.podLogReader = func(_ context.Context, _ kubernetes.Interface, namespace, podName string, options *corev1.PodLogOptions) ([]byte, error) {
+				if namespace != "payments" || podName != "fraud-detection-abc123" {
+					t.Fatalf("unexpected log target %s/%s", namespace, podName)
+				}
+				if options.Container != tc.container || options.Previous != tc.previous {
+					t.Fatalf("unexpected options: container=%q previous=%v", options.Container, options.Previous)
+				}
+				if options.TailLines == nil || *options.TailLines != investigationLogTailLines {
+					t.Fatalf("expected %d tail lines", investigationLogTailLines)
+				}
+				if options.LimitBytes == nil || *options.LimitBytes != investigationLogMaxBytes {
+					t.Fatalf("expected %d byte limit", investigationLogMaxBytes)
+				}
+				if !options.Timestamps {
+					t.Fatal("expected timestamps to be enabled")
+				}
+				return []byte(tc.expectedLogOutput), nil
+			}
+
+			url := "/api/investigation/logs?cluster=" + bogusClusterCtx +
+				"&ns=payments&pod=fraud-detection-abc123&type=crash_loop&container=" + tc.container +
+				"&previous=" + strconv.FormatBool(tc.previous)
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			rec := httptest.NewRecorder()
+			srv.handleInvestigationLogs(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200 OK, got %d: %s", rec.Code, rec.Body.String())
+			}
+			if rec.Header().Get("Cache-Control") != "no-store" {
+				t.Fatalf("expected Cache-Control no-store, got %q", rec.Header().Get("Cache-Control"))
+			}
+			var payload struct {
+				Container string `json:"container"`
+				Source    string `json:"source"`
+				Logs      string `json:"logs"`
+			}
+			if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if payload.Container != tc.container || payload.Source != tc.expectedSource || payload.Logs != tc.expectedLogOutput {
+				t.Fatalf("unexpected response: %#v", payload)
+			}
+		})
+	}
+}
+
+func TestHandleInvestigationLogsRejectsUnavailablePreviousLogs(t *testing.T) {
+	srv := newContainerLogTestServer(t)
+	readerCalled := false
+	srv.podLogReader = func(context.Context, kubernetes.Interface, string, string, *corev1.PodLogOptions) ([]byte, error) {
+		readerCalled = true
+		return nil, nil
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/investigation/logs?cluster="+bogusClusterCtx+"&ns=payments&pod=fraud-detection-abc123&type=crash_loop&container=istio-proxy&previous=true", nil)
+	rec := httptest.NewRecorder()
+	srv.handleInvestigationLogs(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 Conflict, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if readerCalled {
+		t.Fatal("log reader must not run when previous logs are unavailable")
+	}
+}
+
+func TestHandleInvestigationLogsDisabledByDefault(t *testing.T) {
+	t.Setenv("OPSCART_LOGS_ENABLED", "")
+	srv := newTestServer()
+	clientCalled := false
+	srv.kubeClientFor = func(string) (kubernetes.Interface, error) {
+		clientCalled = true
+		return nil, nil
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/investigation/logs?cluster="+bogusClusterCtx+"&ns=payments&pod=fraud-detection-abc123&type=crash_loop&container=app&previous=false", nil)
+	rec := httptest.NewRecorder()
+	srv.handleInvestigationLogs(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 Not Found, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if clientCalled {
+		t.Fatal("Kubernetes client must not be created while log preview is disabled")
+	}
+}
+
+func TestHandleInvestigationLogsRejectsNonIssuePod(t *testing.T) {
+	srv := newContainerLogTestServer(t)
+	clientCalled := false
+	srv.kubeClientFor = func(string) (kubernetes.Interface, error) {
+		clientCalled = true
+		return nil, nil
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/investigation/logs?cluster="+bogusClusterCtx+"&ns=payments&pod=healthy-api&type=crash_loop&container=app&previous=false", nil)
+	rec := httptest.NewRecorder()
+	srv.handleInvestigationLogs(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 Not Found, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if clientCalled {
+		t.Fatal("Kubernetes client must not be created for a pod outside the active issue list")
+	}
+}
+
+func TestHandleInvestigationPageRendersMultiContainerLogControls(t *testing.T) {
+	srv := newContainerLogTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/investigate?cluster="+bogusClusterCtx+"&ns=payments&pod=fraud-detection-abc123&type=crash_loop", nil)
+	rec := httptest.NewRecorder()
+	srv.handleInvestigationPage(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, expected := range []string{"Container Logs", "app · 4 restarts", "istio-proxy · 0 restarts", "Live preview · not stored"} {
+		if !strings.Contains(body, expected) {
+			t.Errorf("expected rendered page to contain %q", expected)
+		}
+	}
+	if strings.Contains(body, ">Download<") {
+		t.Error("log preview must not render a download control")
+	}
+}
+
+func TestLogPreviewEnabledFromEnvDefaultsOff(t *testing.T) {
+	t.Setenv("OPSCART_LOGS_ENABLED", "")
+	if logPreviewEnabledFromEnv() {
+		t.Fatal("expected log preview to be disabled when the environment variable is unset")
+	}
+	t.Setenv("OPSCART_LOGS_ENABLED", "true")
+	if !logPreviewEnabledFromEnv() {
+		t.Fatal("expected log preview to be enabled for true")
+	}
+}

--- a/cmd/opscart-dashboard/server.go
+++ b/cmd/opscart-dashboard/server.go
@@ -86,6 +86,9 @@ type server struct {
 	auth          *authConfig
 	refreshState  func(*dashboardState, []string) error
 	backgroundWG  sync.WaitGroup
+	logsEnabled   bool
+	kubeClientFor kubeClientFactory
+	podLogReader  podLogReaderFunc
 }
 
 func newServer(clusterList []string, db store.Store, retentionDays int, dbPersistent bool) *server {
@@ -101,6 +104,9 @@ func newServer(clusterList []string, db store.Store, retentionDays int, dbPersis
 		retentionDays: retentionDays,
 		dbPersistent:  dbPersistent,
 		auth:          auth,
+		logsEnabled:   logPreviewEnabledFromEnv(),
+		kubeClientFor: func(ctx string) (kubernetes.Interface, error) { return kubeClient(ctx) },
+		podLogReader:  readPodLogs,
 		refreshState: func(state *dashboardState, clusters []string) error {
 			return state.refresh(clusters)
 		},
@@ -235,6 +241,7 @@ func (srv *server) newMux() http.Handler {
 	mux.HandleFunc("/namespaces", srv.handleNamespacesPage)
 	mux.HandleFunc("/optimizations", srv.handleOptimizationsPage)
 	mux.HandleFunc("/investigate", srv.handleInvestigationPage)
+	mux.HandleFunc("/api/investigation/logs", srv.handleInvestigationLogs)
 	mux.HandleFunc("/incidents", srv.handleIncidentsPage)
 	mux.HandleFunc("/security", srv.handleSecurityPage)
 	mux.HandleFunc("/waste", srv.handleWastePage)

--- a/cmd/opscart-dashboard/templates/investigation.html
+++ b/cmd/opscart-dashboard/templates/investigation.html
@@ -58,6 +58,15 @@
 .inv-scope-row:last-child{border-bottom:none}.inv-scope-key{color:var(--text-muted)}.inv-scope-value{color:var(--text);font-weight:500;min-width:0;overflow-wrap:anywhere}
 .inv-current-status{color:#f87171}.inv-current-status:before{content:"";display:inline-block;width:8px;height:8px;border-radius:50%;background:#f87171;margin-right:.4rem}
 .inv-describe{margin-top:.75rem}
+.inv-log-controls{display:flex;align-items:flex-end;gap:.75rem;flex-wrap:wrap;margin-bottom:.75rem}
+.inv-log-field{display:flex;flex-direction:column;gap:.35rem;min-width:190px}
+.inv-log-field label{font-size:.7rem;text-transform:uppercase;letter-spacing:.5px;color:var(--text-muted);font-weight:600}
+.inv-log-select{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font:inherit;font-size:.8rem;padding:.55rem .7rem}
+.inv-log-load{background:var(--primary);border:1px solid var(--primary);border-radius:var(--radius-sm);color:#fff;cursor:pointer;font:inherit;font-size:.78rem;font-weight:600;padding:.57rem .9rem}
+.inv-log-load:disabled{cursor:wait;opacity:.65}
+.inv-log-meta{color:var(--text-muted);font-size:.75rem;line-height:1.5;margin:.5rem 0}
+.inv-log-output{background:rgba(0,0,0,.3);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text-secondary);font-family:'Consolas','Monaco',monospace;font-size:.76rem;line-height:1.55;margin:.75rem 0 0;max-height:420px;overflow:auto;padding:1rem;white-space:pre;word-break:normal}
+.inv-log-error{color:var(--danger);font-size:.8rem;margin-top:.75rem}
 .inv-evidence{display:flex;gap:1rem;flex-wrap:wrap;margin-bottom:1.5rem}
 .inv-evidence-chip{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);padding:0.6rem 1rem;min-width:120px}
 .inv-evidence-label{font-size:0.65rem;text-transform:uppercase;letter-spacing:0.5px;color:var(--text-muted);margin-bottom:0.25rem}
@@ -217,6 +226,36 @@ spec:
       {{if .DescribeCommand}}<div class="inv-cmd inv-describe"><code>{{.DescribeCommand}}</code><button class="wr-copy-btn" data-command="{{.DescribeCommand}}" onclick="navigator.clipboard.writeText(this.dataset.command)">Copy</button></div>{{end}}
     </section>
   </div>{{end}}
+
+  {{if .LogsAvailable}}
+  <div class="inv-section" id="container-logs" data-cluster="{{.ClusterName}}" data-namespace="{{.Namespace}}" data-pod="{{.PodName}}" data-issue-type="{{.IssueType}}">
+    <div class="inv-section-hdr">
+      <h2>Container Logs</h2>
+      <span style="font-size:.75rem;color:var(--text-muted);margin-left:auto">Live preview · not stored</span>
+    </div>
+    <div class="inv-log-controls">
+      <div class="inv-log-field">
+        <label for="inv-log-container">Container</label>
+        <select class="inv-log-select" id="inv-log-container">
+          {{range .LogContainers}}
+          <option value="{{.Name}}" data-previous="{{if .PreviousAvailable}}true{{else}}false{{end}}"{{if .Selected}} selected{{end}}>{{.Name}} · {{.Restarts}} restarts</option>
+          {{end}}
+        </select>
+      </div>
+      <div class="inv-log-field">
+        <label for="inv-log-source">Source</label>
+        <select class="inv-log-select" id="inv-log-source">
+          <option value="current"{{if eq .DefaultLogSource "current"}} selected{{end}}>Current container</option>
+          <option id="inv-log-previous" value="previous"{{if eq .DefaultLogSource "previous"}} selected{{end}}>Previous container</option>
+        </select>
+      </div>
+      <button class="inv-log-load" id="inv-log-load" type="button">Load logs</button>
+    </div>
+    <div class="inv-log-meta">Last 200 lines, maximum 256 KiB. Fetched directly from Kubernetes on request and discarded by OpsCart. Application logs may contain sensitive data.</div>
+    <div class="inv-log-error" id="inv-log-error" role="alert" hidden></div>
+    <pre class="inv-log-output" id="inv-log-output" tabindex="0" hidden></pre>
+  </div>
+  {{end}}
 
   {{if .Hints}}
   <div class="inv-section">
@@ -519,6 +558,65 @@ spec:
     if(el)el.textContent=t;
   }
   setInterval(upd,1000);upd();
+})();
+(function(){
+  var panel=document.getElementById('container-logs');
+  if(!panel)return;
+  var container=document.getElementById('inv-log-container');
+  var source=document.getElementById('inv-log-source');
+  var previous=document.getElementById('inv-log-previous');
+  var load=document.getElementById('inv-log-load');
+  var output=document.getElementById('inv-log-output');
+  var error=document.getElementById('inv-log-error');
+
+  function clearLogs(){
+    output.textContent='';
+    output.hidden=true;
+    error.textContent='';
+    error.hidden=true;
+  }
+  function syncSource(){
+    var selected=container.options[container.selectedIndex];
+    previous.disabled=selected.dataset.previous!=='true';
+    if(previous.disabled&&source.value==='previous')source.value='current';
+  }
+  container.addEventListener('change',function(){syncSource();clearLogs();});
+  source.addEventListener('change',clearLogs);
+  syncSource();
+
+  load.addEventListener('click',async function(){
+    clearLogs();
+    load.disabled=true;
+    load.textContent='Loading…';
+    output.hidden=false;
+    output.textContent='Loading logs…';
+    var params=new URLSearchParams({
+      cluster:panel.dataset.cluster,
+      ns:panel.dataset.namespace,
+      pod:panel.dataset.pod,
+      type:panel.dataset.issueType,
+      container:container.value,
+      previous:String(source.value==='previous')
+    });
+    try{
+      var response=await fetch('/api/investigation/logs?'+params.toString(),{
+        credentials:'same-origin',cache:'no-store',headers:{Accept:'application/json'}
+      });
+      var payload=await response.json();
+      if(!response.ok)throw new Error(payload.error||'Logs could not be loaded');
+      output.textContent=payload.logs||'No log output was returned for this container.';
+    }catch(err){
+      output.textContent='';
+      output.hidden=true;
+      error.textContent=err.message||'Logs could not be loaded';
+      error.hidden=false;
+    }finally{
+      load.disabled=false;
+      load.textContent='Load logs';
+    }
+  });
+  window.addEventListener('pagehide',clearLogs);
+  window.addEventListener('pageshow',function(event){if(event.persisted)clearLogs();});
 })();
 </script>
 </body>

--- a/docs/05-Security.md
+++ b/docs/05-Security.md
@@ -4,6 +4,8 @@
 
 OpsCart's Kubernetes RBAC is `get`/`list` only — no create, update, patch, or
 delete verbs on any resource, including `endpointslices` (added in v1.7.1).
+The optional Investigation log preview adds only `get` on the `pods/log`
+subresource and is disabled by default. It does not add a mutation verb.
 There is no code path in the binary that issues a write call to the
 Kubernetes API. This is enforced at the RBAC layer, not just by convention:
 even if the binary were compromised, the ServiceAccount it runs under cannot
@@ -28,6 +30,13 @@ does not store Secret *values*, environment variable contents, or log
 bodies. Treat the database file with the same sensitivity as `kubectl get`
 output — it reveals cluster topology and workload names, not application
 data.
+
+When log preview is enabled, OpsCart fetches a maximum of 200 lines and 256
+KiB from Kubernetes only after a user requests it. The response is marked
+`no-store`; log bodies are not written to SQLite or application logs. They
+are cleared from the page when the user navigates away. Application logs can
+contain secrets, tokens, or personal data, so dashboard access should be
+granted accordingly.
 
 ## Authentication
 

--- a/helm/opscart-watcher/README.md
+++ b/helm/opscart-watcher/README.md
@@ -130,6 +130,28 @@ minikube image load ghcr.io/opscart/opscart-dashboard:dev
 helm upgrade ... --set image.tag=dev --set image.pullPolicy=Never
 ```
 
+## Container log preview
+
+The Investigation page can fetch a bounded live preview for one container at
+a time, including separate application and sidecar containers such as
+`app` and `istio-proxy`. Current and previous container logs are selectable;
+previous logs are available only after that container has restarted.
+
+The feature is disabled by default because application logs may contain
+sensitive data. Enable it with:
+
+```bash
+helm upgrade opscart-watcher ./helm/opscart-watcher \
+  --namespace opscart-system \
+  --reuse-values \
+  --set logs.enabled=true
+```
+
+Enabling it adds only `get` on the `pods/log` subresource. Each request is
+limited to the last 200 lines and 256 KiB. Logs are fetched directly from
+Kubernetes, returned with `Cache-Control: no-store`, and never written to the
+OpsCart SQLite database. There is no combined-container view or download.
+
 ## Configuration
 
 | Parameter | Default | Description |
@@ -141,6 +163,7 @@ helm upgrade ... --set image.tag=dev --set image.pullPolicy=Never
 | `persistence.size` | `1Gi` | PVC size |
 | `persistence.storageClassName` | `""` | StorageClass (empty = cluster default) |
 | `persistence.existingClaim` | `""` | Use a pre-created PVC |
+| `logs.enabled` | `false` | Enable bounded, non-persistent current/previous container log preview |
 | `volumePermissions.enabled` | `false` | Root init container to chown the data volume |
 | `nodeSelector` | `{}` | Pod node selector |
 | `service.type` | `ClusterIP` | Service type |
@@ -152,7 +175,7 @@ helm upgrade ... --set image.tag=dev --set image.pullPolicy=Never
 ## Security
 
 - Runs as non-root (UID 65534)
-- Read-only ClusterRole (get/list only)
+- Read-only ClusterRole (get/list only; optional `pods/log` get)
 - Core scanning and embedded pricing require no cloud credentials. Optional AWS
   public pricing uses workload identity; see
   [Cost Intelligence](../../docs/07-Cost-Intelligence.md).

--- a/helm/opscart-watcher/templates/clusterrole.yaml
+++ b/helm/opscart-watcher/templates/clusterrole.yaml
@@ -35,3 +35,8 @@ rules:
   - apiGroups: ["discovery.k8s.io"]
     resources: ["endpointslices"]
     verbs: ["get", "list"]
+  {{- if .Values.logs.enabled }}
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  {{- end }}

--- a/helm/opscart-watcher/templates/deployment.yaml
+++ b/helm/opscart-watcher/templates/deployment.yaml
@@ -49,6 +49,8 @@ spec:
             {{- end }}
             - name: OPSCART_RETENTION_DAYS
               value: {{ .Values.retentionDays | quote }}
+            - name: OPSCART_LOGS_ENABLED
+              value: {{ .Values.logs.enabled | quote }}
             - name: OPSCART_AUTH_SECRET_NAME
               value: {{ include "opscart-watcher.authSecretName" . | quote }}
           ports:

--- a/helm/opscart-watcher/values.yaml
+++ b/helm/opscart-watcher/values.yaml
@@ -31,6 +31,11 @@ persistence:
 
 retentionDays: 90   # resolved incidents/events older than this are pruned each scan cycle; 0 = keep forever
 
+logs:
+  # Live, bounded current/previous container log preview on Investigation pages.
+  # Log content is returned to the browser and is never stored by OpsCart.
+  enabled: false
+
 resources:
   requests:
     cpu: 100m


### PR DESCRIPTION
## Why

The Investigation page identified the affected pod and recommended log commands, but users still had to leave OpsCart to inspect the actual failure output.

This closes that gap while preserving OpsCart’s read-only and non-persistent security model.

## What changed

* Added an on-demand **Container Logs** section to pod Investigation pages.
* Supports selecting individual containers, including application and sidecar containers such as `app` and `istio-proxy`.
* Supports current and previous container logs.
* Disables the previous-log option when the selected container has not restarted.
* Limits every request to the last 200 lines and 256 KiB.
* Adds a five-second Kubernetes API timeout.
* Adds read-only commands to inspect privileged-container configuration and Linux capabilities.
* Preserves the existing Investigation page design.

## Security and data handling

* Log preview is disabled by default.
* Enable it with `OPSCART_LOGS_ENABLED=true` or Helm `logs.enabled=true`.
* Helm adds `get` on `pods/log` only when the feature is enabled.
* Requests are restricted to active OpsCart investigation targets.
* Pod, namespace, container, cluster, issue type, and source parameters are validated.
* Log bodies are never written to SQLite or OpsCart application logs.
* Responses use `Cache-Control: no-store`.
* Displayed logs are cleared when navigating away.

## Validation

* Added endpoint tests for current and previous logs.
* Added multi-container coverage using `app` and `istio-proxy`.
* Added tests for disabled-by-default behavior.
* Added tests rejecting pods outside the active issue list.
* Added coverage for unavailable previous logs.
* Manually verified current and previous logs using the local binary.
* Verified privileged-container investigation commands render correctly.

## Deliberately out of scope

* Live log streaming or follow mode
* Multi-pod or combined-container aggregation
* Log search
* Log download
* Log persistence
