### PR TITLE
fix: pod-to-workload identity uses confirmed OwnerReferences, not nam…

### DIFF
--- a/cmd/opscart-dashboard/main_test.go
+++ b/cmd/opscart-dashboard/main_test.go
@@ -434,13 +434,16 @@ func TestBuildWorkloadHealthGrid(t *testing.T) {
 		// Reproduces the reported bug: a crash-looping StatefulSet replica
 		// (prometheus-0) previously showed the parent StatefulSet as
 		// healthy while the replica appeared as its own orphaned critical
-		// workload cell. store.OwnerNameFromPod is deliberately
-		// instance-scoped (design contract, fingerprint-symmetry fix), so
-		// buildWorkloadHealthGrid must resolve the rollup itself using
-		// AllWorkloads, not rely on OwnerNameFromPod to collapse it.
+		// workload cell. buildWorkloadHealthGrid resolves the rollup via
+		// scan.PodWorkloads — confirmed ownership from real
+		// OwnerReferences, populated alongside AllWorkloads by
+		// AnalyzeClusterResources in production — not a name guess.
 		scan := &clusterScan{
 			AllWorkloads: []models.WorkloadRef{
 				{Name: "prometheus", Kind: "StatefulSet", Namespace: "monitoring"},
+			},
+			PodWorkloads: map[string]models.WorkloadRef{
+				"monitoring/prometheus-0": {Name: "prometheus", Kind: "StatefulSet", Namespace: "monitoring"},
 			},
 			wasteAudit: &analyzer.WasteAudit{
 				StalePods: []analyzer.StalePod{
@@ -458,10 +461,9 @@ func TestBuildWorkloadHealthGrid(t *testing.T) {
 	})
 
 	t.Run("ordinal-suffixed pod with no matching StatefulSet is not misattributed", func(t *testing.T) {
-		// A bare pod coincidentally named like "worker-0" must NOT be
-		// collapsed into a StatefulSet named "worker" unless that
-		// StatefulSet actually exists in AllWorkloads — the rollup only
-		// ever applies to a confirmed real owner, never a string guess.
+		// A bare pod coincidentally named like "worker-0" with no
+		// confirmed ownership mapping must NOT be collapsed into any
+		// StatefulSet.
 		scan := &clusterScan{
 			wasteAudit: &analyzer.WasteAudit{
 				StalePods: []analyzer.StalePod{
@@ -472,6 +474,43 @@ func TestBuildWorkloadHealthGrid(t *testing.T) {
 		got := buildWorkloadHealthGrid(scan)
 		if len(got) != 1 || got[0].Name != "worker-0" {
 			t.Fatalf("expected the bare pod's own cell (no false StatefulSet rollup), got %+v", got)
+		}
+	})
+
+	t.Run("Deployment pod named like a StatefulSet replica is not misattributed to a colliding StatefulSet", func(t *testing.T) {
+		// The exact collision scenario: a Deployment named "worker-0"
+		// produces a pod also named "worker-0" (Deployment names without
+		// a ReplicaSet hash suffix are unusual but not impossible — e.g.
+		// a single-replica Deployment whose pod template name collides).
+		// The namespace ALSO has an unrelated StatefulSet named "worker".
+		// A pure name-pattern check (old behavior) would wrongly roll this
+		// pod's issue into the StatefulSet "worker". Confirmed ownership
+		// via PodWorkloads must prevent that: this pod's real owner is
+		// the Deployment, not the StatefulSet.
+		scan := &clusterScan{
+			AllWorkloads: []models.WorkloadRef{
+				{Name: "worker", Kind: "StatefulSet", Namespace: "batch"},
+				{Name: "worker-0", Kind: "Deployment", Namespace: "batch"},
+			},
+			PodWorkloads: map[string]models.WorkloadRef{
+				"batch/worker-0": {Name: "worker-0", Kind: "Deployment", Namespace: "batch"},
+			},
+			wasteAudit: &analyzer.WasteAudit{
+				StalePods: []analyzer.StalePod{
+					{Name: "worker-0", Namespace: "batch", Kind: analyzer.StalePodZombie, Status: "CrashLoopBackOff", RestartCount: 5, AgeDays: 1},
+				},
+			},
+		}
+		got := buildWorkloadHealthGrid(scan)
+		byName := map[string]string{}
+		for _, cell := range got {
+			byName[cell.Name] = cell.Severity
+		}
+		if sev, ok := byName["worker"]; ok && sev == "critical" {
+			t.Fatalf("StatefulSet 'worker' must NOT be marked critical — the failing pod belongs to the unrelated Deployment 'worker-0': %+v", got)
+		}
+		if sev := byName["worker-0"]; sev != "critical" {
+			t.Fatalf("Deployment 'worker-0' should be critical (it's the pod's real owner), got %+v", got)
 		}
 	})
 }

--- a/cmd/opscart-dashboard/scan.go
+++ b/cmd/opscart-dashboard/scan.go
@@ -31,6 +31,14 @@ type clusterScan struct {
 	// enumeration ResourceAnalyzer.AnalyzeClusterResources already performs
 	// for cost allocation, not a second cluster fetch.
 	AllWorkloads []models.WorkloadRef
+
+	// PodWorkloads is the confirmed pod -> owning workload map from the
+	// same pod enumeration, keyed by "namespace/podName". This is the
+	// single source of truth for pod ownership — used instead of
+	// name-pattern matching (store.OwnerNameFromPod + prefix checks),
+	// which cannot distinguish a real StatefulSet replica from an
+	// unrelated pod sharing its naming pattern.
+	PodWorkloads map[string]models.WorkloadRef
 }
 
 // ── Per-cluster state ─────────────────────────────────────────────────────────

--- a/cmd/opscart-dashboard/server.go
+++ b/cmd/opscart-dashboard/server.go
@@ -1268,38 +1268,22 @@ func buildWorkloadHealthGrid(scan *clusterScan) []workloadHealthCell {
 	}
 
 	type workloadKey struct{ namespace, name string }
-
-	// Known StatefulSet names per namespace, from the real workload list —
-	// no new clientset call, this data is already collected on every scan.
-	// Keyed by "namespace/name" (plain string) rather than a struct, so it
-	// can be passed to statefulSetOwnerForInstance without needing a
-	// package-level type shared between the two functions.
-	statefulSets := map[string]bool{}
-	for _, w := range scan.AllWorkloads {
-		if w.Kind == "StatefulSet" {
-			statefulSets[w.Namespace+"/"+w.Name] = true
-		}
-	}
-
 	severityOf := map[workloadKey]string{}
 
 	for _, issue := range collectWarRoomIssues(scan, 0) {
 		if issue.Namespace == "" || issue.Resource == "" || issue.Resource == "namespace" {
 			continue // namespace-level issues (e.g. unprotected_namespace) aren't workloads
 		}
-		// store.OwnerNameFromPod is deliberately instance-scoped for
-		// StatefulSet replicas (prometheus-0 stays prometheus-0) — that's
-		// the correct identity for incident fingerprints, but WRONG here:
-		// aggregating health by workload means a StatefulSet's replicas
-		// must roll up into their one owning StatefulSet, or the parent
-		// shows healthy while its failing replica appears as a separate,
-		// orphaned "critical workload" next to it. Collapse to the known
-		// StatefulSet owner only when AllWorkloads confirms it's real —
-		// never a blind ordinal-stripping guess.
+		// Confirmed ownership first (scan.PodWorkloads — real
+		// OwnerReferences), never a name-pattern guess. Aggregating
+		// health by workload means a StatefulSet's replicas must roll up
+		// into their one owning StatefulSet — using name matching alone
+		// (as this used to) can misattribute an unrelated pod that
+		// merely shares a StatefulSet's naming pattern.
 		name := store.OwnerNameFromPod(issue.Resource)
-		if !statefulSets[issue.Namespace+"/"+name] {
-			if owner, ok := statefulSetOwnerForInstance(issue.Namespace, name, statefulSets); ok {
-				name = owner
+		if scan.PodWorkloads != nil {
+			if ref, ok := scan.PodWorkloads[issue.Namespace+"/"+issue.Resource]; ok && ref.Kind == "StatefulSet" {
+				name = ref.Name
 			}
 		}
 		key := workloadKey{namespace: issue.Namespace, name: name}
@@ -1341,31 +1325,6 @@ func buildWorkloadHealthGrid(scan *clusterScan) []workloadHealthCell {
 		return grid[i].Name < grid[j].Name
 	})
 	return grid
-}
-
-// statefulSetOwnerForInstance reports whether name (an instance-scoped
-// identity like "prometheus-0") is a replica of a StatefulSet the scan
-// actually observed in this namespace, and if so returns that StatefulSet's
-// real name. It never guesses: the candidate parent must be a confirmed
-// entry in statefulSets (keyed "namespace/name"), so a coincidentally
-// ordinal-suffixed pod name (e.g. a bare pod named "worker-0" with no
-// owning StatefulSet) is left alone rather than misattributed.
-func statefulSetOwnerForInstance(namespace, name string, statefulSets map[string]bool) (string, bool) {
-	idx := strings.LastIndex(name, "-")
-	if idx < 0 || idx == len(name)-1 {
-		return "", false
-	}
-	ordinal := name[idx+1:]
-	for _, r := range ordinal {
-		if r < '0' || r > '9' {
-			return "", false
-		}
-	}
-	candidate := name[:idx]
-	if statefulSets[namespace+"/"+candidate] {
-		return candidate, true
-	}
-	return "", false
 }
 
 // investigateURL builds a deep link to the Investigation page for a single
@@ -1928,6 +1887,7 @@ func runFullScan(ctx string) (*clusterScan, error) {
 	// Retained regardless of --breakdown — this is the same pod enumeration
 	// already fetched above, not a second cluster call.
 	scan.AllWorkloads = resourceAnalysis.Workloads
+	scan.PodWorkloads = resourceAnalysis.PodWorkloads
 
 	nsCosts := npCostAnalyzer.AllocateNamespaceCosts(
 		poolCosts, resourceAnalysis.Namespaces,

--- a/cmd/opscart-dashboard/warroom.go
+++ b/cmd/opscart-dashboard/warroom.go
@@ -498,8 +498,36 @@ func enrichWarRoomIdentity(issue *warRoomIssue, scan *clusterScan) {
 		issue.WorkloadKind, issue.WorkloadName = "Namespace", issue.Namespace
 		return
 	}
-	owner := store.OwnerNameFromPod(issue.Resource)
 	issue.WorkloadKind, issue.WorkloadName = "Pod", issue.Resource
+
+	// Confirmed ownership first (scan.PodWorkloads — real OwnerReferences
+	// captured during pod enumeration), never a name-pattern guess. A
+	// Deployment pod literally named like a StatefulSet's replica (e.g.
+	// "worker-0" in a namespace that also has a StatefulSet "worker")
+	// cannot be misattributed this way, unlike the prefix-matching
+	// fallback below.
+	if scan != nil && scan.PodWorkloads != nil {
+		if ref, ok := scan.PodWorkloads[issue.Namespace+"/"+issue.Resource]; ok {
+			if ref.Kind == "StatefulSet" {
+				// War Room stays instance-scoped for StatefulSets (design
+				// contract: prometheus-0 and prometheus-1 keep separate
+				// histories) — only the Kind is confirmed here, the pod's
+				// own identity is kept as WorkloadName.
+				issue.WorkloadKind, issue.WorkloadName = "StatefulSet", issue.Resource
+			} else {
+				issue.WorkloadKind, issue.WorkloadName = ref.Kind, ref.Name
+			}
+			return
+		}
+	}
+
+	// Fallback: no confirmed mapping (e.g. scan.PodWorkloads unset in a
+	// synthetic test fixture, or a namespace-filtered scan that didn't
+	// enumerate this pod). Name-pattern heuristic, same as before this
+	// fix — can theoretically misattribute on a naming collision, which
+	// is exactly why the confirmed path above is preferred whenever
+	// available.
+	owner := store.OwnerNameFromPod(issue.Resource)
 	if scan == nil {
 		if owner != issue.Resource {
 			issue.WorkloadKind, issue.WorkloadName = "Deployment", owner

--- a/cmd/opscart-dashboard/warroom_redesign_test.go
+++ b/cmd/opscart-dashboard/warroom_redesign_test.go
@@ -232,3 +232,50 @@ func TestWarRoomDenseEqualCardsAndResetVisibility(t *testing.T) {
 		t.Fatal("active filter did not render full-height Reset control")
 	}
 }
+
+// TestEnrichWarRoomIdentityUsesConfirmedOwnershipOverNamePattern guards the
+// naming-collision fix: when scan.PodWorkloads has a confirmed mapping for
+// a pod, that mapping is used directly — never the name-pattern fallback,
+// which cannot distinguish a real StatefulSet replica from an unrelated
+// pod (e.g. a Deployment) that merely shares its naming pattern.
+func TestEnrichWarRoomIdentityUsesConfirmedOwnershipOverNamePattern(t *testing.T) {
+	// Namespace has an unrelated StatefulSet "worker" AND a Deployment
+	// whose pod is literally named "worker-0". A name-pattern check alone
+	// (strings.HasPrefix) would misattribute "worker-0" to the StatefulSet.
+	scan := &clusterScan{
+		AllWorkloads: []models.WorkloadRef{
+			{Name: "worker", Kind: "StatefulSet", Namespace: "batch"},
+			{Name: "worker-0", Kind: "Deployment", Namespace: "batch"},
+		},
+		PodWorkloads: map[string]models.WorkloadRef{
+			"batch/worker-0": {Name: "worker-0", Kind: "Deployment", Namespace: "batch"},
+		},
+	}
+	issue := warRoomIssue{Severity: "critical", Type: "crash_loop", Resource: "worker-0", Namespace: "batch"}
+	enrichWarRoomIdentity(&issue, scan)
+
+	if issue.WorkloadKind != "Deployment" || issue.WorkloadName != "worker-0" {
+		t.Fatalf("expected confirmed ownership (Deployment/worker-0), got %s/%s — the StatefulSet naming collision was not prevented",
+			issue.WorkloadKind, issue.WorkloadName)
+	}
+}
+
+// TestEnrichWarRoomIdentityStatefulSetStaysInstanceScopedWithConfirmedOwnership
+// confirms that confirmed ownership doesn't break the StatefulSet
+// instance-scoping design contract: only Kind is taken from the confirmed
+// mapping, WorkloadName stays the pod's own identity (prometheus-0, not
+// prometheus), matching existing War Room card behavior.
+func TestEnrichWarRoomIdentityStatefulSetStaysInstanceScopedWithConfirmedOwnership(t *testing.T) {
+	scan := &clusterScan{
+		PodWorkloads: map[string]models.WorkloadRef{
+			"monitoring/prometheus-0": {Name: "prometheus", Kind: "StatefulSet", Namespace: "monitoring"},
+		},
+	}
+	issue := warRoomIssue{Severity: "critical", Type: "crash_loop", Resource: "prometheus-0", Namespace: "monitoring"}
+	enrichWarRoomIdentity(&issue, scan)
+
+	if issue.WorkloadKind != "StatefulSet" || issue.WorkloadName != "prometheus-0" {
+		t.Fatalf("expected StatefulSet/prometheus-0 (instance-scoped), got %s/%s",
+			issue.WorkloadKind, issue.WorkloadName)
+	}
+}

--- a/pkg/analyzer/resources.go
+++ b/pkg/analyzer/resources.go
@@ -50,6 +50,12 @@ func (ra *ResourceAnalyzer) AnalyzeClusterResources(namespace string) (*models.C
 	// Roll the same pod list up to one entry per owning workload — no
 	// second cluster fetch, just a different view of data already in hand.
 	analysis.Workloads = workloadsFromPods(podList.Items)
+	// Preserve the confirmed per-pod ownership too, so consumers that need
+	// to attribute a specific pod-scoped finding to its real workload
+	// (War Room identity, Overview health-grid aggregation) don't have to
+	// re-derive it from name patterns, which cannot distinguish a real
+	// StatefulSet replica from an unrelated pod sharing its naming pattern.
+	analysis.PodWorkloads = podWorkloadMap(podList.Items)
 
 	// Analyze by namespace
 	namespaceMap := make(map[string]*models.NamespaceResourceUsage)
@@ -165,23 +171,65 @@ func workloadsFromPods(pods []corev1.Pod) []models.WorkloadRef {
 }
 
 // workloadRefForPod resolves a pod's owning Deployment/StatefulSet/DaemonSet
-// from its OwnerReferences. ReplicaSet-owned pods (the common Deployment
-// case) roll up to the Deployment name by stripping the ReplicaSet's own
-// hash suffix — the ReplicaSet object itself is not fetched, avoiding a
-// second API call. StatefulSet/DaemonSet owner names are used verbatim;
-// those controllers name pods deterministically, no suffix to strip.
+// from its OwnerReferences. The controlling reference (Controller == true)
+// is used when present — a pod can carry multiple OwnerReferences, and only
+// the controller is authoritative; falling back to the first matching Kind
+// regardless of Controller could pick a non-controlling reference. When no
+// reference is explicitly marked as controller (uncommon, but not
+// guaranteed by the API), the first recognized Kind is used as before.
+// ReplicaSet-owned pods (the common Deployment case) roll up to the
+// Deployment name by stripping the ReplicaSet's own hash suffix — the
+// ReplicaSet object itself is not fetched, avoiding a second API call.
+// StatefulSet/DaemonSet owner names are used verbatim; those controllers
+// name pods deterministically, no suffix to strip.
 func workloadRefForPod(pod corev1.Pod) (models.WorkloadRef, bool) {
 	for _, owner := range pod.OwnerReferences {
-		switch owner.Kind {
-		case "ReplicaSet":
-			return models.WorkloadRef{Name: stripHashSuffix(owner.Name), Kind: "Deployment", Namespace: pod.Namespace}, true
-		case "StatefulSet":
-			return models.WorkloadRef{Name: owner.Name, Kind: "StatefulSet", Namespace: pod.Namespace}, true
-		case "DaemonSet":
-			return models.WorkloadRef{Name: owner.Name, Kind: "DaemonSet", Namespace: pod.Namespace}, true
+		if owner.Controller != nil && *owner.Controller {
+			// The controller is authoritative — if it's a Kind we don't
+			// roll up (e.g. Job), the pod isn't attributed to a tracked
+			// workload at all; don't fall through to scan other,
+			// non-controlling references, which could misattribute via
+			// an unrelated or stale owner reference.
+			return workloadRefForOwner(pod.Namespace, owner)
+		}
+	}
+	// No reference explicitly marked as controller (uncommon, but not
+	// guaranteed by the API) — fall back to the first recognized Kind.
+	for _, owner := range pod.OwnerReferences {
+		if ref, ok := workloadRefForOwner(pod.Namespace, owner); ok {
+			return ref, true
 		}
 	}
 	return models.WorkloadRef{}, false
+}
+
+func workloadRefForOwner(namespace string, owner metav1.OwnerReference) (models.WorkloadRef, bool) {
+	switch owner.Kind {
+	case "ReplicaSet":
+		return models.WorkloadRef{Name: stripHashSuffix(owner.Name), Kind: "Deployment", Namespace: namespace}, true
+	case "StatefulSet":
+		return models.WorkloadRef{Name: owner.Name, Kind: "StatefulSet", Namespace: namespace}, true
+	case "DaemonSet":
+		return models.WorkloadRef{Name: owner.Name, Kind: "DaemonSet", Namespace: namespace}, true
+	}
+	return models.WorkloadRef{}, false
+}
+
+// podWorkloadKey is the PodWorkloads map key convention: "namespace/podName".
+func podWorkloadKey(namespace, podName string) string {
+	return namespace + "/" + podName
+}
+
+// podWorkloadMap builds the confirmed pod -> owning workload map from the
+// same pod list already collected for workloadsFromPods — no second fetch.
+func podWorkloadMap(pods []corev1.Pod) map[string]models.WorkloadRef {
+	out := make(map[string]models.WorkloadRef, len(pods))
+	for _, pod := range pods {
+		if ref, ok := workloadRefForPod(pod); ok {
+			out[podWorkloadKey(pod.Namespace, pod.Name)] = ref
+		}
+	}
+	return out
 }
 
 // stripHashSuffix removes a trailing ReplicaSet hash segment, e.g.

--- a/pkg/analyzer/resources_test.go
+++ b/pkg/analyzer/resources_test.go
@@ -79,3 +79,85 @@ func TestStripHashSuffix(t *testing.T) {
 		}
 	}
 }
+
+func boolPtr(b bool) *bool { return &b }
+
+// ownedPodMulti builds a pod with multiple OwnerReferences, letting the
+// caller mark exactly one as the controller — mirrors what the real
+// Kubernetes API can return (rare, but not disallowed) and is the scenario
+// workloadRefForPod's Controller-preference logic exists for.
+func ownedPodMulti(namespace, name string, refs ...metav1.OwnerReference) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, OwnerReferences: refs},
+	}
+}
+
+func TestWorkloadRefForPodPrefersExplicitController(t *testing.T) {
+	// The controller (StatefulSet) is listed SECOND — a naive "first Kind
+	// match" would have picked the non-controlling ReplicaSet reference
+	// instead. This is exactly the "OwnerReferences[0] is not necessarily
+	// the controlling owner" gap identified during review.
+	pod := ownedPodMulti("payments", "redis-0",
+		metav1.OwnerReference{Kind: "ReplicaSet", Name: "stale-rs-abc12", Controller: boolPtr(false)},
+		metav1.OwnerReference{Kind: "StatefulSet", Name: "redis", Controller: boolPtr(true)},
+	)
+	ref, ok := workloadRefForPod(pod)
+	if !ok || ref != (models.WorkloadRef{Name: "redis", Kind: "StatefulSet", Namespace: "payments"}) {
+		t.Fatalf("workloadRefForPod = %+v, ok=%v; want the StatefulSet (explicit controller), not the non-controlling ReplicaSet", ref, ok)
+	}
+}
+
+func TestWorkloadRefForPodControllerNotARollupKindReturnsFalse(t *testing.T) {
+	// The controller is explicitly a Job (not rolled up). Even though a
+	// second, non-controlling reference happens to be a StatefulSet, the
+	// pod must NOT be attributed to it — the controller is authoritative,
+	// and falling back to an unrelated non-controlling reference would be
+	// its own misattribution bug.
+	pod := ownedPodMulti("batch", "worker-0",
+		metav1.OwnerReference{Kind: "Job", Name: "worker-job", Controller: boolPtr(true)},
+		metav1.OwnerReference{Kind: "StatefulSet", Name: "worker", Controller: boolPtr(false)},
+	)
+	if _, ok := workloadRefForPod(pod); ok {
+		t.Fatalf("expected no workload attribution when the actual controller (Job) isn't a rolled-up kind")
+	}
+}
+
+func TestWorkloadRefForPodFallsBackWhenNoControllerMarked(t *testing.T) {
+	// No reference is explicitly marked Controller (uncommon but not
+	// guaranteed by the API) — falls back to the first recognized kind,
+	// preserving the original behavior for this edge case.
+	pod := ownedPod("payments", "redis-0", "StatefulSet", "redis")
+	ref, ok := workloadRefForPod(pod)
+	if !ok || ref != (models.WorkloadRef{Name: "redis", Kind: "StatefulSet", Namespace: "payments"}) {
+		t.Fatalf("workloadRefForPod = %+v, ok=%v; want redis/StatefulSet", ref, ok)
+	}
+}
+
+func TestPodWorkloadMap(t *testing.T) {
+	pods := []corev1.Pod{
+		ownedPod("monitoring", "prometheus-0", "StatefulSet", "prometheus"),
+		ownedPod("apps", "worker-0", "ReplicaSet", "worker-0-7d8f9c6b5"),
+		{ObjectMeta: metav1.ObjectMeta{Name: "bare-pod", Namespace: "default"}}, // no owner
+	}
+	got := podWorkloadMap(pods)
+
+	if ref, ok := got["monitoring/prometheus-0"]; !ok || ref != (models.WorkloadRef{Name: "prometheus", Kind: "StatefulSet", Namespace: "monitoring"}) {
+		t.Errorf("monitoring/prometheus-0 = %+v, ok=%v; want prometheus/StatefulSet", ref, ok)
+	}
+	// This is the exact naming-collision scenario: a Deployment whose
+	// rolled-up name happens to be "worker-0" (i.e. the Deployment itself
+	// is literally named "worker-0", pod suffixed by its own ReplicaSet
+	// hash). The map must record the CONFIRMED owner ("worker-0",
+	// Deployment) for this pod, distinct from any unrelated StatefulSet
+	// that might also be named "worker" in the same namespace — nothing
+	// in this map depends on name comparison at lookup time.
+	if ref, ok := got["apps/worker-0"]; !ok || ref.Kind != "Deployment" || ref.Name != "worker-0" {
+		t.Errorf("apps/worker-0 = %+v, ok=%v; want Deployment/worker-0", ref, ok)
+	}
+	if _, ok := got["default/bare-pod"]; ok {
+		t.Error("bare pod with no owner should not appear in the map")
+	}
+	if len(got) != 2 {
+		t.Errorf("expected 2 entries (bare pod excluded), got %d: %+v", len(got), got)
+	}
+}

--- a/pkg/models/resources.go
+++ b/pkg/models/resources.go
@@ -24,6 +24,17 @@ type ClusterResourceAnalysis struct {
 	// enumerating pods for the namespace breakdown above — a rollup of the
 	// same pod list, not a second cluster fetch.
 	Workloads []WorkloadRef `json:"workloads,omitempty"`
+
+	// PodWorkloads is the confirmed pod -> owning workload mapping for
+	// every pod observed, keyed by "namespace/podName". It is the single
+	// source of truth for pod ownership: consumers that need to attribute
+	// a pod-scoped finding to its real workload (War Room identity,
+	// Overview health-grid aggregation) must use this map rather than
+	// re-deriving ownership from name patterns, which cannot distinguish
+	// a real StatefulSet replica from an unrelated pod that merely shares
+	// its naming pattern (e.g. a Deployment pod literally named
+	// "worker-0" in a namespace that also has a StatefulSet "worker").
+	PodWorkloads map[string]WorkloadRef `json:"pod_workloads,omitempty"`
 }
 
 // WorkloadRef identifies a single Deployment/StatefulSet/DaemonSet, derived


### PR DESCRIPTION
…e pattern matching