### PR TITLE
fix: persisted node incident severity now matches War Room display

### DIFF
--- a/cmd/opscart-dashboard/version.go
+++ b/cmd/opscart-dashboard/version.go
@@ -1,3 +1,3 @@
 package main
 
-const Version = "v1.10.3"
+const Version = "v1.11.0"

--- a/deploy/dashboard.yaml
+++ b/deploy/dashboard.yaml
@@ -119,7 +119,7 @@ spec:
 
       containers:
         - name: dashboard
-          image: ghcr.io/opscart/opscart-dashboard:v1.7.0
+          image: ghcr.io/opscart/opscart-dashboard:v1.11.0
           imagePullPolicy: Always
           args:
             - "--port=8080"

--- a/pkg/scanner/node_health.go
+++ b/pkg/scanner/node_health.go
@@ -15,8 +15,13 @@ import (
 )
 
 const (
-	nodeConditionPersistenceSeverity = "low"
-	nodeIncidentScope                = "cluster"
+	nodeIncidentScope = "cluster"
+	// fallbackNodeConditionSeverity is used only for a condition type
+	// models.NodeConditionSeverity doesn't recognize, so persistence never
+	// fails outright on an unexpected/future condition type. It must not be
+	// used for any condition the classifier already knows about — those
+	// take their real severity below.
+	fallbackNodeConditionSeverity = "low"
 )
 
 type nodeConditionDetails struct {
@@ -49,12 +54,22 @@ func NodeConditionIncidents(findings []models.NodeConditionFinding) []store.Inci
 			CorrelationSemantics: "correlated_by_node_placement",
 			CorrelatedWorkloads:  finding.CorrelatedWorkloads,
 		})
+		// Persisted severity must match what the War Room already displays
+		// for this same finding (models.NodeConditionSeverity — see
+		// nodeWarRoomSeverity in the dashboard). A Ready=False node shown
+		// as critical live must not be persisted as "low"; that silently
+		// corrupts incident listings, historical counts, and scoring that
+		// read the stored value instead of re-deriving it.
+		severity, ok := models.NodeConditionSeverity(finding.ConditionType)
+		if !ok {
+			severity = fallbackNodeConditionSeverity
+		}
 		incidents = append(incidents, store.IncidentData{
 			Fingerprint: store.Fingerprint(nodeIncidentScope, "Node", finding.NodeName, finding.ConditionType),
 			Namespace:   "",
 			Resource:    finding.NodeName,
 			IssueType:   finding.ConditionType,
-			Severity:    nodeConditionPersistenceSeverity,
+			Severity:    severity,
 			DetailsJSON: string(details),
 		})
 	}

--- a/pkg/scanner/node_health_test.go
+++ b/pkg/scanner/node_health_test.go
@@ -245,8 +245,8 @@ func TestNodeConditionIncidentsIdentityAndMutableEvidence(t *testing.T) {
 	if first.Fingerprint != "cluster/Node/worker-21/DiskPressure" || second.Fingerprint != first.Fingerprint {
 		t.Fatalf("fingerprints changed with evidence: first=%q second=%q", first.Fingerprint, second.Fingerprint)
 	}
-	if first.Severity != "low" || first.Namespace != "" || first.Resource != "worker-21" || first.IssueType != "DiskPressure" {
-		t.Fatalf("unexpected incident mapping: %+v", first)
+	if first.Severity != "high" || first.Namespace != "" || first.Resource != "worker-21" || first.IssueType != "DiskPressure" {
+		t.Fatalf("unexpected incident mapping (DiskPressure must use models.NodeConditionSeverity, not a hardcoded value): %+v", first)
 	}
 	if first.DetailsJSON == second.DetailsJSON {
 		t.Fatal("mutable evidence did not change details_json")
@@ -404,5 +404,41 @@ func TestNodeHealthProductionFlowPersistsStableIdentityAcrossPlacementChurn(t *t
 	events, err := db.GetIncidentTimeline("cluster-a", first.Fingerprint)
 	if err != nil || len(events) != 1 || events[0].EventType != "DETECTED" {
 		t.Fatalf("evidence churn emitted lifecycle events: %+v err=%v", events, err)
+	}
+}
+
+// TestNodeConditionIncidentsSeverityMatchesDisplayClassifier guards the
+// severity-consistency bug: a node condition shown as critical in the War
+// Room (via models.NodeConditionSeverity) must be persisted with that same
+// severity, not a hardcoded value. Previously every node incident was
+// persisted as "low" regardless of condition type, so a Ready=False node —
+// critical everywhere it was displayed — silently showed as low severity
+// in incident listings, historical counts, and any scoring that reads the
+// stored value.
+func TestNodeConditionIncidentsSeverityMatchesDisplayClassifier(t *testing.T) {
+	cases := []struct {
+		conditionType string
+		wantSeverity  string
+	}{
+		{"Ready", "critical"},
+		{"DiskPressure", "high"},
+		{"MemoryPressure", "high"},
+		{"PIDPressure", "high"},
+		{"NetworkUnavailable", "high"},
+		// A condition type the classifier doesn't recognize must not fail
+		// persistence outright; it falls back rather than matching any of
+		// the known severities.
+		{"SomeFutureConditionType", "low"},
+	}
+	for _, c := range cases {
+		finding := models.NodeConditionFinding{
+			NodeName: "worker-1", ConditionType: c.conditionType,
+			ConditionStatus: "True", Reason: c.conditionType,
+		}
+		got := NodeConditionIncidents([]models.NodeConditionFinding{finding})[0]
+		if got.Severity != c.wantSeverity {
+			t.Errorf("NodeConditionIncidents(%s).Severity = %q, want %q (must match models.NodeConditionSeverity used for display)",
+				c.conditionType, got.Severity, c.wantSeverity)
+		}
 	}
 }


### PR DESCRIPTION
Node incidents were persisted with a hardcoded Severity: "low" regardless of condition type, while the War Room already computed real severity via models.NodeConditionSeverity (critical for Ready, high for pressure/network conditions). Result: a node shown as critical live could be stored as low — silently wrong incident listings, historical counts, and scoring.

Fix: NodeConditionIncidents now calls the same classifier the display uses, instead of the hardcoded constant. Unrecognized condition types fall back to "low" rather than failing persistence.

Updated one existing test that was pinning the bug (DiskPressure expected "low", now "high"), and added a table test covering all condition types plus the fallback case.