### PR TITLE
fix: issue-type vocabulary drift disabled OOM/ImagePull scoring and g…

### DIFF
--- a/cmd/opscart-dashboard/issue_type_vocabulary_test.go
+++ b/cmd/opscart-dashboard/issue_type_vocabulary_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/opscart/opscart-k8s-watcher/pkg/store"
+)
+
+// These tests guard against issue-type vocabulary drift: producers emitting
+// one identifier (e.g. "oomkilled") while consumers switch on another
+// (e.g. "oom_killed"), which silently disables scoring and grouping.
+// See v1.11.0 bug: calcIncidentScore, formatGroupedIssue, humanizeWRType
+// checked "oom_killed"/"image_pull" which no producer ever emits.
+
+// TestZombieTypeEmitsCanonicalIssueTypes pins that the War Room producer
+// only emits canonical identifiers. If a new status is added with a
+// non-canonical identifier, this test fails.
+func TestZombieTypeEmitsCanonicalIssueTypes(t *testing.T) {
+	statuses := []string{
+		"OOMKilled",
+		"ImagePullBackOff",
+		"ProbeFailure",
+		"CrashLoopBackOff",
+		"anything-else-falls-back",
+	}
+	for _, status := range statuses {
+		got := zombieTypeForStatus(status)
+		if got != store.CanonicalIssueType(got) {
+			t.Errorf("zombieTypeForStatus(%q) = %q, which is not canonical (canonical: %q)",
+				status, got, store.CanonicalIssueType(got))
+		}
+	}
+}
+
+// TestHumanizeWRTypeAcceptsCanonicalAndAliases pins that the consumer
+// recognizes both the canonical vocabulary and legacy aliases, so no
+// producer output can silently fall through to the default branch.
+func TestHumanizeWRTypeAcceptsCanonicalAndAliases(t *testing.T) {
+	cases := map[string]string{
+		// canonical (what producers emit today)
+		store.IssueCrashLoop:            "Pod crash looping",
+		store.IssueOOMKilled:            "Pod OOMKilled",
+		store.IssueImagePullBackOff:     "Image pull failure",
+		store.IssueUnprotectedNamespace: "Namespace",
+		// legacy aliases (must normalize, not fall through)
+		"oom_killed": "Pod OOMKilled",
+		"image_pull": "Image pull failure",
+	}
+	for input, want := range cases {
+		if got := humanizeWRType(input); got != want {
+			t.Errorf("humanizeWRType(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+// TestFormatGroupedIssueUsesCanonicalTitles pins that OOMKilled and
+// ImagePullBackOff groups produce their dedicated titles instead of
+// falling through to the generic default branch (the v1.11.0 bug).
+func TestFormatGroupedIssueUsesCanonicalTitles(t *testing.T) {
+	grp := []warRoomIssue{
+		{Namespace: "payments", Resource: "api-7f9c4d5b6-abcde", Type: store.IssueOOMKilled, Severity: "critical"},
+		{Namespace: "payments", Resource: "api-7f9c4d5b6-fghij", Type: store.IssueOOMKilled, Severity: "critical"},
+	}
+	title, _, countText, _ := formatGroupedIssue(store.IssueOOMKilled, "critical", grp)
+	if title != "2 pods OOMKilled" {
+		t.Errorf("OOMKilled group title = %q, want %q", title, "2 pods OOMKilled")
+	}
+	if countText != "2 pods" {
+		t.Errorf("OOMKilled group countText = %q, want %q", countText, "2 pods")
+	}
+
+	grp2 := []warRoomIssue{
+		{Namespace: "web", Resource: "frontend-abc123-xyzzy", Type: store.IssueImagePullBackOff, Severity: "high"},
+	}
+	title2, _, _, _ := formatGroupedIssue(store.IssueImagePullBackOff, "high", grp2)
+	if title2 != "1 ImagePullBackOff failure" {
+		t.Errorf("ImagePullBackOff group title = %q, want %q", title2, "1 ImagePullBackOff failure")
+	}
+}

--- a/cmd/opscart-dashboard/server.go
+++ b/cmd/opscart-dashboard/server.go
@@ -431,14 +431,14 @@ func calcIncidentScore(scan *clusterScan) (score int, color string, label string
 	unprotectedNS := 0
 
 	for _, issue := range issues {
-		switch issue.Type {
-		case "crash_loop":
+		switch store.CanonicalIssueType(issue.Type) {
+		case store.IssueCrashLoop:
 			crashLoops++
-		case "image_pull":
+		case store.IssueImagePullBackOff:
 			imagePulls++
-		case "oom_killed":
+		case store.IssueOOMKilled:
 			oomKills++
-		case "unprotected_namespace":
+		case store.IssueUnprotectedNamespace:
 			unprotectedNS++
 		}
 	}
@@ -1488,7 +1488,7 @@ func formatGroupedIssue(issueType, severity string, grp []warRoomIssue) (title, 
 	nsCount := len(namespaces)
 	moreThan3 := count - 3
 
-	switch issueType {
+	switch store.CanonicalIssueType(issueType) {
 	case "Ready", "DiskPressure", "MemoryPressure", "PIDPressure", "NetworkUnavailable":
 		if count == 1 {
 			title = fmt.Sprintf("%s on %s", nodeConditionLabel(grp[0]), grp[0].Resource)
@@ -1515,11 +1515,11 @@ func formatGroupedIssue(issueType, severity string, grp []warRoomIssue) (title, 
 		}
 		countText = fmt.Sprintf("%d pod%s", count, pluralS(count))
 		action = fmt.Sprintf("kubectl logs %s -n %s", samples[0], grp[0].Namespace)
-	case "oom_killed":
+	case store.IssueOOMKilled:
 		title = fmt.Sprintf("%d pod%s OOMKilled", count, pluralS(count))
 		subtitle = fmt.Sprintf("Out of memory across %d namespace%s", nsCount, pluralS(nsCount))
 		countText = fmt.Sprintf("%d pod%s", count, pluralS(count))
-	case "image_pull":
+	case store.IssueImagePullBackOff:
 		title = fmt.Sprintf("%d ImagePullBackOff failure%s", count, pluralS(count))
 		subtitle = fmt.Sprintf("Image pull failures across %d namespace%s", nsCount, pluralS(nsCount))
 		countText = fmt.Sprintf("%d pod%s", count, pluralS(count))
@@ -1549,14 +1549,14 @@ func formatGroupedIssue(issueType, severity string, grp []warRoomIssue) (title, 
 }
 
 func humanizeWRType(t string) string {
-	switch t {
-	case "crash_loop":
+	switch store.CanonicalIssueType(t) {
+	case store.IssueCrashLoop:
 		return "Pod crash looping"
-	case "oom_killed":
+	case store.IssueOOMKilled:
 		return "Pod OOMKilled"
-	case "image_pull":
+	case store.IssueImagePullBackOff:
 		return "Image pull failure"
-	case "unprotected_namespace":
+	case store.IssueUnprotectedNamespace:
 		return "Namespace"
 	default:
 		return t

--- a/pkg/store/issue_type.go
+++ b/pkg/store/issue_type.go
@@ -2,6 +2,21 @@ package store
 
 import "strings"
 
+// Canonical issue-type identifiers. Producers and consumers must use these
+// constants (or normalize raw input through CanonicalIssueType) instead of
+// string literals, so the compiler catches vocabulary drift between the
+// scanner, dashboard, CLI, and store layers.
+const (
+	IssueCrashLoop            = "crash_loop"
+	IssueProbeFailure         = "probe_failure"
+	IssueOOMKilled            = "oomkilled"
+	IssueImagePullBackOff     = "image_pull_backoff"
+	IssueHighRestartCount     = "high_restart_count"
+	IssuePrivilegedContainer  = "privileged_container"
+	IssueUnprotectedNamespace = "unprotected_namespace"
+	IssueIdleNamespace        = "idle_namespace"
+)
+
 // CanonicalIssueType returns the durable issue type used by new writes.
 // Unknown issue types are intentionally preserved verbatim.
 func CanonicalIssueType(issueType string) string {


### PR DESCRIPTION
…rouping

Producers emitted canonical issue types (oomkilled, image_pull_backoff) but calcIncidentScore, formatGroupedIssue, and humanizeWRType in server.go switched on a dead vocabulary (oom_killed, image_pull) that no producer emitted. OOM and ImagePull penalties never applied to the incident score, and their War Room groups fell through to generic titles instead of dedicated ones.

Fix: exported canonical constants in pkg/store/issue_type.go and normalized all three consumers through store.CanonicalIssueType() before matching, so future drift is compile-time safe rather than a silent runtime miss.

Added regression tests pinning that producers emit canonical types, consumers accept canonical + legacy aliases, and OOM/ImagePull groups render their dedicated titles.