### PR TITLE
fix: include node incidents in dashboard counters and scoring

### DIFF
--- a/cmd/opscart-dashboard/main_test.go
+++ b/cmd/opscart-dashboard/main_test.go
@@ -1787,3 +1787,96 @@ func TestRedesignedPagesPreserveClusterQueryLinks(t *testing.T) {
 		}
 	}
 }
+
+// ── Node findings in aggregate counters ─────────────────────────────────
+//
+// Node conditions are visible in War Room (via the DB-aware
+// collectActiveNodeWarRoomIssues) but calcIncidentScore, countCriticalIssues,
+// and the persisted snapshot's critical/warnings tally all read from the
+// plain, non-DB collectWarRoomIssues — which never included node findings.
+// These read scan.nodeHealth directly instead: it's already the current
+// scan's data, no DB query, and no risk of the staleness that a DB-backed
+// collector would introduce here (calcIncidentScore runs before this
+// scan's node incidents are persisted).
+
+func TestCountCriticalIssuesIncludesCriticalNodeFindings(t *testing.T) {
+	scan := &clusterScan{
+		nodeHealth: []models.NodeConditionFinding{
+			{NodeName: "node-1", ConditionType: "Ready", ConditionStatus: "False"},
+			{NodeName: "node-2", ConditionType: "DiskPressure", ConditionStatus: "True"},
+		},
+	}
+	got := countCriticalIssues(scan)
+	if got != 1 {
+		t.Fatalf("countCriticalIssues = %d, want 1 (only Ready=False is critical; DiskPressure is high, not critical)", got)
+	}
+}
+
+func TestCalcIncidentScorePenalizesCriticalNodeCondition(t *testing.T) {
+	clean := &clusterScan{}
+	cleanScore, _, _ := calcIncidentScore(clean)
+
+	withCriticalNode := &clusterScan{
+		nodeHealth: []models.NodeConditionFinding{
+			{NodeName: "node-1", ConditionType: "Ready", ConditionStatus: "False"},
+		},
+	}
+	gotScore, _, _ := calcIncidentScore(withCriticalNode)
+
+	if gotScore >= cleanScore {
+		t.Fatalf("score with a critical node condition (%d) should be lower than a clean scan (%d)", gotScore, cleanScore)
+	}
+	if cleanScore-gotScore != 10 {
+		t.Errorf("expected exactly the -10 critical-node penalty, got a %d point drop", cleanScore-gotScore)
+	}
+}
+
+func TestCalcIncidentScorePenalizesHighNodeConditionLessThanCritical(t *testing.T) {
+	withHighNode := &clusterScan{
+		nodeHealth: []models.NodeConditionFinding{
+			{NodeName: "node-1", ConditionType: "DiskPressure", ConditionStatus: "True"},
+		},
+	}
+	gotScore, _, _ := calcIncidentScore(withHighNode)
+	if 100-gotScore != 4 {
+		t.Errorf("expected exactly the -4 high-node penalty, got a %d point drop", 100-gotScore)
+	}
+}
+
+func TestCalcIncidentScoreNodePenaltiesCap(t *testing.T) {
+	var findings []models.NodeConditionFinding
+	for i := 0; i < 10; i++ {
+		findings = append(findings, models.NodeConditionFinding{
+			NodeName: fmt.Sprintf("node-%d", i), ConditionType: "Ready", ConditionStatus: "False",
+		})
+	}
+	gotScore, _, _ := calcIncidentScore(&clusterScan{nodeHealth: findings})
+	if 100-gotScore != 30 {
+		t.Errorf("expected the critical-node penalty capped at -30 (10 nodes x -10 would be -100), got a %d point drop", 100-gotScore)
+	}
+}
+
+func TestTallySnapshotCountsIncludesNodeFindings(t *testing.T) {
+	issues := []warRoomIssue{
+		{Severity: "critical"},
+		{Severity: "high"},
+	}
+	nodeHealth := []models.NodeConditionFinding{
+		{NodeName: "node-1", ConditionType: "Ready", ConditionStatus: "False"},        // critical
+		{NodeName: "node-2", ConditionType: "MemoryPressure", ConditionStatus: "True"}, // high -> warnings
+	}
+	critical, warnings := tallySnapshotCounts(issues, nodeHealth)
+	if critical != 2 {
+		t.Errorf("critical = %d, want 2 (1 pod issue + 1 Ready=False node)", critical)
+	}
+	if warnings != 2 {
+		t.Errorf("warnings = %d, want 2 (1 pod issue + 1 MemoryPressure node)", warnings)
+	}
+}
+
+func TestTallySnapshotCountsEmptyInputs(t *testing.T) {
+	critical, warnings := tallySnapshotCounts(nil, nil)
+	if critical != 0 || warnings != 0 {
+		t.Errorf("tallySnapshotCounts(nil, nil) = (%d, %d), want (0, 0)", critical, warnings)
+	}
+}

--- a/cmd/opscart-dashboard/scan.go
+++ b/cmd/opscart-dashboard/scan.go
@@ -83,15 +83,9 @@ func (s *dashboardState) refresh(clusterList []string) error {
 		incScore, _, _ := calcIncidentScore(scan)
 		issues := collectWarRoomIssues(scan, 0)
 
-		critical, warnings := 0, 0
+		critical, warnings := tallySnapshotCounts(issues, scan.nodeHealth)
 		var incidents []store.IncidentData
 		for _, is := range issues {
-			if is.Severity == "critical" {
-				critical++
-			} else {
-				warnings++
-			}
-
 			details, _ := json.Marshal(map[string]any{
 				"resource_age_days": is.ResourceAgeDays,
 				"message":           is.Message,
@@ -144,6 +138,32 @@ func (s *dashboardState) refresh(clusterList []string) error {
 
 	log.Printf("[%s] scan complete: %d namespaces, $%s/month, %d critical issues", displayName(s.ctx), len(scan.report.NamespaceCosts), formatMoney(scan.report.TotalMonthlyCost), countCriticalIssues(scan))
 	return nil
+}
+
+// tallySnapshotCounts computes the critical/warning counts for a scan
+// snapshot. Pod-scoped issues come from collectWarRoomIssues; node findings
+// are counted separately from nodeHealth because collectWarRoomIssues has
+// no DB access to correlate node incidents (see collectActiveNodeWarRoomIssues,
+// which does but requires a persisted incident to already exist — wrong
+// timing for this call site, which runs before this scan's node incidents
+// are persisted).
+func tallySnapshotCounts(issues []warRoomIssue, nodeHealth []models.NodeConditionFinding) (critical, warnings int) {
+	for _, is := range issues {
+		if is.Severity == "critical" {
+			critical++
+		} else {
+			warnings++
+		}
+	}
+	for _, finding := range nodeHealth {
+		switch sev, _ := models.NodeConditionSeverity(finding.ConditionType); sev {
+		case "critical":
+			critical++
+		case "high":
+			warnings++
+		}
+	}
+	return critical, warnings
 }
 
 func completeIncidentBatch(workloads []store.IncidentData, nodeFindings []models.NodeConditionFinding) []store.IncidentData {

--- a/cmd/opscart-dashboard/server.go
+++ b/cmd/opscart-dashboard/server.go
@@ -471,6 +471,33 @@ func calcIncidentScore(scan *clusterScan) (score int, color string, label string
 	}
 	penalties += nsPenalty
 
+	// Node conditions: uses scan.nodeHealth directly rather than the
+	// DB-backed War Room node-issue query. calcIncidentScore runs before
+	// this scan's node incidents are persisted (see refresh() in scan.go),
+	// so a DB query here would read the PREVIOUS scan's data, not this
+	// one — scan.nodeHealth is what this scan pass actually observed.
+	criticalNodes, highNodes := 0, 0
+	for _, finding := range scan.nodeHealth {
+		switch sev, _ := models.NodeConditionSeverity(finding.ConditionType); sev {
+		case "critical":
+			criticalNodes++
+		case "high":
+			highNodes++
+		}
+	}
+	// Critical node conditions (e.g. Ready=False): -10 each, cap at -30
+	nodeCriticalPenalty := criticalNodes * 10
+	if nodeCriticalPenalty > 30 {
+		nodeCriticalPenalty = 30
+	}
+	penalties += nodeCriticalPenalty
+	// High node conditions (pressure/network): -4 each, cap at -12
+	nodeHighPenalty := highNodes * 4
+	if nodeHighPenalty > 12 {
+		nodeHighPenalty = 12
+	}
+	penalties += nodeHighPenalty
+
 	// Waste: orphaned PVCs -1 each, cap at -5
 	if scan.wasteAudit != nil {
 		pvcPenalty := len(scan.wasteAudit.OrphanedPVCs)
@@ -519,6 +546,15 @@ func countCriticalIssues(scan *clusterScan) int {
 	count := 0
 	for _, issue := range issues {
 		if issue.Severity == "critical" {
+			count++
+		}
+	}
+	// Node conditions aren't in collectWarRoomIssues (that one requires DB
+	// access to correlate against persisted incidents — see
+	// collectActiveNodeWarRoomIssues). Count directly from this scan's
+	// observed node findings instead.
+	for _, finding := range scan.nodeHealth {
+		if sev, _ := models.NodeConditionSeverity(finding.ConditionType); sev == "critical" {
 			count++
 		}
 	}


### PR DESCRIPTION
Count critical node conditions in sidebar badges and include node severity in incident scoring.

Include critical and high-severity node conditions in persisted snapshot totals using current scan data rather than potentially stale database records.

Preserve existing node incident persistence and resource-aware fingerprints.

Add regression tests covering critical versus high node conditions, scoring penalties, penalty caps, and snapshot totals.