### PR TITLE
fix: accurate scan duration timing + active vs. review-candidate labe…

### DIFF
--- a/cmd/opscart-dashboard/scan.go
+++ b/cmd/opscart-dashboard/scan.go
@@ -51,6 +51,12 @@ func (s *dashboardState) refresh(clusterList []string) error {
 	}
 	defer s.scanning.Store(false)
 
+	// Timer covers the full cycle — scan, render, and persistence — so
+	// DurationMS reflects what "scan duration" actually means to a reader.
+	// Previously this started after runFullScan/renderHTML completed, so
+	// the recorded duration measured only the persistence block below.
+	start := time.Now()
+
 	scan, err := runFullScan(s.ctx)
 	if err != nil {
 		return err
@@ -65,7 +71,6 @@ func (s *dashboardState) refresh(clusterList []string) error {
 	// Persist to operational memory (best-effort, never blocks scan)
 	if s.db != nil {
 		scanID := newScanID()
-		start := time.Now()
 
 		incScore, _, _ := calcIncidentScore(scan)
 		issues := collectWarRoomIssues(scan, 0)

--- a/pkg/analyzer/waste.go
+++ b/pkg/analyzer/waste.go
@@ -1371,6 +1371,21 @@ func PrintWasteAudit(audit *WasteAudit, minAgeDays int) {
 	printWasteSummary(audit)
 }
 
+// splitMisconfiguredHPAs separates currently-active failures
+// (ScalingActive=False) from age-gated tuning-review candidates
+// (AlwaysAtMin), so callers classify waste findings without conflating a
+// live break with a review suggestion.
+func splitMisconfiguredHPAs(hpas []MisconfiguredHPA) (active, tuning int) {
+	for _, hpa := range hpas {
+		if hpa.IsActive {
+			active++
+		} else {
+			tuning++
+		}
+	}
+	return active, tuning
+}
+
 func printExecutiveSummary(audit *WasteAudit) {
 	zombieCount := 0
 	for _, p := range audit.StalePods {
@@ -1379,9 +1394,17 @@ func printExecutiveSummary(audit *WasteAudit) {
 		}
 	}
 
-	criticalCount := len(audit.AbandonedNamespaces) + zombieCount + len(audit.OrphanedPVCs)
+	// BrokenIngress is only ever produced from a currently-broken backend
+	// (IsActive is always true for it — see the waste detector). Among
+	// MisconfiguredHPAs, only the ScalingActive=False ones are live
+	// failures; AlwaysAtMin is a tuning-review candidate, not an active
+	// break, and stays in the warning bucket below.
+	activeIngresses := len(audit.BrokenIngresses)
+	activeHPAs, tuningHPAs := splitMisconfiguredHPAs(audit.MisconfiguredHPAs)
+
+	criticalCount := len(audit.AbandonedNamespaces) + zombieCount + len(audit.OrphanedPVCs) + activeIngresses + activeHPAs
 	warningCount := len(audit.StaleJobs) + len(audit.ZeroReplicaWorkloads) +
-		len(audit.OrphanedServices) + len(audit.BrokenIngresses) + len(audit.MisconfiguredHPAs)
+		len(audit.OrphanedServices) + tuningHPAs
 
 	fmt.Println("EXECUTIVE SUMMARY")
 	fmt.Println("═══════════════════════════════════════════════════════════")
@@ -1416,6 +1439,12 @@ func printExecutiveSummary(audit *WasteAudit) {
 	if len(audit.AbandonedNamespaces) > 0 {
 		fmt.Printf("     • %d abandoned namespace(s)\n", len(audit.AbandonedNamespaces))
 	}
+	if activeIngresses > 0 {
+		fmt.Printf("     • %d broken ingress(es) — active routing failure\n", activeIngresses)
+	}
+	if activeHPAs > 0 {
+		fmt.Printf("     • %d HPA(s) currently reporting ScalingActive=False\n", activeHPAs)
+	}
 	if criticalCount == 0 {
 		fmt.Println("     • None")
 	}
@@ -1431,11 +1460,8 @@ func printExecutiveSummary(audit *WasteAudit) {
 	if len(audit.ZeroReplicaWorkloads) > 0 {
 		fmt.Printf("     • %d zero-replica workload(s)\n", len(audit.ZeroReplicaWorkloads))
 	}
-	if len(audit.BrokenIngresses) > 0 {
-		fmt.Printf("     • %d broken ingress(es)\n", len(audit.BrokenIngresses))
-	}
-	if len(audit.MisconfiguredHPAs) > 0 {
-		fmt.Printf("     • %d misconfigured HPA(s)\n", len(audit.MisconfiguredHPAs))
+	if tuningHPAs > 0 {
+		fmt.Printf("     • %d HPA(s) at minReplicas — tuning review candidate\n", tuningHPAs)
 	}
 	if warningCount == 0 {
 		fmt.Println("     • None")
@@ -1469,11 +1495,15 @@ func printWasteScorecard(audit *WasteAudit) {
 	printScoreRow("Unmanaged Pods (no controller)", bareCount, "🔴")
 	printScoreRow("Orphaned PVCs", len(audit.OrphanedPVCs), "🔴")
 	printScoreRow("Orphaned Services", len(audit.OrphanedServices), "🟡")
-	printScoreRow("Broken Ingresses", len(audit.BrokenIngresses), "🟡")
+	printScoreRow("Broken Ingresses", len(audit.BrokenIngresses), "🔴") // always an active routing failure when present
 	printScoreRow("Stale Jobs/CronJobs", len(audit.StaleJobs), "🟡")
 	printScoreRow("Zero-Replica Workloads", len(audit.ZeroReplicaWorkloads), "🟡")
 	printScoreRow("Old ReplicaSets", len(audit.OldReplicaSets), "🟢")
-	printScoreRow("Misconfigured HPAs", len(audit.MisconfiguredHPAs), "🟢")
+	hpaEmoji := "🟢" // tuning candidates only (AlwaysAtMin)
+	if active, _ := splitMisconfiguredHPAs(audit.MisconfiguredHPAs); active > 0 {
+		hpaEmoji = "🔴" // at least one HPA currently reporting ScalingActive=False
+	}
+	printScoreRow("Misconfigured HPAs", len(audit.MisconfiguredHPAs), hpaEmoji)
 
 	fmt.Println("───────────────────────────────────────────────────────────")
 	fmt.Printf("  Total waste items found:  %d\n", audit.TotalWasteItems)

--- a/pkg/analyzer/waste_test.go
+++ b/pkg/analyzer/waste_test.go
@@ -691,3 +691,32 @@ func TestHPAYoungAndHealthyProducesNoFinding(t *testing.T) {
 		t.Fatalf("healthy scaling HPA should produce no finding: %+v", audit.MisconfiguredHPAs)
 	}
 }
+
+// TestSplitMisconfiguredHPAs guards the CLI summary-labeling fix: active
+// failures (ScalingActive=False) must be counted separately from tuning
+// candidates (AlwaysAtMin), so a live autoscaling failure never gets
+// silently folded into a "warning" bucket or shown with a green scorecard
+// emoji next to other, merely-worth-reviewing findings.
+func TestSplitMisconfiguredHPAs(t *testing.T) {
+	hpas := []MisconfiguredHPA{
+		{Name: "a", IsActive: true},
+		{Name: "b", IsActive: false},
+		{Name: "c", IsActive: true},
+		{Name: "d", IsActive: false},
+		{Name: "e", IsActive: false},
+	}
+	active, tuning := splitMisconfiguredHPAs(hpas)
+	if active != 2 {
+		t.Errorf("active = %d, want 2", active)
+	}
+	if tuning != 3 {
+		t.Errorf("tuning = %d, want 3", tuning)
+	}
+}
+
+func TestSplitMisconfiguredHPAsEmpty(t *testing.T) {
+	active, tuning := splitMisconfiguredHPAs(nil)
+	if active != 0 || tuning != 0 {
+		t.Errorf("splitMisconfiguredHPAs(nil) = (%d, %d), want (0, 0)", active, tuning)
+	}
+}


### PR DESCRIPTION
…ls in CLI waste summaries

Two independent fixes:

1. scan.go: refresh()'s duration timer started after runFullScan and renderHTML completed, so DurationMS measured only persistence work (scoring, incident diffing, DB writes, retention prune) instead of the actual scan. Moved the timer to the top of refresh().

2. waste.go: printExecutiveSummary counted all BrokenIngresses and MisconfiguredHPAs as warning findings, and printWasteScorecard hardcoded green for Misconfigured HPAs and yellow for Broken Ingresses, regardless of IsActive. A live ScalingActive=False HPA failure could show under warnings with a green scorecard row, indistinguishable from an AlwaysAtMin tuning suggestion; a broken Ingress (always active by construction) never appeared under critical at all.

   Extracted splitMisconfiguredHPAs(hpas) []MisconfiguredHPA (active, tuning int) as a small pure function so the classification logic is unit-testable. BrokenIngresses now count as critical always; MisconfiguredHPAs split between critical (IsActive) and warning (AlwaysAtMin tuning candidates).

Tests: TestSplitMisconfiguredHPAs, TestSplitMisconfiguredHPAsEmpty. No test added for the timer fix — refresh() has no injection seam for its live-cluster scan call; verified manually via scan_history duration values instead.