### PR TITLE
fix: active Ingress/HPA failures no longer hidden behind minAgeDays

### DIFF
--- a/cmd/opscart-dashboard/pages.go
+++ b/cmd/opscart-dashboard/pages.go
@@ -1253,10 +1253,18 @@ func buildWasteReviewRows(a *analyzer.WasteAudit, idle []analyzer.StalePod) (res
 		drift = append(drift, wasteReviewRow{"Zero-replica workload", item.Name, item.Namespace, item.Reason, fmt.Sprintf("%dd", item.AgeDays), "—", "Intent review", wasteCommand(strings.ToLower(item.Kind), item.Name, item.Namespace), item.Score})
 	}
 	for _, item := range a.BrokenIngresses {
-		drift = append(drift, wasteReviewRow{"Broken ingress", item.Name, item.Namespace, item.Reason, fmt.Sprintf("%dd", item.AgeDays), "—", "Configuration review", wasteCommand("ingress", item.Name, item.Namespace), item.Score})
+		status := "Active routing failure"
+		if !item.IsActive {
+			status = "Configuration review"
+		}
+		drift = append(drift, wasteReviewRow{"Broken ingress", item.Name, item.Namespace, item.Reason, fmt.Sprintf("%dd", item.AgeDays), "—", status, wasteCommand("ingress", item.Name, item.Namespace), item.Score})
 	}
 	for _, item := range a.MisconfiguredHPAs {
-		drift = append(drift, wasteReviewRow{"Misconfigured HPA", item.Name, item.Namespace, item.Reason, fmt.Sprintf("%dd", item.AgeDays), "—", "Configuration review", wasteCommand("hpa", item.Name, item.Namespace), item.Score})
+		status := "Configuration review"
+		if item.IsActive {
+			status = "Active autoscaling failure"
+		}
+		drift = append(drift, wasteReviewRow{"Misconfigured HPA", item.Name, item.Namespace, item.Reason, fmt.Sprintf("%dd", item.AgeDays), "—", status, wasteCommand("hpa", item.Name, item.Namespace), item.Score})
 	}
 	for _, item := range a.OldReplicaSets {
 		housekeeping = append(housekeeping, wasteReviewRow{"Old ReplicaSet", item.Name, item.Namespace, item.Reason, fmt.Sprintf("%dd", item.AgeDays), "—", "Housekeeping; excluded from total", wasteCommand("replicaset", item.Name, item.Namespace), item.Score})

--- a/pkg/analyzer/waste.go
+++ b/pkg/analyzer/waste.go
@@ -175,6 +175,9 @@ type BrokenIngress struct {
 	Hosts     []string
 	Reason    string // which backend is missing
 	Score     float64
+	// IsActive is always true for BrokenIngress: it is only ever
+	// produced from currently-observed missing endpoints, never age-gated.
+	IsActive bool
 }
 
 // ----------------------------------------------------------------
@@ -191,6 +194,9 @@ type MisconfiguredHPA struct {
 	Condition   string // ScalingDisabled, MetricNotAvailable, AlwaysAtMin
 	Reason      string
 	Score       float64
+	// IsActive is true for a currently K8s-reported ScalingActive=False
+	// condition, false for the age-gated AlwaysAtMin tuning candidate.
+	IsActive bool
 }
 
 // ================================================================
@@ -281,6 +287,24 @@ func (a *WasteAudit) addDetectorWarning(category string, err error) {
 		Category: category,
 		Error:    err.Error(),
 	})
+}
+
+// formatDurationSince renders the time elapsed since t in the coarsest
+// meaningful unit, so a failure that started 2 hours ago reads "2h", not
+// the misleading "0 day(s)" that integer-day truncation would produce.
+func formatDurationSince(t time.Time) string {
+	elapsed := time.Since(t)
+	if elapsed < time.Hour {
+		mins := int(elapsed.Minutes())
+		if mins < 1 {
+			mins = 1
+		}
+		return fmt.Sprintf("%dm", mins)
+	}
+	if elapsed < 24*time.Hour {
+		return fmt.Sprintf("%dh", int(elapsed.Hours()))
+	}
+	return fmt.Sprintf("%dd", int(elapsed.Hours()/24))
 }
 
 // ================================================================
@@ -1108,13 +1132,14 @@ func (w *WasteAuditor) detectBrokenIngresses(audit *WasteAudit, filterNamespace 
 		}
 
 		ageDays := int(now.Sub(ing.CreationTimestamp.Time).Hours() / 24)
-		if ageDays < w.minAgeDays {
-			continue
-		}
+
+		// No age gate: a backend with zero ready endpoints is a current
+		// condition, not something that needs time to become meaningful.
+		// Age-gating this finding hides a currently-broken route for the
+		// entire gate window.
 
 		missingBackends := []string{}
 
-		// Check each rule's backend service exists and has endpoints
 		for _, rule := range ing.Spec.Rules {
 			if rule.HTTP == nil {
 				continue
@@ -1124,19 +1149,29 @@ func (w *WasteAuditor) detectBrokenIngresses(audit *WasteAudit, filterNamespace 
 					continue
 				}
 				svcName := path.Backend.Service.Name
-				hasReady, _ := kube.ServiceHasReadyEndpoints(w.ctx, w.clientset, ing.Namespace, svcName)
+				hasReady, err := kube.ServiceHasReadyEndpoints(w.ctx, w.clientset, ing.Namespace, svcName)
+				if err != nil {
+					// An API failure means endpoint status is UNKNOWN, not
+					// zero. Surface it as a detector warning rather than
+					// fabricating an outage finding.
+					audit.addDetectorWarning("Broken ingresses",
+						fmt.Errorf("checking endpoints for %s/%s (backend of ingress %s): %w", ing.Namespace, svcName, ing.Name, err))
+					continue
+				}
 				if !hasReady {
-					missingBackends = append(missingBackends, fmt.Sprintf("%s → %s (no endpoints)", rule.Host, svcName))
+					missingBackends = append(missingBackends, fmt.Sprintf("%s → %s (no ready endpoints)", rule.Host, svcName))
 				}
 			}
 		}
 
-		// Also check default backend
 		if ing.Spec.DefaultBackend != nil && ing.Spec.DefaultBackend.Service != nil {
 			svcName := ing.Spec.DefaultBackend.Service.Name
-			hasReady, _ := kube.ServiceHasReadyEndpoints(w.ctx, w.clientset, ing.Namespace, svcName)
-			if !hasReady {
-				missingBackends = append(missingBackends, fmt.Sprintf("default-backend → %s (no endpoints)", svcName))
+			hasReady, err := kube.ServiceHasReadyEndpoints(w.ctx, w.clientset, ing.Namespace, svcName)
+			if err != nil {
+				audit.addDetectorWarning("Broken ingresses",
+					fmt.Errorf("checking endpoints for %s/%s (default backend of ingress %s): %w", ing.Namespace, svcName, ing.Name, err))
+			} else if !hasReady {
+				missingBackends = append(missingBackends, fmt.Sprintf("default-backend → %s (no ready endpoints)", svcName))
 			}
 		}
 
@@ -1148,12 +1183,11 @@ func (w *WasteAuditor) detectBrokenIngresses(audit *WasteAudit, filterNamespace 
 				}
 			}
 
+			// Evidence-only wording: we observed zero ready endpoints, not
+			// actual request failures.
 			reason := fmt.Sprintf(
-				"Ingress is %d days old and has %d backend(s) with no active endpoints: %s. "+
-					"Traffic arriving at %v will return errors.",
-				ageDays, len(missingBackends),
+				"Ingress backend currently has no ready endpoints for: %s.",
 				strings.Join(missingBackends, "; "),
-				hosts,
 			)
 
 			audit.BrokenIngresses = append(audit.BrokenIngresses, BrokenIngress{
@@ -1162,7 +1196,8 @@ func (w *WasteAuditor) detectBrokenIngresses(audit *WasteAudit, filterNamespace 
 				AgeDays:   ageDays,
 				Hosts:     hosts,
 				Reason:    reason,
-				Score:     float64(ageDays)*0.4 + float64(len(missingBackends))*10,
+				Score:     float64(len(missingBackends)) * 10,
+				IsActive:  true,
 			})
 		}
 	}
@@ -1220,23 +1255,30 @@ func (w *WasteAuditor) detectMisconfiguredHPAs(audit *WasteAudit, filterNamespac
 		}
 
 		ageDays := int(now.Sub(hpa.CreationTimestamp.Time).Hours() / 24)
-		if ageDays < w.minAgeDays {
-			continue
-		}
 
 		minReplicas := int32(1)
 		if hpa.Spec.MinReplicas != nil {
 			minReplicas = *hpa.Spec.MinReplicas
 		}
 
-		// Check HPA conditions for issues
+		// A currently K8s-reported ScalingActive=False is a live condition —
+		// no age gate. Duration comes from the condition's own transition
+		// time (rendered in the coarsest meaningful unit — minutes, hours,
+		// or days), never substituted with the HPA object's age.
+		scalingInactive := false
 		for _, cond := range hpa.Status.Conditions {
 			if cond.Type == "ScalingActive" && cond.Status == "False" {
+				scalingInactive = true
+
+				var durationClause string
+				if !cond.LastTransitionTime.IsZero() {
+					durationClause = fmt.Sprintf(" for %s", formatDurationSince(cond.LastTransitionTime.Time))
+				}
+
 				reason := fmt.Sprintf(
-					"HPA targeting '%s' has been inactive for %d days. "+
-						"Condition: %s - %s. "+
-						"The HPA exists but cannot function, so autoscaling is disabled effectively.",
-					hpa.Spec.ScaleTargetRef.Name, ageDays,
+					"HPA targeting '%s' currently reports ScalingActive=False%s (reason: %s - %s). "+
+						"Autoscaling is not functioning while this condition persists.",
+					hpa.Spec.ScaleTargetRef.Name, durationClause,
 					cond.Reason, cond.Message,
 				)
 				audit.MisconfiguredHPAs = append(audit.MisconfiguredHPAs, MisconfiguredHPA{
@@ -1248,21 +1290,29 @@ func (w *WasteAuditor) detectMisconfiguredHPAs(audit *WasteAudit, filterNamespac
 					AgeDays:     ageDays,
 					Condition:   string(cond.Reason),
 					Reason:      reason,
-					Score:       float64(ageDays) * 0.3,
+					Score:       100, // active failure — ranks above tuning candidates
+					IsActive:    true,
 				})
 				break
 			}
 		}
 
-		// HPA where current == min for a very long time (not scaling up)
-		if hpa.Status.CurrentReplicas == minReplicas &&
+		// AlwaysAtMin is a point-in-time snapshot (current==desired==min at
+		// THIS scan), not observed history — it must not claim the HPA
+		// "never scaled up". Kept age-gated: this is a tuning-review
+		// candidate, not a proven active failure. Suppressed when the same
+		// HPA already produced a ScalingActive=False finding this scan, so
+		// one broken HPA doesn't produce two overlapping findings.
+		if !scalingInactive &&
+			ageDays >= w.minAgeDays &&
+			hpa.Status.CurrentReplicas == minReplicas &&
 			hpa.Status.DesiredReplicas == minReplicas &&
 			ageDays > 30 {
 			reason := fmt.Sprintf(
-				"HPA targeting '%s' has been at minReplicas (%d) for %d days and never scaled up. "+
-					"Either the workload has no traffic/load, the metric source is wrong, "+
-					"or the HPA thresholds are set too high.",
-				hpa.Spec.ScaleTargetRef.Name, minReplicas, ageDays,
+				"HPA is %d days old and currently has both current and desired replicas "+
+					"equal to minReplicas (%d) at this scan. Review scaling history and demand "+
+					"before changing configuration.",
+				ageDays, minReplicas,
 			)
 			audit.MisconfiguredHPAs = append(audit.MisconfiguredHPAs, MisconfiguredHPA{
 				Name:        hpa.Name,
@@ -1274,6 +1324,7 @@ func (w *WasteAuditor) detectMisconfiguredHPAs(audit *WasteAudit, filterNamespac
 				Condition:   "AlwaysAtMin",
 				Reason:      reason,
 				Score:       float64(ageDays) * 0.2,
+				IsActive:    false,
 			})
 		}
 	}
@@ -1623,7 +1674,11 @@ func printBrokenIngresses(audit *WasteAudit) {
 	fmt.Printf("🟡 INGRESSES WITH MISSING BACKENDS (%d)\n", len(audit.BrokenIngresses))
 	fmt.Println("═══════════════════════════════════════════════════════════")
 	for _, ing := range audit.BrokenIngresses {
-		fmt.Printf("\n  🌐 %s (namespace: %s)\n", ing.Name, ing.Namespace)
+		activeNote := ""
+		if ing.IsActive {
+			activeNote = " 🔴 ACTIVE NOW"
+		}
+		fmt.Printf("\n  🌐 %s (namespace: %s)%s\n", ing.Name, ing.Namespace, activeNote)
 		fmt.Printf("     Hosts:   %s\n", strings.Join(ing.Hosts, ", "))
 		fmt.Printf("     Age:     %d days\n", ing.AgeDays)
 		fmt.Printf("     Finding: %s\n", ing.Reason)
@@ -1640,7 +1695,11 @@ func printMisconfiguredHPAs(audit *WasteAudit) {
 	fmt.Printf("🟢 MISCONFIGURED HPAs (%d)\n", len(audit.MisconfiguredHPAs))
 	fmt.Println("═══════════════════════════════════════════════════════════")
 	for _, hpa := range audit.MisconfiguredHPAs {
-		fmt.Printf("\n  📈 %s → %s (namespace: %s)\n", hpa.Name, hpa.TargetName, hpa.Namespace)
+		activeNote := ""
+		if hpa.IsActive {
+			activeNote = " 🔴 ACTIVE NOW"
+		}
+		fmt.Printf("\n  📈 %s → %s (namespace: %s)%s\n", hpa.Name, hpa.TargetName, hpa.Namespace, activeNote)
 		fmt.Printf("     Replicas: min=%d max=%d  Condition: %s\n", hpa.MinReplicas, hpa.MaxReplicas, hpa.Condition)
 		fmt.Printf("     Age:      %d days\n", hpa.AgeDays)
 		fmt.Printf("     Finding:  %s\n", hpa.Reason)

--- a/pkg/analyzer/waste_test.go
+++ b/pkg/analyzer/waste_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 	"time"
 
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -485,5 +487,207 @@ func TestEventsFetchedOncePerNamespaceNotPerPod(t *testing.T) {
 
 	if eventListCalls != 1 {
 		t.Errorf("events List called %d times for 3 pods in one namespace, want exactly 1 (must be batched per-namespace, not per-pod)", eventListCalls)
+	}
+}
+
+// ── Active-vs-age-gated malfunction detection ──────────────────────────────
+//
+// Currently-broken resources (Ingress backends with no ready endpoints,
+// HPAs reporting ScalingActive=False) must be reported immediately, not
+// hidden behind minAgeDays. Age-gating remains correct for findings
+// inferred from a sustained pattern (AlwaysAtMin), which needs time to
+// become a meaningful signal. The Service-availability detector (matched
+// pods with no ready endpoints) was deliberately deferred to a separate PR
+// pending a batched EndpointSlice query design — see PR discussion on
+// per-Service API call cost at scale.
+
+func TestFormatDurationSinceSubDay(t *testing.T) {
+	cases := []struct {
+		ago  time.Duration
+		want string
+	}{
+		{30 * time.Second, "1m"},
+		{45 * time.Minute, "45m"},
+		{2 * time.Hour, "2h"},
+		{25 * time.Hour, "1d"},
+	}
+	for _, c := range cases {
+		got := formatDurationSince(time.Now().Add(-c.ago))
+		if got != c.want {
+			t.Errorf("formatDurationSince(-%s) = %q, want %q", c.ago, got, c.want)
+		}
+	}
+}
+
+func ingressFixture(name, namespace, host, svcName string, ageDays int) *networkingv1.Ingress {
+	pathType := networkingv1.PathTypePrefix
+	return &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(-time.Duration(ageDays) * 24 * time.Hour)},
+		},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{{
+				Host: host,
+				IngressRuleValue: networkingv1.IngressRuleValue{
+					HTTP: &networkingv1.HTTPIngressRuleValue{
+						Paths: []networkingv1.HTTPIngressPath{{
+							PathType: &pathType,
+							Backend: networkingv1.IngressBackend{
+								Service: &networkingv1.IngressServiceBackend{
+									Name: svcName,
+									Port: networkingv1.ServiceBackendPort{Number: 80},
+								},
+							},
+						}},
+					},
+				},
+			}},
+		},
+	}
+}
+
+func TestBrokenIngressNotAgeGated(t *testing.T) {
+	// Ingress created today (age 0), backend has zero ready endpoints.
+	// Before the fix, minAgeDays=7 hid this for a week.
+	ing := ingressFixture("checkout", "shop", "checkout.example.com", "checkout-svc", 0)
+	svc := oldService("checkout-svc", "shop", map[string]string{"app": "checkout"}, corev1.ServiceTypeClusterIP)
+	svc.CreationTimestamp = metav1.Time{Time: time.Now()}
+
+	wa := newTestAuditor(7, ing, svc)
+	audit := &WasteAudit{}
+	if err := wa.detectBrokenIngresses(audit, ""); err != nil {
+		t.Fatalf("detectBrokenIngresses: %v", err)
+	}
+	if len(audit.BrokenIngresses) != 1 {
+		t.Fatalf("broken ingresses = %d, want 1 (must not be age-gated): %+v", len(audit.BrokenIngresses), audit.BrokenIngresses)
+	}
+	got := audit.BrokenIngresses[0]
+	if !got.IsActive {
+		t.Errorf("broken ingress finding should be marked IsActive")
+	}
+	if strings.Contains(got.Reason, "will fail") || strings.Contains(got.Reason, "will return errors") {
+		t.Errorf("reason overclaims an observed request outcome: %q", got.Reason)
+	}
+}
+
+func TestBrokenIngressEndpointCheckErrorSurfacesAsWarningNotFalsePositive(t *testing.T) {
+	ing := ingressFixture("checkout", "shop", "checkout.example.com", "checkout-svc", 0)
+	svc := oldService("checkout-svc", "shop", map[string]string{"app": "checkout"}, corev1.ServiceTypeClusterIP)
+
+	wa := newTestAuditor(7, ing, svc)
+	wa.clientset.(*fake.Clientset).PrependReactor("list", "endpointslices", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, context.DeadlineExceeded
+	})
+
+	audit := &WasteAudit{}
+	if err := wa.detectBrokenIngresses(audit, ""); err != nil {
+		t.Fatalf("detectBrokenIngresses: %v", err)
+	}
+	if len(audit.BrokenIngresses) != 0 {
+		t.Fatalf("an EndpointSlice API error must not fabricate a broken-ingress finding: %+v", audit.BrokenIngresses)
+	}
+	found := false
+	for _, w := range audit.DetectorWarnings {
+		if w.Category == "Broken ingresses" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a detector warning for the endpoint-check failure, got: %+v", audit.DetectorWarnings)
+	}
+}
+
+func hpaFixture(name, namespace string, ageDays int, minReplicas, currentReplicas, desiredReplicas int32, conditions []autoscalingv2.HorizontalPodAutoscalerCondition) *autoscalingv2.HorizontalPodAutoscaler {
+	return &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(-time.Duration(ageDays) * 24 * time.Hour)},
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{Kind: "Deployment", Name: "checkout"},
+			MinReplicas:    &minReplicas,
+			MaxReplicas:    10,
+		},
+		Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+			CurrentReplicas: currentReplicas,
+			DesiredReplicas: desiredReplicas,
+			Conditions:      conditions,
+		},
+	}
+}
+
+func TestHPAScalingInactiveNotAgeGated(t *testing.T) {
+	hpa := hpaFixture("checkout-hpa", "shop", 0, 1, 1, 1, []autoscalingv2.HorizontalPodAutoscalerCondition{
+		{Type: "ScalingActive", Status: "False", Reason: "FailedGetResourceMetric", Message: "unable to get metrics",
+			LastTransitionTime: metav1.Time{Time: time.Now().Add(-2 * time.Hour)}},
+	})
+	wa := newTestAuditor(7, hpa)
+	audit := &WasteAudit{}
+	if err := wa.detectMisconfiguredHPAs(audit, ""); err != nil {
+		t.Fatalf("detectMisconfiguredHPAs: %v", err)
+	}
+	if len(audit.MisconfiguredHPAs) != 1 {
+		t.Fatalf("misconfigured HPAs = %d, want 1 (ScalingActive=False must not be age-gated): %+v", len(audit.MisconfiguredHPAs), audit.MisconfiguredHPAs)
+	}
+	got := audit.MisconfiguredHPAs[0]
+	if !got.IsActive {
+		t.Errorf("ScalingActive=False finding should be marked IsActive")
+	}
+	if !strings.Contains(got.Reason, "for 2h") {
+		t.Errorf("reason should report real failure duration (2h), got: %q", got.Reason)
+	}
+	if strings.Contains(got.Reason, "inactive for 0 days") {
+		t.Errorf("reason must not substitute object age for failure duration: %q", got.Reason)
+	}
+}
+
+func TestHPAAlwaysAtMinStaysAgeGatedAndDoesNotOverclaimHistory(t *testing.T) {
+	hpa := hpaFixture("checkout-hpa", "shop", 35, 1, 1, 1, nil)
+	wa := newTestAuditor(7, hpa)
+	audit := &WasteAudit{}
+	if err := wa.detectMisconfiguredHPAs(audit, ""); err != nil {
+		t.Fatalf("detectMisconfiguredHPAs: %v", err)
+	}
+	if len(audit.MisconfiguredHPAs) != 1 {
+		t.Fatalf("misconfigured HPAs = %d, want 1: %+v", len(audit.MisconfiguredHPAs), audit.MisconfiguredHPAs)
+	}
+	got := audit.MisconfiguredHPAs[0]
+	if got.IsActive {
+		t.Errorf("AlwaysAtMin is a tuning candidate, not an active failure")
+	}
+	if strings.Contains(got.Reason, "never scaled up") {
+		t.Errorf("reason overclaims history the detector never observed: %q", got.Reason)
+	}
+}
+
+func TestHPAAlwaysAtMinSuppressedWhenScalingActiveAlreadyFired(t *testing.T) {
+	hpa := hpaFixture("checkout-hpa", "shop", 35, 1, 1, 1, []autoscalingv2.HorizontalPodAutoscalerCondition{
+		{Type: "ScalingActive", Status: "False", Reason: "FailedGetResourceMetric", Message: "unable to get metrics"},
+	})
+	wa := newTestAuditor(7, hpa)
+	audit := &WasteAudit{}
+	if err := wa.detectMisconfiguredHPAs(audit, ""); err != nil {
+		t.Fatalf("detectMisconfiguredHPAs: %v", err)
+	}
+	if len(audit.MisconfiguredHPAs) != 1 {
+		t.Fatalf("expected exactly one finding for one broken HPA (no AlwaysAtMin duplicate), got %d: %+v", len(audit.MisconfiguredHPAs), audit.MisconfiguredHPAs)
+	}
+	if audit.MisconfiguredHPAs[0].Condition == "AlwaysAtMin" {
+		t.Errorf("ScalingActive=False finding should take precedence, not AlwaysAtMin")
+	}
+}
+
+func TestHPAYoungAndHealthyProducesNoFinding(t *testing.T) {
+	hpa := hpaFixture("checkout-hpa", "shop", 1, 1, 3, 3, nil)
+	wa := newTestAuditor(7, hpa)
+	audit := &WasteAudit{}
+	if err := wa.detectMisconfiguredHPAs(audit, ""); err != nil {
+		t.Fatalf("detectMisconfiguredHPAs: %v", err)
+	}
+	if len(audit.MisconfiguredHPAs) != 0 {
+		t.Fatalf("healthy scaling HPA should produce no finding: %+v", audit.MisconfiguredHPAs)
 	}
 }


### PR DESCRIPTION
detectBrokenIngresses and detectMisconfiguredHPAs applied the same 7-day minAgeDays gate used for true waste findings (idle PVCs, unused Services) to currently-broken resources. A backend with zero ready endpoints, or an HPA Kubernetes itself reports as ScalingActive=False, is broken right now — age-gating it just delays discovery for up to a week.

Fixes:
- Broken Ingress: no age gate. EndpointSlice API errors now produce a DetectorWarning instead of a false "broken" finding (previously hasReady, _ := ... silently discarded the error).
- HPA ScalingActive=False: no age gate. Failure duration now comes from the condition's own LastTransitionTime via a new formatDurationSince helper (minutes/hours/days), never substituted with the HPA object's age as it was before.
- HPA AlwaysAtMin: age gate kept (genuine tuning-review signal, not a live break). Wording no longer claims "never scaled up" — the detector only has a point-in-time snapshot. Suppressed when the same HPA already produced a ScalingActive=False finding, so one broken HPA doesn't produce two overlapping findings.
- New IsActive field on BrokenIngress/MisconfiguredHPA. CLI marks active findings "ACTIVE NOW"; dashboard Waste page now shows "Active routing failure" / "Active autoscaling failure" instead of "Configuration review" for these.

Deferred to a separate PR: a Service-availability detector (matched pods with no ready endpoints) was considered but pulled — at ~500 Services per AKS cluster with a 60s dashboard refresh, a per-Service EndpointSlice call is meaningful API load and a new failure mode. Needs a batched query design first. detectOrphanedServices is untouched in this PR.

Validated on a live cluster: a fresh Ingress with a nonexistent backend and a fresh HPA with no metrics-server both appeared immediately (age 0d) with correct labels and duration wording.