### PR TITLE
fix: StatefulSet replica issues no longer split from their owning Sta…

### DIFF
--- a/cmd/opscart-dashboard/main_test.go
+++ b/cmd/opscart-dashboard/main_test.go
@@ -429,6 +429,51 @@ func TestBuildWorkloadHealthGrid(t *testing.T) {
 			t.Fatalf("expected single orphan-svc/critical cell, got %+v", got)
 		}
 	})
+
+	t.Run("StatefulSet replica issue rolls up into its owning StatefulSet, not a separate cell", func(t *testing.T) {
+		// Reproduces the reported bug: a crash-looping StatefulSet replica
+		// (prometheus-0) previously showed the parent StatefulSet as
+		// healthy while the replica appeared as its own orphaned critical
+		// workload cell. store.OwnerNameFromPod is deliberately
+		// instance-scoped (design contract, fingerprint-symmetry fix), so
+		// buildWorkloadHealthGrid must resolve the rollup itself using
+		// AllWorkloads, not rely on OwnerNameFromPod to collapse it.
+		scan := &clusterScan{
+			AllWorkloads: []models.WorkloadRef{
+				{Name: "prometheus", Kind: "StatefulSet", Namespace: "monitoring"},
+			},
+			wasteAudit: &analyzer.WasteAudit{
+				StalePods: []analyzer.StalePod{
+					{Name: "prometheus-0", Namespace: "monitoring", Kind: analyzer.StalePodZombie, Status: "CrashLoopBackOff", RestartCount: 12, AgeDays: 1},
+				},
+			},
+		}
+		got := buildWorkloadHealthGrid(scan)
+		if len(got) != 1 {
+			t.Fatalf("expected exactly one cell (the StatefulSet, not a separate replica cell), got %d: %+v", len(got), got)
+		}
+		if got[0].Name != "prometheus" || got[0].Severity != "critical" {
+			t.Fatalf("expected {prometheus, critical}, got %+v", got[0])
+		}
+	})
+
+	t.Run("ordinal-suffixed pod with no matching StatefulSet is not misattributed", func(t *testing.T) {
+		// A bare pod coincidentally named like "worker-0" must NOT be
+		// collapsed into a StatefulSet named "worker" unless that
+		// StatefulSet actually exists in AllWorkloads — the rollup only
+		// ever applies to a confirmed real owner, never a string guess.
+		scan := &clusterScan{
+			wasteAudit: &analyzer.WasteAudit{
+				StalePods: []analyzer.StalePod{
+					{Name: "worker-0", Namespace: "batch", Kind: analyzer.StalePodZombie, Status: "CrashLoopBackOff", RestartCount: 5, AgeDays: 1},
+				},
+			},
+		}
+		got := buildWorkloadHealthGrid(scan)
+		if len(got) != 1 || got[0].Name != "worker-0" {
+			t.Fatalf("expected the bare pod's own cell (no false StatefulSet rollup), got %+v", got)
+		}
+	})
 }
 
 // fullyPopulatedOverviewData builds an overviewPageData with every optional

--- a/cmd/opscart-dashboard/server.go
+++ b/cmd/opscart-dashboard/server.go
@@ -1268,13 +1268,41 @@ func buildWorkloadHealthGrid(scan *clusterScan) []workloadHealthCell {
 	}
 
 	type workloadKey struct{ namespace, name string }
+
+	// Known StatefulSet names per namespace, from the real workload list —
+	// no new clientset call, this data is already collected on every scan.
+	// Keyed by "namespace/name" (plain string) rather than a struct, so it
+	// can be passed to statefulSetOwnerForInstance without needing a
+	// package-level type shared between the two functions.
+	statefulSets := map[string]bool{}
+	for _, w := range scan.AllWorkloads {
+		if w.Kind == "StatefulSet" {
+			statefulSets[w.Namespace+"/"+w.Name] = true
+		}
+	}
+
 	severityOf := map[workloadKey]string{}
 
 	for _, issue := range collectWarRoomIssues(scan, 0) {
 		if issue.Namespace == "" || issue.Resource == "" || issue.Resource == "namespace" {
 			continue // namespace-level issues (e.g. unprotected_namespace) aren't workloads
 		}
-		key := workloadKey{namespace: issue.Namespace, name: store.OwnerNameFromPod(issue.Resource)}
+		// store.OwnerNameFromPod is deliberately instance-scoped for
+		// StatefulSet replicas (prometheus-0 stays prometheus-0) — that's
+		// the correct identity for incident fingerprints, but WRONG here:
+		// aggregating health by workload means a StatefulSet's replicas
+		// must roll up into their one owning StatefulSet, or the parent
+		// shows healthy while its failing replica appears as a separate,
+		// orphaned "critical workload" next to it. Collapse to the known
+		// StatefulSet owner only when AllWorkloads confirms it's real —
+		// never a blind ordinal-stripping guess.
+		name := store.OwnerNameFromPod(issue.Resource)
+		if !statefulSets[issue.Namespace+"/"+name] {
+			if owner, ok := statefulSetOwnerForInstance(issue.Namespace, name, statefulSets); ok {
+				name = owner
+			}
+		}
+		key := workloadKey{namespace: issue.Namespace, name: name}
 		if existing, ok := severityOf[key]; !ok || workloadSeverityRank[issue.Severity] > workloadSeverityRank[existing] {
 			severityOf[key] = issue.Severity
 		}
@@ -1294,7 +1322,9 @@ func buildWorkloadHealthGrid(scan *clusterScan) []workloadHealthCell {
 
 	// Always include workloads implied by an active issue, even when
 	// AllWorkloads didn't independently observe them (e.g. a test fixture
-	// or a partial scan).
+	// or a partial scan). This no longer produces orphaned StatefulSet
+	// replica cells: any issue resolved to a known StatefulSet above was
+	// already re-keyed to the parent before reaching this map.
 	for key, sev := range severityOf {
 		if seen[key] {
 			continue
@@ -1311,6 +1341,31 @@ func buildWorkloadHealthGrid(scan *clusterScan) []workloadHealthCell {
 		return grid[i].Name < grid[j].Name
 	})
 	return grid
+}
+
+// statefulSetOwnerForInstance reports whether name (an instance-scoped
+// identity like "prometheus-0") is a replica of a StatefulSet the scan
+// actually observed in this namespace, and if so returns that StatefulSet's
+// real name. It never guesses: the candidate parent must be a confirmed
+// entry in statefulSets (keyed "namespace/name"), so a coincidentally
+// ordinal-suffixed pod name (e.g. a bare pod named "worker-0" with no
+// owning StatefulSet) is left alone rather than misattributed.
+func statefulSetOwnerForInstance(namespace, name string, statefulSets map[string]bool) (string, bool) {
+	idx := strings.LastIndex(name, "-")
+	if idx < 0 || idx == len(name)-1 {
+		return "", false
+	}
+	ordinal := name[idx+1:]
+	for _, r := range ordinal {
+		if r < '0' || r > '9' {
+			return "", false
+		}
+	}
+	candidate := name[:idx]
+	if statefulSets[namespace+"/"+candidate] {
+		return candidate, true
+	}
+	return "", false
 }
 
 // investigateURL builds a deep link to the Investigation page for a single


### PR DESCRIPTION
…tefulSet in Workload Health

buildWorkloadHealthGrid resolved each issue's workload identity with store.OwnerNameFromPod, which is deliberately instance-scoped for StatefulSet replicas (prometheus-0 stays prometheus-0) — correct for incident fingerprints, but wrong here: scan.AllWorkloads only has an entry for the real StatefulSet name, so a crash-looping prometheus-0 never matched it. The parent StatefulSet showed healthy while the replica appeared as its own orphaned critical workload cell.

Fix: buildWorkloadHealthGrid now builds a set of known StatefulSet names per namespace from AllWorkloads (already-collected data, no new clientset call). A new helper, statefulSetOwnerForInstance, rolls a replica's issue up into its StatefulSet only when AllWorkloads confirms that StatefulSet actually exists — never a blind ordinal-stripping guess, so an unrelated pod coincidentally named like worker-0 is never misattributed.

store.OwnerNameFromPod itself is unchanged; the fix is local to this one call site's aggregation logic.

Tests: reproduces the exact reported bug (prometheus-0 rolling up into prometheus) and confirms no false rollup for a bare pod with no matching StatefulSet. Two existing subtests (Deployment-only scenarios) verified unaffected.