### PR TITLE
Validation / optimization checkpoint

### DIFF
--- a/cmd/opscart-dashboard/investigation.go
+++ b/cmd/opscart-dashboard/investigation.go
@@ -324,8 +324,29 @@ func investigationHints(issueType string, stateReason string, restarts int32, po
 	return hints
 }
 
-// resolveOwner walks Pod → ReplicaSet → Deployment (or returns the direct owner).
-func resolveOwner(clientset kubernetes.Interface, pod *corev1.Pod) (kind, name string) {
+type replicaSetOwnerKey struct {
+	namespace string
+	name      string
+}
+
+type ownerResolution struct {
+	kind string
+	name string
+}
+
+// ownerResolver caches successful ReplicaSet lookups for one Investigation
+// request. A resolver is never stored on server or shared across requests.
+type ownerResolver struct {
+	clientset   kubernetes.Interface
+	replicaSets map[replicaSetOwnerKey]ownerResolution
+}
+
+func newOwnerResolver(clientset kubernetes.Interface) *ownerResolver {
+	return &ownerResolver{clientset: clientset, replicaSets: make(map[replicaSetOwnerKey]ownerResolution)}
+}
+
+// resolve walks Pod → ReplicaSet → Deployment (or returns the direct owner).
+func (r *ownerResolver) resolve(pod *corev1.Pod) (kind, name string) {
 	if len(pod.OwnerReferences) == 0 {
 		return "", ""
 	}
@@ -334,14 +355,25 @@ func resolveOwner(clientset kubernetes.Interface, pod *corev1.Pod) (kind, name s
 
 	// If owned by a ReplicaSet, walk up to the Deployment
 	if ref.Kind == "ReplicaSet" {
-		rs, err := clientset.AppsV1().ReplicaSets(pod.Namespace).Get(
+		key := replicaSetOwnerKey{namespace: pod.Namespace, name: ref.Name}
+		if cached, ok := r.replicaSets[key]; ok {
+			return cached.kind, cached.name
+		}
+		rs, err := r.clientset.AppsV1().ReplicaSets(pod.Namespace).Get(
 			context.TODO(), ref.Name, metav1.GetOptions{})
 		if err == nil && len(rs.OwnerReferences) > 0 {
 			parent := rs.OwnerReferences[0]
 			kind, name = parent.Kind, parent.Name
 		}
+		if err == nil {
+			r.replicaSets[key] = ownerResolution{kind: kind, name: name}
+		}
 	}
 	return kind, name
+}
+
+func resolveOwner(clientset kubernetes.Interface, pod *corev1.Pod) (kind, name string) {
+	return newOwnerResolver(clientset).resolve(pod)
 }
 
 // podEvents returns the last n events for a specific pod, newest first.
@@ -443,7 +475,7 @@ func referencedResources(pod *corev1.Pod) (cms, secrets, pvcs []string) {
 }
 
 // blastRadiusSiblings returns all pods owned by the same workload.
-func blastRadiusSiblings(clientset kubernetes.Interface, namespace, ownerKind, ownerName string) (pods []blastRadiusPod, healthy, total int) {
+func blastRadiusSiblings(clientset kubernetes.Interface, resolver *ownerResolver, namespace, ownerKind, ownerName string) (pods []blastRadiusPod, healthy, total int) {
 	if ownerName == "" {
 		return
 	}
@@ -452,7 +484,7 @@ func blastRadiusSiblings(clientset kubernetes.Interface, namespace, ownerKind, o
 		return
 	}
 	for _, p := range list.Items {
-		kind, name := resolveOwner(clientset, &p)
+		kind, name := resolver.resolve(&p)
 		if kind != ownerKind || name != ownerName {
 			continue
 		}
@@ -589,7 +621,7 @@ func blastIngresses(clientset kubernetes.Interface, namespace string, serviceNam
 
 // blastNamespaceHealth counts healthy vs total pods per workload in the namespace,
 // excluding the pod under investigation.
-func blastNamespaceHealth(clientset kubernetes.Interface, namespace, excludeOwnerName string) (workloads []blastNamespacePod, healthy, total int) {
+func blastNamespaceHealth(clientset kubernetes.Interface, resolver *ownerResolver, namespace, excludeOwnerName string) (workloads []blastNamespacePod, healthy, total int) {
 	list, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return
@@ -597,7 +629,7 @@ func blastNamespaceHealth(clientset kubernetes.Interface, namespace, excludeOwne
 	type counts struct{ h, t int }
 	tally := map[string]*counts{}
 	for _, p := range list.Items {
-		_, ownerName := resolveOwner(clientset, &p)
+		_, ownerName := resolver.resolve(&p)
 		if ownerName == excludeOwnerName {
 			continue
 		}
@@ -992,7 +1024,8 @@ func (srv *server) handleInvestigationPage(w http.ResponseWriter, r *http.Reques
 		isActiveInvestigationTarget(scan, namespace, podName, issueType)
 
 	// Owner, events, related resources, hints
-	data.OwnerKind, data.OwnerName = resolveOwner(clientset, pod)
+	ownerResolver := newOwnerResolver(clientset)
+	data.OwnerKind, data.OwnerName = ownerResolver.resolve(pod)
 	if data.OwnerKind != "" {
 		data.WorkloadLabel = data.OwnerKind + "/" + data.OwnerName
 		if data.OwnerKind == "StatefulSet" {
@@ -1010,7 +1043,7 @@ func (srv *server) handleInvestigationPage(w http.ResponseWriter, r *http.Reques
 	data.Hints = investigationHints(issueType, data.StateReason, data.Restarts, pod, namespace)
 
 	// Blast radius
-	data.BlastSiblings, data.BlastHealthy, data.BlastTotal = blastRadiusSiblings(clientset, namespace, data.OwnerKind, data.OwnerName)
+	data.BlastSiblings, data.BlastHealthy, data.BlastTotal = blastRadiusSiblings(clientset, ownerResolver, namespace, data.OwnerKind, data.OwnerName)
 	data.BlastServices = blastRadiusServices(clientset, namespace, pod.Labels)
 	data.BlastSharedConf = blastRadiusSharedConfig(clientset, namespace, data.OwnerName, data.ConfigMaps, data.Secrets)
 
@@ -1019,7 +1052,7 @@ func (srv *server) handleInvestigationPage(w http.ResponseWriter, r *http.Reques
 		svcNames = append(svcNames, s.Name)
 	}
 	data.BlastIngresses = blastIngresses(clientset, namespace, svcNames)
-	data.BlastNamespacePods, data.BlastNsHealthy, data.BlastNsTotal = blastNamespaceHealth(clientset, namespace, data.OwnerName)
+	data.BlastNamespacePods, data.BlastNsHealthy, data.BlastNsTotal = blastNamespaceHealth(clientset, ownerResolver, namespace, data.OwnerName)
 	data.CustomerImpact = deriveCustomerImpact(data.BlastIngresses, data.BlastServices)
 
 	// ── First detected (from incidents table) ─────────────────────────────────

--- a/cmd/opscart-dashboard/investigation.go
+++ b/cmd/opscart-dashboard/investigation.go
@@ -958,17 +958,21 @@ func (srv *server) handleInvestigationPage(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Live cluster data — fresh client, not scan cache
-	clientset, err := srv.kubeClientFor(ctx)
-	if err != nil {
-		log.Printf("investigation: kube client: %v", err)
-		http.Error(w, "cluster connection failed", http.StatusBadGateway)
-		return
-	}
 	if idx := strings.Index(podName, "/"); idx != -1 {
 		data.PodName = podName[:idx]
 		data.ContainerName = podName[idx+1:]
 		podName = podName[:idx]
+	}
+	// Live cluster data — fresh client, not scan cache. The local recorder is
+	// unique to this HTML request, so concurrent API traffic cannot enter it.
+	investigationCounters := newAPICounters()
+	investigationStarted := time.Now()
+	defer srv.completeInvestigation(namespace, podName, investigationStarted, investigationCounters)
+	clientset, err := srv.kubeClientFor(ctx, investigationCounters)
+	if err != nil {
+		log.Printf("investigation: kube client: %v", err)
+		http.Error(w, "cluster connection failed", http.StatusBadGateway)
+		return
 	}
 	pod, err := clientset.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
 	if err != nil {

--- a/cmd/opscart-dashboard/investigation.go
+++ b/cmd/opscart-dashboard/investigation.go
@@ -475,15 +475,11 @@ func referencedResources(pod *corev1.Pod) (cms, secrets, pvcs []string) {
 }
 
 // blastRadiusSiblings returns all pods owned by the same workload.
-func blastRadiusSiblings(clientset kubernetes.Interface, resolver *ownerResolver, namespace, ownerKind, ownerName string) (pods []blastRadiusPod, healthy, total int) {
+func blastRadiusSiblings(namespacePods []corev1.Pod, resolver *ownerResolver, ownerKind, ownerName string) (pods []blastRadiusPod, healthy, total int) {
 	if ownerName == "" {
 		return
 	}
-	list, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return
-	}
-	for _, p := range list.Items {
+	for _, p := range namespacePods {
 		kind, name := resolver.resolve(&p)
 		if kind != ownerKind || name != ownerName {
 			continue
@@ -621,14 +617,10 @@ func blastIngresses(clientset kubernetes.Interface, namespace string, serviceNam
 
 // blastNamespaceHealth counts healthy vs total pods per workload in the namespace,
 // excluding the pod under investigation.
-func blastNamespaceHealth(clientset kubernetes.Interface, resolver *ownerResolver, namespace, excludeOwnerName string) (workloads []blastNamespacePod, healthy, total int) {
-	list, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return
-	}
+func blastNamespaceHealth(namespacePods []corev1.Pod, resolver *ownerResolver, excludeOwnerName string) (workloads []blastNamespacePod, healthy, total int) {
 	type counts struct{ h, t int }
 	tally := map[string]*counts{}
-	for _, p := range list.Items {
+	for _, p := range namespacePods {
 		_, ownerName := resolver.resolve(&p)
 		if ownerName == excludeOwnerName {
 			continue
@@ -1047,7 +1039,12 @@ func (srv *server) handleInvestigationPage(w http.ResponseWriter, r *http.Reques
 	data.Hints = investigationHints(issueType, data.StateReason, data.Restarts, pod, namespace)
 
 	// Blast radius
-	data.BlastSiblings, data.BlastHealthy, data.BlastTotal = blastRadiusSiblings(clientset, ownerResolver, namespace, data.OwnerKind, data.OwnerName)
+	namespacePods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		namespacePods = &corev1.PodList{}
+	}
+	podSnapshotAvailable := err == nil
+	data.BlastSiblings, data.BlastHealthy, data.BlastTotal = blastRadiusSiblings(namespacePods.Items, ownerResolver, data.OwnerKind, data.OwnerName)
 	data.BlastServices = blastRadiusServices(clientset, namespace, pod.Labels)
 	data.BlastSharedConf = blastRadiusSharedConfig(clientset, namespace, data.OwnerName, data.ConfigMaps, data.Secrets)
 
@@ -1056,7 +1053,14 @@ func (srv *server) handleInvestigationPage(w http.ResponseWriter, r *http.Reques
 		svcNames = append(svcNames, s.Name)
 	}
 	data.BlastIngresses = blastIngresses(clientset, namespace, svcNames)
-	data.BlastNamespacePods, data.BlastNsHealthy, data.BlastNsTotal = blastNamespaceHealth(clientset, ownerResolver, namespace, data.OwnerName)
+	if !podSnapshotAvailable {
+		// Preserve the legacy partial-result behavior: the sibling lookup could
+		// fail while the later namespace-health lookup still succeeded.
+		if fallbackPods, fallbackErr := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{}); fallbackErr == nil {
+			namespacePods = fallbackPods
+		}
+	}
+	data.BlastNamespacePods, data.BlastNsHealthy, data.BlastNsTotal = blastNamespaceHealth(namespacePods.Items, ownerResolver, data.OwnerName)
 	data.CustomerImpact = deriveCustomerImpact(data.BlastIngresses, data.BlastServices)
 
 	// ── First detected (from incidents table) ─────────────────────────────────

--- a/cmd/opscart-dashboard/investigation_logs.go
+++ b/cmd/opscart-dashboard/investigation_logs.go
@@ -22,7 +22,7 @@ const (
 	investigationLogMaxBytes  int64 = 256 * 1024
 )
 
-type kubeClientFactory func(string) (kubernetes.Interface, error)
+type kubeClientFactory func(string, *apiCounters) (kubernetes.Interface, error)
 
 type podLogReaderFunc func(context.Context, kubernetes.Interface, string, string, *corev1.PodLogOptions) ([]byte, error)
 
@@ -133,7 +133,7 @@ func (srv *server) handleInvestigationLogs(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	clientset, err := srv.kubeClientFor(ctxName)
+	clientset, err := srv.kubeClientFor(ctxName, nil)
 	if err != nil {
 		log.Printf("investigation logs: kube client: %v", err)
 		writeInvestigationLogError(w, http.StatusBadGateway, "cluster connection failed")

--- a/cmd/opscart-dashboard/investigation_logs_test.go
+++ b/cmd/opscart-dashboard/investigation_logs_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/opscart/opscart-k8s-watcher/pkg/analyzer"
 	corev1 "k8s.io/api/core/v1"
@@ -66,7 +67,7 @@ func newContainerLogTestServer(t *testing.T) *server {
 	srv := newTestServer()
 	srv.logsEnabled = true
 	clientset := fake.NewSimpleClientset(multiContainerInvestigationPod())
-	srv.kubeClientFor = func(string) (kubernetes.Interface, error) {
+	srv.kubeClientFor = func(string, *apiCounters) (kubernetes.Interface, error) {
 		return clientset, nil
 	}
 	state := srv.getState(bogusClusterCtx)
@@ -148,6 +149,35 @@ func TestHandleInvestigationLogsSelectsOneContainerAndSource(t *testing.T) {
 	}
 }
 
+func TestInvestigationLogsAreExcludedFromLatestInvestigationMeasurement(t *testing.T) {
+	srv := newContainerLogTestServer(t)
+	counters := newAPICounters()
+	counters.recordRequest("GET", "replicasets", "200")
+	srv.completeInvestigation("payments", "fraud-detection-abc123", time.Now().Add(-time.Second), counters)
+	want := srv.investigationSnapshot()
+	originalFactory := srv.kubeClientFor
+	srv.kubeClientFor = func(ctx string, local *apiCounters) (kubernetes.Interface, error) {
+		if local != nil {
+			t.Fatal("log endpoint received Investigation-local counters")
+		}
+		return originalFactory(ctx, local)
+	}
+	srv.podLogReader = func(context.Context, kubernetes.Interface, string, string, *corev1.PodLogOptions) ([]byte, error) {
+		return []byte("log line"), nil
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/investigation/logs?cluster="+bogusClusterCtx+"&ns=payments&pod=fraud-detection-abc123&type=crash_loop&container=app&previous=true", nil)
+	rec := httptest.NewRecorder()
+	srv.handleInvestigationLogs(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("log status = %d: %s", rec.Code, rec.Body.String())
+	}
+	got := srv.investigationSnapshot()
+	if got.CompletedAt != want.CompletedAt || got.API.Requests[apiMetricKey{"GET", "replicasets", "200"}] != 1 {
+		t.Fatalf("log request replaced latest Investigation: got %+v, want %+v", got, want)
+	}
+}
+
 func TestHandleInvestigationLogsRejectsUnavailablePreviousLogs(t *testing.T) {
 	srv := newContainerLogTestServer(t)
 	readerCalled := false
@@ -172,7 +202,7 @@ func TestHandleInvestigationLogsWhenDisabled(t *testing.T) {
 	t.Setenv("OPSCART_LOGS_ENABLED", "false")
 	srv := newTestServer()
 	clientCalled := false
-	srv.kubeClientFor = func(string) (kubernetes.Interface, error) {
+	srv.kubeClientFor = func(string, *apiCounters) (kubernetes.Interface, error) {
 		clientCalled = true
 		return nil, nil
 	}
@@ -192,7 +222,7 @@ func TestHandleInvestigationLogsWhenDisabled(t *testing.T) {
 func TestHandleInvestigationLogsRejectsNonIssuePod(t *testing.T) {
 	srv := newContainerLogTestServer(t)
 	clientCalled := false
-	srv.kubeClientFor = func(string) (kubernetes.Interface, error) {
+	srv.kubeClientFor = func(string, *apiCounters) (kubernetes.Interface, error) {
 		clientCalled = true
 		return nil, nil
 	}

--- a/cmd/opscart-dashboard/investigation_owner_cache_test.go
+++ b/cmd/opscart-dashboard/investigation_owner_cache_test.go
@@ -59,7 +59,7 @@ func requestPodInvestigation(t *testing.T, client *fake.Clientset, podName, name
 	t.Helper()
 	srv := newTestServer()
 	srv.logsEnabled = false
-	srv.kubeClientFor = func(string) (kubernetes.Interface, error) { return client, nil }
+	srv.kubeClientFor = func(string, *apiCounters) (kubernetes.Interface, error) { return client, nil }
 	req := httptest.NewRequest(http.MethodGet, "/investigate?cluster="+bogusClusterCtx+"&ns="+namespace+"&pod="+podName+"&type=crash_loop", nil)
 	rec := httptest.NewRecorder()
 	srv.handleInvestigationPage(rec, req)

--- a/cmd/opscart-dashboard/investigation_owner_cache_test.go
+++ b/cmd/opscart-dashboard/investigation_owner_cache_test.go
@@ -55,6 +55,16 @@ func replicaSetGETCount(client *fake.Clientset) int {
 	return count
 }
 
+func podLISTCount(client *fake.Clientset) int {
+	count := 0
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "list" && action.GetResource().Resource == "pods" {
+			count++
+		}
+	}
+	return count
+}
+
 func requestPodInvestigation(t *testing.T, client *fake.Clientset, podName, namespace string) string {
 	t.Helper()
 	srv := newTestServer()
@@ -76,14 +86,47 @@ func TestInvestigationOwnerCacheFetchesReplicaSetOncePerRequest(t *testing.T) {
 		investigationOwnedPod(namespace, "api-1", "ReplicaSet", "api-abc123"),
 		investigationOwnedPod(namespace, "api-2", "ReplicaSet", "api-abc123"),
 		investigationOwnedPod(namespace, "api-3", "ReplicaSet", "api-abc123"),
+		investigationOwnedPod(namespace, "worker-0", "StatefulSet", "worker"),
 	)
 	body := requestPodInvestigation(t, client, "api-1", namespace)
+	if got := podLISTCount(client); got != 1 {
+		t.Fatalf("Pod LISTs = %d, want one shared namespace snapshot", got)
+	}
 	if got := replicaSetGETCount(client); got != 1 {
 		t.Fatalf("ReplicaSet GETs = %d, want 1", got)
 	}
-	for _, want := range []string{"Deployment/api", "api-1", "api-2", "api-3"} {
+	for _, want := range []string{"Deployment/api", "api-1", "api-2", "api-3", "Sibling Pods", "Other pods in namespace", "worker"} {
 		if !strings.Contains(body, want) {
 			t.Errorf("Investigation output missing %q", want)
+		}
+	}
+}
+
+func TestInvestigationSharedPodSnapshotFailurePreservesLegacyPartialResults(t *testing.T) {
+	const namespace = "payments"
+	client := fake.NewSimpleClientset(
+		investigationReplicaSet(namespace, "api-abc123", "api"),
+		investigationOwnedPod(namespace, "api-1", "ReplicaSet", "api-abc123"),
+		investigationOwnedPod(namespace, "worker-0", "StatefulSet", "worker"),
+	)
+	listCalls := 0
+	client.PrependReactor("list", "pods", func(ktesting.Action) (bool, runtime.Object, error) {
+		listCalls++
+		if listCalls == 1 {
+			return true, nil, errors.New("pods unavailable")
+		}
+		return false, nil, nil
+	})
+	body := requestPodInvestigation(t, client, "api-1", namespace)
+	if got := podLISTCount(client); got != 2 {
+		t.Fatalf("Pod LISTs after snapshot failure = %d, want legacy second attempt", got)
+	}
+	if strings.Contains(body, "Sibling Pods") {
+		t.Error("failed sibling snapshot unexpectedly rendered sibling results")
+	}
+	for _, want := range []string{"Other pods in namespace", "worker"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("legacy namespace-health fallback missing %q", want)
 		}
 	}
 }

--- a/cmd/opscart-dashboard/investigation_owner_cache_test.go
+++ b/cmd/opscart-dashboard/investigation_owner_cache_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func investigationReplicaSet(namespace, name, deployment string) *appsv1.ReplicaSet {
+	return &appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{
+		Namespace: namespace,
+		Name:      name,
+		OwnerReferences: []metav1.OwnerReference{{
+			Kind: "Deployment", Name: deployment,
+		}},
+	}}
+}
+
+func investigationOwnedPod(namespace, name, ownerKind, ownerName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			OwnerReferences: []metav1.OwnerReference{{
+				Kind: ownerKind, Name: ownerName,
+			}},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "app", Ready: true,
+			}},
+		},
+	}
+}
+
+func replicaSetGETCount(client *fake.Clientset) int {
+	count := 0
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "get" && action.GetResource().Resource == "replicasets" {
+			count++
+		}
+	}
+	return count
+}
+
+func requestPodInvestigation(t *testing.T, client *fake.Clientset, podName, namespace string) string {
+	t.Helper()
+	srv := newTestServer()
+	srv.logsEnabled = false
+	srv.kubeClientFor = func(string) (kubernetes.Interface, error) { return client, nil }
+	req := httptest.NewRequest(http.MethodGet, "/investigate?cluster="+bogusClusterCtx+"&ns="+namespace+"&pod="+podName+"&type=crash_loop", nil)
+	rec := httptest.NewRecorder()
+	srv.handleInvestigationPage(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Investigation status = %d: %s", rec.Code, rec.Body.String())
+	}
+	return rec.Body.String()
+}
+
+func TestInvestigationOwnerCacheFetchesReplicaSetOncePerRequest(t *testing.T) {
+	const namespace = "payments"
+	client := fake.NewSimpleClientset(
+		investigationReplicaSet(namespace, "api-abc123", "api"),
+		investigationOwnedPod(namespace, "api-1", "ReplicaSet", "api-abc123"),
+		investigationOwnedPod(namespace, "api-2", "ReplicaSet", "api-abc123"),
+		investigationOwnedPod(namespace, "api-3", "ReplicaSet", "api-abc123"),
+	)
+	body := requestPodInvestigation(t, client, "api-1", namespace)
+	if got := replicaSetGETCount(client); got != 1 {
+		t.Fatalf("ReplicaSet GETs = %d, want 1", got)
+	}
+	for _, want := range []string{"Deployment/api", "api-1", "api-2", "api-3"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("Investigation output missing %q", want)
+		}
+	}
+}
+
+func TestInvestigationOwnerCacheFetchesEachDistinctReplicaSetOnce(t *testing.T) {
+	const namespace = "payments"
+	client := fake.NewSimpleClientset(
+		investigationReplicaSet(namespace, "api-abc123", "api"),
+		investigationReplicaSet(namespace, "worker-def456", "worker"),
+		investigationOwnedPod(namespace, "api-1", "ReplicaSet", "api-abc123"),
+		investigationOwnedPod(namespace, "api-2", "ReplicaSet", "api-abc123"),
+		investigationOwnedPod(namespace, "worker-1", "ReplicaSet", "worker-def456"),
+	)
+	requestPodInvestigation(t, client, "api-1", namespace)
+	if got := replicaSetGETCount(client); got != 2 {
+		t.Fatalf("ReplicaSet GETs = %d, want 2 distinct lookups", got)
+	}
+}
+
+func TestOwnerCacheIsolatesIdenticalReplicaSetNamesByNamespace(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		investigationReplicaSet("one", "api-abc123", "api-one"),
+		investigationReplicaSet("two", "api-abc123", "api-two"),
+	)
+	resolver := newOwnerResolver(client)
+	kindOne, nameOne := resolver.resolve(investigationOwnedPod("one", "api-1", "ReplicaSet", "api-abc123"))
+	kindTwo, nameTwo := resolver.resolve(investigationOwnedPod("two", "api-1", "ReplicaSet", "api-abc123"))
+	if kindOne != "Deployment" || nameOne != "api-one" || kindTwo != "Deployment" || nameTwo != "api-two" {
+		t.Fatalf("namespace-isolated results = %s/%s and %s/%s", kindOne, nameOne, kindTwo, nameTwo)
+	}
+	if got := replicaSetGETCount(client); got != 2 {
+		t.Fatalf("ReplicaSet GETs = %d, want 2", got)
+	}
+}
+
+func TestOwnerCacheDirectOwnersDoNotFetchReplicaSets(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	resolver := newOwnerResolver(client)
+	for _, tc := range []struct{ kind, name string }{{"StatefulSet", "database"}, {"DaemonSet", "agent"}} {
+		kind, name := resolver.resolve(investigationOwnedPod("app", tc.name+"-0", tc.kind, tc.name))
+		if kind != tc.kind || name != tc.name {
+			t.Errorf("direct owner = %s/%s, want %s/%s", kind, name, tc.kind, tc.name)
+		}
+	}
+	if got := replicaSetGETCount(client); got != 0 {
+		t.Fatalf("ReplicaSet GETs = %d, want 0", got)
+	}
+}
+
+func TestInvestigationOwnerCacheIsFreshForEachHTTPRequest(t *testing.T) {
+	const namespace = "payments"
+	client := fake.NewSimpleClientset(
+		investigationReplicaSet(namespace, "api-abc123", "api"),
+		investigationOwnedPod(namespace, "api-1", "ReplicaSet", "api-abc123"),
+	)
+	requestPodInvestigation(t, client, "api-1", namespace)
+	requestPodInvestigation(t, client, "api-1", namespace)
+	if got := replicaSetGETCount(client); got != 2 {
+		t.Fatalf("ReplicaSet GETs across two requests = %d, want 2", got)
+	}
+}
+
+func TestOwnerCacheDoesNotCacheFailedReplicaSetLookups(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	client.PrependReactor("get", "replicasets", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("temporary lookup failure")
+	})
+	resolver := newOwnerResolver(client)
+	pod := investigationOwnedPod("app", "api-1", "ReplicaSet", "api-abc123")
+	for i := 0; i < 2; i++ {
+		kind, name := resolver.resolve(pod)
+		if kind != "ReplicaSet" || name != "api-abc123" {
+			t.Fatalf("failed lookup result = %s/%s", kind, name)
+		}
+	}
+	if got := replicaSetGETCount(client); got != 2 {
+		t.Fatalf("failed ReplicaSet GETs = %d, want 2 uncached attempts", got)
+	}
+}

--- a/cmd/opscart-dashboard/main.go
+++ b/cmd/opscart-dashboard/main.go
@@ -143,7 +143,7 @@ func runDashboard(_ *cobra.Command, _ []string) error {
 		stopBackground()
 		srv.backgroundWG.Wait()
 	}()
-	srv.startBackgroundRefresh(backgroundCtx, 60*time.Second)
+	srv.startBackgroundRefresh(backgroundCtx, dashboardScanInterval)
 
 	addr := ":" + port
 	var httpHandlers sync.WaitGroup

--- a/cmd/opscart-dashboard/observability.go
+++ b/cmd/opscart-dashboard/observability.go
@@ -1,0 +1,309 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const dashboardScanInterval = 60 * time.Second
+
+type apiMetricKey struct {
+	Operation string
+	Resource  string
+	Result    string
+}
+
+type apiOperationKey struct {
+	Operation string
+	Resource  string
+}
+
+type apiCounters struct {
+	mu       sync.RWMutex
+	requests map[apiMetricKey]uint64
+	objects  map[string]uint64
+}
+
+func newAPICounters() *apiCounters {
+	return &apiCounters{requests: make(map[apiMetricKey]uint64), objects: make(map[string]uint64)}
+}
+
+func (c *apiCounters) recordRequest(operation, resource, result string) {
+	c.mu.Lock()
+	c.requests[apiMetricKey{operation, resource, result}]++
+	c.mu.Unlock()
+}
+
+func (c *apiCounters) recordObjects(resource string, count uint64) {
+	if count == 0 {
+		return
+	}
+	c.mu.Lock()
+	c.objects[resource] += count
+	c.mu.Unlock()
+}
+
+type apiCounterSnapshot struct {
+	Requests map[apiMetricKey]uint64
+	Objects  map[string]uint64
+}
+
+func (c *apiCounters) snapshot() apiCounterSnapshot {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	s := apiCounterSnapshot{Requests: make(map[apiMetricKey]uint64, len(c.requests)), Objects: make(map[string]uint64, len(c.objects))}
+	for k, v := range c.requests {
+		s.Requests[k] = v
+	}
+	for k, v := range c.objects {
+		s.Objects[k] = v
+	}
+	return s
+}
+
+func (s apiCounterSnapshot) totals() (requests, errors uint64) {
+	for key, count := range s.Requests {
+		requests += count
+		if key.Result == "error" || strings.HasPrefix(key.Result, "4") || strings.HasPrefix(key.Result, "5") {
+			errors += count
+		}
+	}
+	return
+}
+
+var processAPICounters = newAPICounters()
+
+type measuringTransport struct {
+	base       http.RoundTripper
+	cumulative *apiCounters
+	scan       *apiCounters
+}
+
+func (t *measuringTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	operation, resource := classifyKubernetesRequest(req.Method, req.URL)
+	resp, err := t.base.RoundTrip(req)
+	result := "error"
+	if err == nil && resp != nil {
+		result = strconv.Itoa(resp.StatusCode)
+	}
+	t.cumulative.recordRequest(operation, resource, result)
+	if t.scan != nil {
+		t.scan.recordRequest(operation, resource, result)
+	}
+	if err == nil && resp != nil && resp.Body != nil && operation == "LIST" {
+		resp.Body = &countingResponseBody{ReadCloser: resp.Body, resource: resource, counters: []*apiCounters{t.cumulative, t.scan}}
+	}
+	return resp, err
+}
+
+type countingResponseBody struct {
+	io.ReadCloser
+	resource string
+	counters []*apiCounters
+	buf      bytes.Buffer
+	once     sync.Once
+}
+
+func (b *countingResponseBody) Read(p []byte) (int, error) {
+	n, err := b.ReadCloser.Read(p)
+	if n > 0 {
+		_, _ = b.buf.Write(p[:n])
+	}
+	if err == io.EOF {
+		b.count()
+	}
+	return n, err
+}
+
+func (b *countingResponseBody) Close() error {
+	err := b.ReadCloser.Close()
+	b.count()
+	return err
+}
+
+func (b *countingResponseBody) count() {
+	b.once.Do(func() {
+		var list struct {
+			Items []json.RawMessage `json:"items"`
+		}
+		if json.Unmarshal(b.buf.Bytes(), &list) != nil {
+			return
+		}
+		for _, counters := range b.counters {
+			if counters != nil {
+				counters.recordObjects(b.resource, uint64(len(list.Items)))
+			}
+		}
+	})
+}
+
+func classifyKubernetesRequest(method string, u *url.URL) (operation, resource string) {
+	segments := strings.FieldsFunc(u.Path, func(r rune) bool { return r == '/' })
+	resourceIndex := -1
+	if len(segments) >= 3 && segments[0] == "api" {
+		resourceIndex = 2
+	} else if len(segments) >= 4 && segments[0] == "apis" {
+		resourceIndex = 3
+	}
+	resource = "unknown"
+	if resourceIndex >= 0 && resourceIndex < len(segments) {
+		if segments[resourceIndex] == "watch" && resourceIndex+1 < len(segments) {
+			resourceIndex++
+		}
+		if segments[resourceIndex] == "namespaces" && resourceIndex+2 < len(segments) {
+			resourceIndex += 2
+		}
+		resource = segments[resourceIndex]
+	}
+
+	if resource == "pods" && resourceIndex+2 < len(segments) && segments[resourceIndex+2] == "log" {
+		return "POD_LOG_GET", resource
+	}
+	if strings.EqualFold(u.Query().Get("watch"), "true") || (resourceIndex > 0 && segments[resourceIndex-1] == "watch") {
+		return "WATCH", resource
+	}
+	if method != http.MethodGet {
+		return strings.ToUpper(method), resource
+	}
+	if resourceIndex == len(segments)-1 {
+		return "LIST", resource
+	}
+	return "GET", resource
+}
+
+type scanObservation struct {
+	CompletedAt time.Time
+	Duration    time.Duration
+	API         apiCounterSnapshot
+}
+
+type diagnosticOperation struct {
+	Operation string
+	Resource  string
+	Count     uint64
+}
+
+type diagnosticsPageData struct {
+	Cluster       string
+	CompletedAt   string
+	Duration      string
+	Interval      string
+	Requests      uint64
+	Errors        uint64
+	Pods          uint64
+	Nodes         uint64
+	Namespaces    uint64
+	Events        uint64
+	TopOperations []diagnosticOperation
+}
+
+func (srv *server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
+	state := srv.getState(srv.activeCtx(r))
+	state.mu.RLock()
+	obs := state.observation
+	state.mu.RUnlock()
+	requests, errors := obs.API.totals()
+	data := diagnosticsPageData{Cluster: displayName(state.ctx), CompletedAt: "No completed scan", Interval: dashboardScanInterval.String(), Requests: requests, Errors: errors,
+		Pods: obs.API.Objects["pods"], Nodes: obs.API.Objects["nodes"], Namespaces: obs.API.Objects["namespaces"], Events: obs.API.Objects["events"]}
+	if !obs.CompletedAt.IsZero() {
+		data.CompletedAt = obs.CompletedAt.Format(time.RFC3339)
+		data.Duration = obs.Duration.Round(time.Millisecond).String()
+	}
+	byOperation := make(map[apiOperationKey]uint64)
+	for key, count := range obs.API.Requests {
+		byOperation[apiOperationKey{key.Operation, key.Resource}] += count
+	}
+	for key, count := range byOperation {
+		data.TopOperations = append(data.TopOperations, diagnosticOperation{key.Operation, key.Resource, count})
+	}
+	sort.Slice(data.TopOperations, func(i, j int) bool { return data.TopOperations[i].Count > data.TopOperations[j].Count })
+	if len(data.TopOperations) > 10 {
+		data.TopOperations = data.TopOperations[:10]
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := getDiagnosticsTmpl().Execute(w, data); err != nil {
+		http.Error(w, "template error", http.StatusInternalServerError)
+	}
+}
+
+var getDiagnosticsTmpl = sync.OnceValue(func() *template.Template {
+	return template.Must(template.New("diagnostics.html").ParseFS(templateFS, "templates/base.html", "templates/diagnostics.html"))
+})
+
+func (srv *server) handleMetrics(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	writePrometheusMetrics(w, processAPICounters.snapshot(), srv.observationSnapshots())
+}
+
+func (srv *server) observationSnapshots() map[string]scanObservation {
+	srv.mu.RLock()
+	defer srv.mu.RUnlock()
+	result := make(map[string]scanObservation, len(srv.states))
+	for cluster, state := range srv.states {
+		state.mu.RLock()
+		result[displayName(cluster)] = state.observation
+		state.mu.RUnlock()
+	}
+	return result
+}
+
+func writePrometheusMetrics(w io.Writer, cumulative apiCounterSnapshot, observations map[string]scanObservation) {
+	fmt.Fprintln(w, "# HELP opscart_kubernetes_api_requests_total Kubernetes API requests made by this process.")
+	fmt.Fprintln(w, "# TYPE opscart_kubernetes_api_requests_total counter")
+	keys := make([]apiMetricKey, 0, len(cumulative.Requests))
+	for key := range cumulative.Requests {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].Operation != keys[j].Operation {
+			return keys[i].Operation < keys[j].Operation
+		}
+		if keys[i].Resource != keys[j].Resource {
+			return keys[i].Resource < keys[j].Resource
+		}
+		return keys[i].Result < keys[j].Result
+	})
+	for _, key := range keys {
+		fmt.Fprintf(w, "opscart_kubernetes_api_requests_total{operation=%q,resource=%q,status=%q} %d\n", key.Operation, key.Resource, key.Result, cumulative.Requests[key])
+	}
+	fmt.Fprintln(w, "# HELP opscart_scanner_last_scan_duration_seconds Wall-clock duration of the latest completed full scan.")
+	fmt.Fprintln(w, "# TYPE opscart_scanner_last_scan_duration_seconds gauge")
+	fmt.Fprintln(w, "# HELP opscart_scanner_last_scan_timestamp_seconds Unix timestamp of the latest completed full scan.")
+	fmt.Fprintln(w, "# TYPE opscart_scanner_last_scan_timestamp_seconds gauge")
+	fmt.Fprintln(w, "# HELP opscart_scanner_last_scan_api_requests Kubernetes API requests made by the latest completed full scan.")
+	fmt.Fprintln(w, "# TYPE opscart_scanner_last_scan_api_requests gauge")
+	fmt.Fprintln(w, "# HELP opscart_scanner_last_scan_api_errors Kubernetes API transport errors and HTTP 4xx/5xx responses in the latest completed full scan.")
+	fmt.Fprintln(w, "# TYPE opscart_scanner_last_scan_api_errors gauge")
+	fmt.Fprintln(w, "# HELP opscart_scanner_last_scan_objects_examined Kubernetes objects returned in LIST responses to the latest completed full scan.")
+	fmt.Fprintln(w, "# TYPE opscart_scanner_last_scan_objects_examined gauge")
+	clusters := make([]string, 0, len(observations))
+	for cluster := range observations {
+		clusters = append(clusters, cluster)
+	}
+	sort.Strings(clusters)
+	for _, cluster := range clusters {
+		obs := observations[cluster]
+		requests, errors := obs.API.totals()
+		fmt.Fprintf(w, "opscart_scanner_last_scan_duration_seconds{cluster=%q} %g\n", cluster, obs.Duration.Seconds())
+		timestamp := int64(0)
+		if !obs.CompletedAt.IsZero() {
+			timestamp = obs.CompletedAt.Unix()
+		}
+		fmt.Fprintf(w, "opscart_scanner_last_scan_timestamp_seconds{cluster=%q} %d\n", cluster, timestamp)
+		fmt.Fprintf(w, "opscart_scanner_last_scan_api_requests{cluster=%q} %d\n", cluster, requests)
+		fmt.Fprintf(w, "opscart_scanner_last_scan_api_errors{cluster=%q} %d\n", cluster, errors)
+		for _, resource := range []string{"pods", "nodes", "namespaces", "events"} {
+			fmt.Fprintf(w, "opscart_scanner_last_scan_objects_examined{cluster=%q,resource=%q} %d\n", cluster, resource, obs.API.Objects[resource])
+		}
+	}
+}

--- a/cmd/opscart-dashboard/observability.go
+++ b/cmd/opscart-dashboard/observability.go
@@ -86,7 +86,7 @@ var processAPICounters = newAPICounters()
 type measuringTransport struct {
 	base       http.RoundTripper
 	cumulative *apiCounters
-	scan       *apiCounters
+	local      *apiCounters
 }
 
 func (t *measuringTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -97,11 +97,11 @@ func (t *measuringTransport) RoundTrip(req *http.Request) (*http.Response, error
 		result = strconv.Itoa(resp.StatusCode)
 	}
 	t.cumulative.recordRequest(operation, resource, result)
-	if t.scan != nil {
-		t.scan.recordRequest(operation, resource, result)
+	if t.local != nil {
+		t.local.recordRequest(operation, resource, result)
 	}
 	if err == nil && resp != nil && resp.Body != nil && operation == "LIST" {
-		resp.Body = &countingResponseBody{ReadCloser: resp.Body, resource: resource, counters: []*apiCounters{t.cumulative, t.scan}}
+		resp.Body = &countingResponseBody{ReadCloser: resp.Body, resource: resource, counters: []*apiCounters{t.cumulative, t.local}}
 	}
 	return resp, err
 }
@@ -187,6 +187,14 @@ type scanObservation struct {
 	API         apiCounterSnapshot
 }
 
+type investigationObservation struct {
+	Namespace   string
+	Pod         string
+	CompletedAt time.Time
+	Duration    time.Duration
+	API         apiCounterSnapshot
+}
+
 type diagnosticOperation struct {
 	Operation string
 	Resource  string
@@ -194,6 +202,19 @@ type diagnosticOperation struct {
 }
 
 type diagnosticsPageData struct {
+	ActivePage    string
+	DashHref      string
+	WrHref        string
+	CostsHref     string
+	InfraHref     string
+	NsHref        string
+	OptHref       string
+	WasteHref     string
+	SecurityHref  string
+	IncidentsHref string
+	ClusterName   string
+	CriticalCount int
+	Clusters      []sidebarCluster
 	Cluster       string
 	CompletedAt   string
 	Duration      string
@@ -205,30 +226,47 @@ type diagnosticsPageData struct {
 	Namespaces    uint64
 	Events        uint64
 	TopOperations []diagnosticOperation
+	Investigation investigationDiagnostics
+}
+
+type investigationDiagnostics struct {
+	HasData       bool
+	Target        string
+	CompletedAt   string
+	Duration      string
+	Requests      uint64
+	Errors        uint64
+	TopOperations []diagnosticOperation
 }
 
 func (srv *server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
-	state := srv.getState(srv.activeCtx(r))
+	ctx := srv.activeCtx(r)
+	state := srv.getState(ctx)
 	state.mu.RLock()
 	obs := state.observation
+	scan := state.scan
 	state.mu.RUnlock()
 	requests, errors := obs.API.totals()
-	data := diagnosticsPageData{Cluster: displayName(state.ctx), CompletedAt: "No completed scan", Interval: dashboardScanInterval.String(), Requests: requests, Errors: errors,
+	q := "?cluster=" + url.QueryEscape(ctx)
+	data := diagnosticsPageData{ActivePage: "settings", DashHref: "/" + q, WrHref: "/warroom" + q, CostsHref: "/costs" + q,
+		InfraHref: "/infrastructure" + q, NsHref: "/namespaces" + q, OptHref: "/optimizations" + q, WasteHref: "/waste" + q,
+		SecurityHref: "/security" + q, IncidentsHref: "/incidents" + q, ClusterName: displayName(ctx), CriticalCount: countCriticalIssues(scan),
+		Clusters: convertToSidebarClusters(srv.clusterList, ctx, "/settings/diagnostics"), Cluster: displayName(state.ctx), CompletedAt: "No completed scan", Interval: dashboardScanInterval.String(), Requests: requests, Errors: errors,
 		Pods: obs.API.Objects["pods"], Nodes: obs.API.Objects["nodes"], Namespaces: obs.API.Objects["namespaces"], Events: obs.API.Objects["events"]}
 	if !obs.CompletedAt.IsZero() {
 		data.CompletedAt = obs.CompletedAt.Format(time.RFC3339)
 		data.Duration = obs.Duration.Round(time.Millisecond).String()
 	}
-	byOperation := make(map[apiOperationKey]uint64)
-	for key, count := range obs.API.Requests {
-		byOperation[apiOperationKey{key.Operation, key.Resource}] += count
-	}
-	for key, count := range byOperation {
-		data.TopOperations = append(data.TopOperations, diagnosticOperation{key.Operation, key.Resource, count})
-	}
-	sort.Slice(data.TopOperations, func(i, j int) bool { return data.TopOperations[i].Count > data.TopOperations[j].Count })
-	if len(data.TopOperations) > 10 {
-		data.TopOperations = data.TopOperations[:10]
+	data.TopOperations = diagnosticOperations(obs.API)
+
+	srv.investigationMu.RLock()
+	investigation := srv.latestInvestigation
+	srv.investigationMu.RUnlock()
+	if !investigation.CompletedAt.IsZero() {
+		invRequests, invErrors := investigation.API.totals()
+		data.Investigation = investigationDiagnostics{HasData: true, Target: investigation.Namespace + "/" + investigation.Pod,
+			CompletedAt: investigation.CompletedAt.Format(time.RFC3339), Duration: investigation.Duration.Round(time.Millisecond).String(),
+			Requests: invRequests, Errors: invErrors, TopOperations: diagnosticOperations(investigation.API)}
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := getDiagnosticsTmpl().Execute(w, data); err != nil {
@@ -237,8 +275,53 @@ func (srv *server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
 }
 
 var getDiagnosticsTmpl = sync.OnceValue(func() *template.Template {
-	return template.Must(template.New("diagnostics.html").ParseFS(templateFS, "templates/base.html", "templates/diagnostics.html"))
+	return template.Must(template.New("diagnostics.html").ParseFS(templateFS, "templates/base.html", "templates/sidebar.html", "templates/diagnostics.html"))
 })
+
+func diagnosticOperations(snapshot apiCounterSnapshot) []diagnosticOperation {
+	byOperation := make(map[apiOperationKey]uint64)
+	for key, count := range snapshot.Requests {
+		byOperation[apiOperationKey{key.Operation, key.Resource}] += count
+	}
+	operations := make([]diagnosticOperation, 0, len(byOperation))
+	for key, count := range byOperation {
+		operations = append(operations, diagnosticOperation{key.Operation, key.Resource, count})
+	}
+	sort.Slice(operations, func(i, j int) bool {
+		if operations[i].Count != operations[j].Count {
+			return operations[i].Count > operations[j].Count
+		}
+		if operations[i].Operation != operations[j].Operation {
+			return operations[i].Operation < operations[j].Operation
+		}
+		return operations[i].Resource < operations[j].Resource
+	})
+	if len(operations) > 10 {
+		operations = operations[:10]
+	}
+	return operations
+}
+
+func (srv *server) completeInvestigation(namespace, pod string, started time.Time, counters *apiCounters) {
+	observation := investigationObservation{Namespace: namespace, Pod: pod, CompletedAt: time.Now(), Duration: time.Since(started), API: counters.snapshot()}
+	srv.investigationMu.Lock()
+	srv.latestInvestigation = observation
+	srv.investigationMu.Unlock()
+}
+
+func (srv *server) investigationSnapshot() investigationObservation {
+	srv.investigationMu.RLock()
+	defer srv.investigationMu.RUnlock()
+	return srv.latestInvestigation
+}
+
+func (srv *server) handleDiagnosticsRedirect(w http.ResponseWriter, r *http.Request) {
+	target := "/settings/diagnostics"
+	if r.URL.RawQuery != "" {
+		target += "?" + r.URL.RawQuery
+	}
+	http.Redirect(w, r, target, http.StatusPermanentRedirect)
+}
 
 func (srv *server) handleMetrics(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")

--- a/cmd/opscart-dashboard/observability.go
+++ b/cmd/opscart-dashboard/observability.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"html/template"
 	"io"
@@ -31,7 +29,6 @@ type apiOperationKey struct {
 type apiCounters struct {
 	mu              sync.RWMutex
 	requests        map[apiMetricKey]uint64
-	objects         map[string]uint64
 	responseBytes   map[apiOperationKey]uint64
 	requestDuration map[apiOperationKey]time.Duration
 	maxDuration     map[apiOperationKey]time.Duration
@@ -40,7 +37,6 @@ type apiCounters struct {
 func newAPICounters() *apiCounters {
 	return &apiCounters{
 		requests:        make(map[apiMetricKey]uint64),
-		objects:         make(map[string]uint64),
 		responseBytes:   make(map[apiOperationKey]uint64),
 		requestDuration: make(map[apiOperationKey]time.Duration),
 		maxDuration:     make(map[apiOperationKey]time.Duration),
@@ -72,18 +68,8 @@ func (c *apiCounters) recordResponseBytes(operation, resource string, count uint
 	c.mu.Unlock()
 }
 
-func (c *apiCounters) recordObjects(resource string, count uint64) {
-	if count == 0 {
-		return
-	}
-	c.mu.Lock()
-	c.objects[resource] += count
-	c.mu.Unlock()
-}
-
 type apiCounterSnapshot struct {
 	Requests        map[apiMetricKey]uint64
-	Objects         map[string]uint64
 	ResponseBytes   map[apiOperationKey]uint64
 	RequestDuration map[apiOperationKey]time.Duration
 	MaxDuration     map[apiOperationKey]time.Duration
@@ -94,16 +80,12 @@ func (c *apiCounters) snapshot() apiCounterSnapshot {
 	defer c.mu.RUnlock()
 	s := apiCounterSnapshot{
 		Requests:        make(map[apiMetricKey]uint64, len(c.requests)),
-		Objects:         make(map[string]uint64, len(c.objects)),
 		ResponseBytes:   make(map[apiOperationKey]uint64, len(c.responseBytes)),
 		RequestDuration: make(map[apiOperationKey]time.Duration, len(c.requestDuration)),
 		MaxDuration:     make(map[apiOperationKey]time.Duration, len(c.maxDuration)),
 	}
 	for k, v := range c.requests {
 		s.Requests[k] = v
-	}
-	for k, v := range c.objects {
-		s.Objects[k] = v
 	}
 	for k, v := range c.responseBytes {
 		s.ResponseBytes[k] = v
@@ -168,7 +150,7 @@ func (t *measuringTransport) RoundTrip(req *http.Request) (*http.Response, error
 		t.local.recordRequest(operation, resource, result)
 	}
 	if err == nil && resp != nil && resp.Body != nil {
-		resp.Body = &countingResponseBody{ReadCloser: resp.Body, operation: operation, resource: resource, countObjects: operation == "LIST", started: started, counters: []*apiCounters{t.cumulative, t.local}}
+		resp.Body = &countingResponseBody{ReadCloser: resp.Body, operation: operation, resource: resource, started: started, counters: []*apiCounters{t.cumulative, t.local}}
 	} else {
 		for _, counters := range []*apiCounters{t.cumulative, t.local} {
 			if counters != nil {
@@ -181,23 +163,18 @@ func (t *measuringTransport) RoundTrip(req *http.Request) (*http.Response, error
 
 type countingResponseBody struct {
 	io.ReadCloser
-	operation    string
-	resource     string
-	countObjects bool
-	started      time.Time
-	counters     []*apiCounters
-	buf          bytes.Buffer
-	bytesRead    uint64
-	once         sync.Once
+	operation string
+	resource  string
+	started   time.Time
+	counters  []*apiCounters
+	bytesRead uint64
+	once      sync.Once
 }
 
 func (b *countingResponseBody) Read(p []byte) (int, error) {
 	n, err := b.ReadCloser.Read(p)
 	if n > 0 {
 		b.bytesRead += uint64(n)
-		if b.countObjects {
-			_, _ = b.buf.Write(p[:n])
-		}
 	}
 	if err == io.EOF {
 		b.count()
@@ -217,20 +194,6 @@ func (b *countingResponseBody) count() {
 			if counters != nil {
 				counters.recordResponseBytes(b.operation, b.resource, b.bytesRead)
 				counters.recordRequestDuration(b.operation, b.resource, time.Since(b.started))
-			}
-		}
-		if !b.countObjects {
-			return
-		}
-		var list struct {
-			Items []json.RawMessage `json:"items"`
-		}
-		if json.Unmarshal(b.buf.Bytes(), &list) != nil {
-			return
-		}
-		for _, counters := range b.counters {
-			if counters != nil {
-				counters.recordObjects(b.resource, uint64(len(list.Items)))
 			}
 		}
 	})
@@ -288,7 +251,6 @@ type diagnosticOperation struct {
 	Operation string
 	Resource  string
 	Count     uint64
-	Objects   uint64
 	Bytes     string
 	TotalTime string
 	Average   string
@@ -318,10 +280,6 @@ type diagnosticsPageData struct {
 	ResponseData  string
 	TotalAPITime  string
 	MaxAPITime    string
-	Pods          uint64
-	Nodes         uint64
-	Namespaces    uint64
-	Events        uint64
 	TopOperations []diagnosticOperation
 	Investigation investigationDiagnostics
 }
@@ -350,8 +308,7 @@ func (srv *server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
 		InfraHref: "/infrastructure" + q, NsHref: "/namespaces" + q, OptHref: "/optimizations" + q, WasteHref: "/waste" + q,
 		SecurityHref: "/security" + q, IncidentsHref: "/incidents" + q, ClusterName: displayName(ctx), CriticalCount: countCriticalIssues(scan),
 		Clusters: convertToSidebarClusters(srv.clusterList, ctx, "/settings/diagnostics"), Cluster: displayName(state.ctx), CompletedAt: "No completed scan", Interval: dashboardScanInterval.String(), Requests: requests, Errors: errors,
-		Throttles: throttles, ResponseData: formatByteCount(responseBytes), TotalAPITime: totalAPITime.Round(time.Millisecond).String(), MaxAPITime: maxAPITime.Round(time.Millisecond).String(),
-		Pods: obs.API.Objects["pods"], Nodes: obs.API.Objects["nodes"], Namespaces: obs.API.Objects["namespaces"], Events: obs.API.Objects["events"]}
+		Throttles: throttles, ResponseData: formatByteCount(responseBytes), TotalAPITime: totalAPITime.Round(time.Millisecond).String(), MaxAPITime: maxAPITime.Round(time.Millisecond).String()}
 	if !obs.CompletedAt.IsZero() {
 		data.CompletedAt = obs.CompletedAt.Format(time.RFC3339)
 		data.Duration = obs.Duration.Round(time.Millisecond).String()
@@ -388,12 +345,8 @@ func diagnosticOperations(snapshot apiCounterSnapshot) []diagnosticOperation {
 		if count != 0 {
 			average = snapshot.RequestDuration[key] / time.Duration(count)
 		}
-		objects := uint64(0)
-		if key.Operation == "LIST" {
-			objects = snapshot.Objects[key.Resource]
-		}
 		operations = append(operations, diagnosticOperation{
-			Operation: key.Operation, Resource: key.Resource, Count: count, Objects: objects,
+			Operation: key.Operation, Resource: key.Resource, Count: count,
 			Bytes: formatByteCount(snapshot.ResponseBytes[key]), TotalTime: snapshot.RequestDuration[key].Round(time.Millisecond).String(), Average: average.Round(time.Millisecond).String(),
 		})
 	}
@@ -527,8 +480,6 @@ func writePrometheusMetrics(w io.Writer, cumulative apiCounterSnapshot, observat
 	fmt.Fprintln(w, "# TYPE opscart_scanner_last_scan_api_operation_requests gauge")
 	fmt.Fprintln(w, "# HELP opscart_scanner_last_scan_api_operation_request_duration_seconds End-to-end Kubernetes API request time by operation and resource in the latest completed full scan.")
 	fmt.Fprintln(w, "# TYPE opscart_scanner_last_scan_api_operation_request_duration_seconds gauge")
-	fmt.Fprintln(w, "# HELP opscart_scanner_last_scan_objects_examined Kubernetes objects returned in LIST responses to the latest completed full scan.")
-	fmt.Fprintln(w, "# TYPE opscart_scanner_last_scan_objects_examined gauge")
 	clusters := make([]string, 0, len(observations))
 	for cluster := range observations {
 		clusters = append(clusters, cluster)
@@ -560,9 +511,6 @@ func writePrometheusMetrics(w io.Writer, cumulative apiCounterSnapshot, observat
 			fmt.Fprintf(w, "opscart_scanner_last_scan_api_operation_requests{cluster=%q,operation=%q,resource=%q} %d\n", cluster, key.Operation, key.Resource, operationRequests)
 			fmt.Fprintf(w, "opscart_scanner_last_scan_api_operation_response_bytes{cluster=%q,operation=%q,resource=%q} %d\n", cluster, key.Operation, key.Resource, obs.API.ResponseBytes[key])
 			fmt.Fprintf(w, "opscart_scanner_last_scan_api_operation_request_duration_seconds{cluster=%q,operation=%q,resource=%q} %g\n", cluster, key.Operation, key.Resource, obs.API.RequestDuration[key].Seconds())
-		}
-		for _, resource := range []string{"pods", "nodes", "namespaces", "events"} {
-			fmt.Fprintf(w, "opscart_scanner_last_scan_objects_examined{cluster=%q,resource=%q} %d\n", cluster, resource, obs.API.Objects[resource])
 		}
 	}
 }

--- a/cmd/opscart-dashboard/observability.go
+++ b/cmd/opscart-dashboard/observability.go
@@ -313,7 +313,7 @@ func (srv *server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
 		data.CompletedAt = obs.CompletedAt.Format(time.RFC3339)
 		data.Duration = obs.Duration.Round(time.Millisecond).String()
 	}
-	data.TopOperations = diagnosticOperations(obs.API)
+	data.TopOperations = scannerDiagnosticOperations(obs.API)
 
 	srv.investigationMu.RLock()
 	investigation := srv.latestInvestigation
@@ -335,6 +335,42 @@ var getDiagnosticsTmpl = sync.OnceValue(func() *template.Template {
 })
 
 func diagnosticOperations(snapshot apiCounterSnapshot) []diagnosticOperation {
+	operations := buildDiagnosticOperations(snapshot)
+	sort.Slice(operations, func(i, j int) bool {
+		if operations[i].Count != operations[j].Count {
+			return operations[i].Count > operations[j].Count
+		}
+		if operations[i].Operation != operations[j].Operation {
+			return operations[i].Operation < operations[j].Operation
+		}
+		return operations[i].Resource < operations[j].Resource
+	})
+	if len(operations) > 10 {
+		operations = operations[:10]
+	}
+	return operations
+}
+
+func scannerDiagnosticOperations(snapshot apiCounterSnapshot) []diagnosticOperation {
+	operations := buildDiagnosticOperations(snapshot)
+	sort.Slice(operations, func(i, j int) bool {
+		left := apiOperationKey{operations[i].Operation, operations[i].Resource}
+		right := apiOperationKey{operations[j].Operation, operations[j].Resource}
+		if snapshot.ResponseBytes[left] != snapshot.ResponseBytes[right] {
+			return snapshot.ResponseBytes[left] > snapshot.ResponseBytes[right]
+		}
+		if snapshot.RequestDuration[left] != snapshot.RequestDuration[right] {
+			return snapshot.RequestDuration[left] > snapshot.RequestDuration[right]
+		}
+		if operations[i].Operation != operations[j].Operation {
+			return operations[i].Operation < operations[j].Operation
+		}
+		return operations[i].Resource < operations[j].Resource
+	})
+	return operations
+}
+
+func buildDiagnosticOperations(snapshot apiCounterSnapshot) []diagnosticOperation {
 	byOperation := make(map[apiOperationKey]uint64)
 	for key, count := range snapshot.Requests {
 		byOperation[apiOperationKey{key.Operation, key.Resource}] += count
@@ -349,18 +385,6 @@ func diagnosticOperations(snapshot apiCounterSnapshot) []diagnosticOperation {
 			Operation: key.Operation, Resource: key.Resource, Count: count,
 			Bytes: formatByteCount(snapshot.ResponseBytes[key]), TotalTime: snapshot.RequestDuration[key].Round(time.Millisecond).String(), Average: average.Round(time.Millisecond).String(),
 		})
-	}
-	sort.Slice(operations, func(i, j int) bool {
-		if operations[i].Count != operations[j].Count {
-			return operations[i].Count > operations[j].Count
-		}
-		if operations[i].Operation != operations[j].Operation {
-			return operations[i].Operation < operations[j].Operation
-		}
-		return operations[i].Resource < operations[j].Resource
-	})
-	if len(operations) > 10 {
-		operations = operations[:10]
 	}
 	return operations
 }

--- a/cmd/opscart-dashboard/observability.go
+++ b/cmd/opscart-dashboard/observability.go
@@ -29,18 +29,46 @@ type apiOperationKey struct {
 }
 
 type apiCounters struct {
-	mu       sync.RWMutex
-	requests map[apiMetricKey]uint64
-	objects  map[string]uint64
+	mu              sync.RWMutex
+	requests        map[apiMetricKey]uint64
+	objects         map[string]uint64
+	responseBytes   map[apiOperationKey]uint64
+	requestDuration map[apiOperationKey]time.Duration
+	maxDuration     map[apiOperationKey]time.Duration
 }
 
 func newAPICounters() *apiCounters {
-	return &apiCounters{requests: make(map[apiMetricKey]uint64), objects: make(map[string]uint64)}
+	return &apiCounters{
+		requests:        make(map[apiMetricKey]uint64),
+		objects:         make(map[string]uint64),
+		responseBytes:   make(map[apiOperationKey]uint64),
+		requestDuration: make(map[apiOperationKey]time.Duration),
+		maxDuration:     make(map[apiOperationKey]time.Duration),
+	}
 }
 
 func (c *apiCounters) recordRequest(operation, resource, result string) {
 	c.mu.Lock()
 	c.requests[apiMetricKey{operation, resource, result}]++
+	c.mu.Unlock()
+}
+
+func (c *apiCounters) recordRequestDuration(operation, resource string, duration time.Duration) {
+	key := apiOperationKey{operation, resource}
+	c.mu.Lock()
+	c.requestDuration[key] += duration
+	if duration > c.maxDuration[key] {
+		c.maxDuration[key] = duration
+	}
+	c.mu.Unlock()
+}
+
+func (c *apiCounters) recordResponseBytes(operation, resource string, count uint64) {
+	if count == 0 {
+		return
+	}
+	c.mu.Lock()
+	c.responseBytes[apiOperationKey{operation, resource}] += count
 	c.mu.Unlock()
 }
 
@@ -54,19 +82,37 @@ func (c *apiCounters) recordObjects(resource string, count uint64) {
 }
 
 type apiCounterSnapshot struct {
-	Requests map[apiMetricKey]uint64
-	Objects  map[string]uint64
+	Requests        map[apiMetricKey]uint64
+	Objects         map[string]uint64
+	ResponseBytes   map[apiOperationKey]uint64
+	RequestDuration map[apiOperationKey]time.Duration
+	MaxDuration     map[apiOperationKey]time.Duration
 }
 
 func (c *apiCounters) snapshot() apiCounterSnapshot {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	s := apiCounterSnapshot{Requests: make(map[apiMetricKey]uint64, len(c.requests)), Objects: make(map[string]uint64, len(c.objects))}
+	s := apiCounterSnapshot{
+		Requests:        make(map[apiMetricKey]uint64, len(c.requests)),
+		Objects:         make(map[string]uint64, len(c.objects)),
+		ResponseBytes:   make(map[apiOperationKey]uint64, len(c.responseBytes)),
+		RequestDuration: make(map[apiOperationKey]time.Duration, len(c.requestDuration)),
+		MaxDuration:     make(map[apiOperationKey]time.Duration, len(c.maxDuration)),
+	}
 	for k, v := range c.requests {
 		s.Requests[k] = v
 	}
 	for k, v := range c.objects {
 		s.Objects[k] = v
+	}
+	for k, v := range c.responseBytes {
+		s.ResponseBytes[k] = v
+	}
+	for k, v := range c.requestDuration {
+		s.RequestDuration[k] = v
+	}
+	for k, v := range c.maxDuration {
+		s.MaxDuration[k] = v
 	}
 	return s
 }
@@ -76,6 +122,26 @@ func (s apiCounterSnapshot) totals() (requests, errors uint64) {
 		requests += count
 		if key.Result == "error" || strings.HasPrefix(key.Result, "4") || strings.HasPrefix(key.Result, "5") {
 			errors += count
+		}
+	}
+	return
+}
+
+func (s apiCounterSnapshot) costTotals() (responseBytes uint64, totalDuration, maxDuration time.Duration, throttles uint64) {
+	for key, count := range s.Requests {
+		if key.Result == "429" {
+			throttles += count
+		}
+	}
+	for _, count := range s.ResponseBytes {
+		responseBytes += count
+	}
+	for _, duration := range s.RequestDuration {
+		totalDuration += duration
+	}
+	for _, duration := range s.MaxDuration {
+		if duration > maxDuration {
+			maxDuration = duration
 		}
 	}
 	return
@@ -91,6 +157,7 @@ type measuringTransport struct {
 
 func (t *measuringTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	operation, resource := classifyKubernetesRequest(req.Method, req.URL)
+	started := time.Now()
 	resp, err := t.base.RoundTrip(req)
 	result := "error"
 	if err == nil && resp != nil {
@@ -100,24 +167,37 @@ func (t *measuringTransport) RoundTrip(req *http.Request) (*http.Response, error
 	if t.local != nil {
 		t.local.recordRequest(operation, resource, result)
 	}
-	if err == nil && resp != nil && resp.Body != nil && operation == "LIST" {
-		resp.Body = &countingResponseBody{ReadCloser: resp.Body, resource: resource, counters: []*apiCounters{t.cumulative, t.local}}
+	if err == nil && resp != nil && resp.Body != nil {
+		resp.Body = &countingResponseBody{ReadCloser: resp.Body, operation: operation, resource: resource, countObjects: operation == "LIST", started: started, counters: []*apiCounters{t.cumulative, t.local}}
+	} else {
+		for _, counters := range []*apiCounters{t.cumulative, t.local} {
+			if counters != nil {
+				counters.recordRequestDuration(operation, resource, time.Since(started))
+			}
+		}
 	}
 	return resp, err
 }
 
 type countingResponseBody struct {
 	io.ReadCloser
-	resource string
-	counters []*apiCounters
-	buf      bytes.Buffer
-	once     sync.Once
+	operation    string
+	resource     string
+	countObjects bool
+	started      time.Time
+	counters     []*apiCounters
+	buf          bytes.Buffer
+	bytesRead    uint64
+	once         sync.Once
 }
 
 func (b *countingResponseBody) Read(p []byte) (int, error) {
 	n, err := b.ReadCloser.Read(p)
 	if n > 0 {
-		_, _ = b.buf.Write(p[:n])
+		b.bytesRead += uint64(n)
+		if b.countObjects {
+			_, _ = b.buf.Write(p[:n])
+		}
 	}
 	if err == io.EOF {
 		b.count()
@@ -133,6 +213,15 @@ func (b *countingResponseBody) Close() error {
 
 func (b *countingResponseBody) count() {
 	b.once.Do(func() {
+		for _, counters := range b.counters {
+			if counters != nil {
+				counters.recordResponseBytes(b.operation, b.resource, b.bytesRead)
+				counters.recordRequestDuration(b.operation, b.resource, time.Since(b.started))
+			}
+		}
+		if !b.countObjects {
+			return
+		}
 		var list struct {
 			Items []json.RawMessage `json:"items"`
 		}
@@ -199,6 +288,10 @@ type diagnosticOperation struct {
 	Operation string
 	Resource  string
 	Count     uint64
+	Objects   uint64
+	Bytes     string
+	TotalTime string
+	Average   string
 }
 
 type diagnosticsPageData struct {
@@ -221,6 +314,10 @@ type diagnosticsPageData struct {
 	Interval      string
 	Requests      uint64
 	Errors        uint64
+	Throttles     uint64
+	ResponseData  string
+	TotalAPITime  string
+	MaxAPITime    string
 	Pods          uint64
 	Nodes         uint64
 	Namespaces    uint64
@@ -247,11 +344,13 @@ func (srv *server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
 	scan := state.scan
 	state.mu.RUnlock()
 	requests, errors := obs.API.totals()
+	responseBytes, totalAPITime, maxAPITime, throttles := obs.API.costTotals()
 	q := "?cluster=" + url.QueryEscape(ctx)
 	data := diagnosticsPageData{ActivePage: "settings", DashHref: "/" + q, WrHref: "/warroom" + q, CostsHref: "/costs" + q,
 		InfraHref: "/infrastructure" + q, NsHref: "/namespaces" + q, OptHref: "/optimizations" + q, WasteHref: "/waste" + q,
 		SecurityHref: "/security" + q, IncidentsHref: "/incidents" + q, ClusterName: displayName(ctx), CriticalCount: countCriticalIssues(scan),
 		Clusters: convertToSidebarClusters(srv.clusterList, ctx, "/settings/diagnostics"), Cluster: displayName(state.ctx), CompletedAt: "No completed scan", Interval: dashboardScanInterval.String(), Requests: requests, Errors: errors,
+		Throttles: throttles, ResponseData: formatByteCount(responseBytes), TotalAPITime: totalAPITime.Round(time.Millisecond).String(), MaxAPITime: maxAPITime.Round(time.Millisecond).String(),
 		Pods: obs.API.Objects["pods"], Nodes: obs.API.Objects["nodes"], Namespaces: obs.API.Objects["namespaces"], Events: obs.API.Objects["events"]}
 	if !obs.CompletedAt.IsZero() {
 		data.CompletedAt = obs.CompletedAt.Format(time.RFC3339)
@@ -285,7 +384,18 @@ func diagnosticOperations(snapshot apiCounterSnapshot) []diagnosticOperation {
 	}
 	operations := make([]diagnosticOperation, 0, len(byOperation))
 	for key, count := range byOperation {
-		operations = append(operations, diagnosticOperation{key.Operation, key.Resource, count})
+		average := time.Duration(0)
+		if count != 0 {
+			average = snapshot.RequestDuration[key] / time.Duration(count)
+		}
+		objects := uint64(0)
+		if key.Operation == "LIST" {
+			objects = snapshot.Objects[key.Resource]
+		}
+		operations = append(operations, diagnosticOperation{
+			Operation: key.Operation, Resource: key.Resource, Count: count, Objects: objects,
+			Bytes: formatByteCount(snapshot.ResponseBytes[key]), TotalTime: snapshot.RequestDuration[key].Round(time.Millisecond).String(), Average: average.Round(time.Millisecond).String(),
+		})
 	}
 	sort.Slice(operations, func(i, j int) bool {
 		if operations[i].Count != operations[j].Count {
@@ -300,6 +410,22 @@ func diagnosticOperations(snapshot apiCounterSnapshot) []diagnosticOperation {
 		operations = operations[:10]
 	}
 	return operations
+}
+
+func formatByteCount(count uint64) string {
+	const unit = 1024
+	if count < unit {
+		return fmt.Sprintf("%d B", count)
+	}
+	value := float64(count)
+	units := []string{"KB", "MB", "GB"}
+	for _, suffix := range units {
+		value /= unit
+		if value < unit || suffix == units[len(units)-1] {
+			return fmt.Sprintf("%.1f %s", value, suffix)
+		}
+	}
+	return fmt.Sprintf("%d B", count)
 }
 
 func (srv *server) completeInvestigation(namespace, pod string, started time.Time, counters *apiCounters) {
@@ -359,6 +485,26 @@ func writePrometheusMetrics(w io.Writer, cumulative apiCounterSnapshot, observat
 	for _, key := range keys {
 		fmt.Fprintf(w, "opscart_kubernetes_api_requests_total{operation=%q,resource=%q,status=%q} %d\n", key.Operation, key.Resource, key.Result, cumulative.Requests[key])
 	}
+	fmt.Fprintln(w, "# HELP opscart_kubernetes_api_response_bytes_total Kubernetes API response body bytes read by this process.")
+	fmt.Fprintln(w, "# TYPE opscart_kubernetes_api_response_bytes_total counter")
+	fmt.Fprintln(w, "# HELP opscart_kubernetes_api_request_duration_seconds_total End-to-end Kubernetes API request time observed by this process.")
+	fmt.Fprintln(w, "# TYPE opscart_kubernetes_api_request_duration_seconds_total counter")
+	fmt.Fprintln(w, "# HELP opscart_kubernetes_api_request_duration_seconds_max Maximum end-to-end Kubernetes API request time observed by this process.")
+	fmt.Fprintln(w, "# TYPE opscart_kubernetes_api_request_duration_seconds_max gauge")
+	fmt.Fprintln(w, "# HELP opscart_kubernetes_api_throttles_total Kubernetes API HTTP 429 responses received by this process.")
+	fmt.Fprintln(w, "# TYPE opscart_kubernetes_api_throttles_total counter")
+	for _, key := range operationKeys(cumulative) {
+		fmt.Fprintf(w, "opscart_kubernetes_api_response_bytes_total{operation=%q,resource=%q} %d\n", key.Operation, key.Resource, cumulative.ResponseBytes[key])
+		fmt.Fprintf(w, "opscart_kubernetes_api_request_duration_seconds_total{operation=%q,resource=%q} %g\n", key.Operation, key.Resource, cumulative.RequestDuration[key].Seconds())
+		fmt.Fprintf(w, "opscart_kubernetes_api_request_duration_seconds_max{operation=%q,resource=%q} %g\n", key.Operation, key.Resource, cumulative.MaxDuration[key].Seconds())
+		var throttles uint64
+		for metric, count := range cumulative.Requests {
+			if metric.Operation == key.Operation && metric.Resource == key.Resource && metric.Result == "429" {
+				throttles += count
+			}
+		}
+		fmt.Fprintf(w, "opscart_kubernetes_api_throttles_total{operation=%q,resource=%q} %d\n", key.Operation, key.Resource, throttles)
+	}
 	fmt.Fprintln(w, "# HELP opscart_scanner_last_scan_duration_seconds Wall-clock duration of the latest completed full scan.")
 	fmt.Fprintln(w, "# TYPE opscart_scanner_last_scan_duration_seconds gauge")
 	fmt.Fprintln(w, "# HELP opscart_scanner_last_scan_timestamp_seconds Unix timestamp of the latest completed full scan.")
@@ -367,6 +513,20 @@ func writePrometheusMetrics(w io.Writer, cumulative apiCounterSnapshot, observat
 	fmt.Fprintln(w, "# TYPE opscart_scanner_last_scan_api_requests gauge")
 	fmt.Fprintln(w, "# HELP opscart_scanner_last_scan_api_errors Kubernetes API transport errors and HTTP 4xx/5xx responses in the latest completed full scan.")
 	fmt.Fprintln(w, "# TYPE opscart_scanner_last_scan_api_errors gauge")
+	fmt.Fprintln(w, "# HELP opscart_scanner_last_scan_api_throttles Kubernetes API HTTP 429 responses in the latest completed full scan.")
+	fmt.Fprintln(w, "# TYPE opscart_scanner_last_scan_api_throttles gauge")
+	fmt.Fprintln(w, "# HELP opscart_scanner_last_scan_api_response_bytes Kubernetes API response body bytes read in the latest completed full scan.")
+	fmt.Fprintln(w, "# TYPE opscart_scanner_last_scan_api_response_bytes gauge")
+	fmt.Fprintln(w, "# HELP opscart_scanner_last_scan_api_request_duration_seconds End-to-end Kubernetes API request time in the latest completed full scan.")
+	fmt.Fprintln(w, "# TYPE opscart_scanner_last_scan_api_request_duration_seconds gauge")
+	fmt.Fprintln(w, "# HELP opscart_scanner_last_scan_api_request_max_duration_seconds Maximum end-to-end Kubernetes API request time in the latest completed full scan.")
+	fmt.Fprintln(w, "# TYPE opscart_scanner_last_scan_api_request_max_duration_seconds gauge")
+	fmt.Fprintln(w, "# HELP opscart_scanner_last_scan_api_operation_response_bytes Kubernetes API response body bytes read by operation and resource in the latest completed full scan.")
+	fmt.Fprintln(w, "# TYPE opscart_scanner_last_scan_api_operation_response_bytes gauge")
+	fmt.Fprintln(w, "# HELP opscart_scanner_last_scan_api_operation_requests Kubernetes API requests by operation and resource in the latest completed full scan.")
+	fmt.Fprintln(w, "# TYPE opscart_scanner_last_scan_api_operation_requests gauge")
+	fmt.Fprintln(w, "# HELP opscart_scanner_last_scan_api_operation_request_duration_seconds End-to-end Kubernetes API request time by operation and resource in the latest completed full scan.")
+	fmt.Fprintln(w, "# TYPE opscart_scanner_last_scan_api_operation_request_duration_seconds gauge")
 	fmt.Fprintln(w, "# HELP opscart_scanner_last_scan_objects_examined Kubernetes objects returned in LIST responses to the latest completed full scan.")
 	fmt.Fprintln(w, "# TYPE opscart_scanner_last_scan_objects_examined gauge")
 	clusters := make([]string, 0, len(observations))
@@ -377,6 +537,7 @@ func writePrometheusMetrics(w io.Writer, cumulative apiCounterSnapshot, observat
 	for _, cluster := range clusters {
 		obs := observations[cluster]
 		requests, errors := obs.API.totals()
+		responseBytes, totalDuration, maxDuration, throttles := obs.API.costTotals()
 		fmt.Fprintf(w, "opscart_scanner_last_scan_duration_seconds{cluster=%q} %g\n", cluster, obs.Duration.Seconds())
 		timestamp := int64(0)
 		if !obs.CompletedAt.IsZero() {
@@ -385,8 +546,44 @@ func writePrometheusMetrics(w io.Writer, cumulative apiCounterSnapshot, observat
 		fmt.Fprintf(w, "opscart_scanner_last_scan_timestamp_seconds{cluster=%q} %d\n", cluster, timestamp)
 		fmt.Fprintf(w, "opscart_scanner_last_scan_api_requests{cluster=%q} %d\n", cluster, requests)
 		fmt.Fprintf(w, "opscart_scanner_last_scan_api_errors{cluster=%q} %d\n", cluster, errors)
+		fmt.Fprintf(w, "opscart_scanner_last_scan_api_throttles{cluster=%q} %d\n", cluster, throttles)
+		fmt.Fprintf(w, "opscart_scanner_last_scan_api_response_bytes{cluster=%q} %d\n", cluster, responseBytes)
+		fmt.Fprintf(w, "opscart_scanner_last_scan_api_request_duration_seconds{cluster=%q} %g\n", cluster, totalDuration.Seconds())
+		fmt.Fprintf(w, "opscart_scanner_last_scan_api_request_max_duration_seconds{cluster=%q} %g\n", cluster, maxDuration.Seconds())
+		for _, key := range operationKeys(obs.API) {
+			var operationRequests uint64
+			for metric, count := range obs.API.Requests {
+				if metric.Operation == key.Operation && metric.Resource == key.Resource {
+					operationRequests += count
+				}
+			}
+			fmt.Fprintf(w, "opscart_scanner_last_scan_api_operation_requests{cluster=%q,operation=%q,resource=%q} %d\n", cluster, key.Operation, key.Resource, operationRequests)
+			fmt.Fprintf(w, "opscart_scanner_last_scan_api_operation_response_bytes{cluster=%q,operation=%q,resource=%q} %d\n", cluster, key.Operation, key.Resource, obs.API.ResponseBytes[key])
+			fmt.Fprintf(w, "opscart_scanner_last_scan_api_operation_request_duration_seconds{cluster=%q,operation=%q,resource=%q} %g\n", cluster, key.Operation, key.Resource, obs.API.RequestDuration[key].Seconds())
+		}
 		for _, resource := range []string{"pods", "nodes", "namespaces", "events"} {
 			fmt.Fprintf(w, "opscart_scanner_last_scan_objects_examined{cluster=%q,resource=%q} %d\n", cluster, resource, obs.API.Objects[resource])
 		}
 	}
+}
+
+func operationKeys(snapshot apiCounterSnapshot) []apiOperationKey {
+	set := make(map[apiOperationKey]struct{})
+	for key := range snapshot.ResponseBytes {
+		set[key] = struct{}{}
+	}
+	for key := range snapshot.RequestDuration {
+		set[key] = struct{}{}
+	}
+	keys := make([]apiOperationKey, 0, len(set))
+	for key := range set {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].Operation != keys[j].Operation {
+			return keys[i].Operation < keys[j].Operation
+		}
+		return keys[i].Resource < keys[j].Resource
+	})
+	return keys
 }

--- a/cmd/opscart-dashboard/observability_test.go
+++ b/cmd/opscart-dashboard/observability_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestClassifyKubernetesRequest(t *testing.T) {
+	tests := []struct{ name, method, rawURL, operation, resource string }{
+		{"core list", "GET", "/api/v1/nodes", "LIST", "nodes"},
+		{"core namespaced get", "GET", "/api/v1/namespaces/x/pods/pod-a", "GET", "pods"},
+		{"grouped list", "GET", "/apis/apps/v1/namespaces/x/deployments", "LIST", "deployments"},
+		{"autoscaling list", "GET", "/apis/autoscaling/v2/namespaces/x/horizontalpodautoscalers", "LIST", "horizontalpodautoscalers"},
+		{"networking list", "GET", "/apis/networking.k8s.io/v1/namespaces/x/networkpolicies", "LIST", "networkpolicies"},
+		{"watch query", "GET", "/api/v1/pods?watch=true", "WATCH", "pods"},
+		{"watch path", "GET", "/api/v1/watch/pods", "WATCH", "pods"},
+		{"pod logs", "GET", "/api/v1/namespaces/x/pods/pod-a/log", "POD_LOG_GET", "pods"},
+		{"write", "POST", "/apis/apps/v1/namespaces/x/deployments", "POST", "deployments"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.rawURL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			op, resource := classifyKubernetesRequest(tt.method, u)
+			if op != tt.operation || resource != tt.resource {
+				t.Fatalf("got %s/%s, want %s/%s", op, resource, tt.operation, tt.resource)
+			}
+		})
+	}
+}
+
+func TestAPICountersConcurrent(t *testing.T) {
+	counters := newAPICounters()
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				counters.recordRequest("LIST", "pods", "200")
+				counters.recordObjects("pods", 1)
+			}
+		}()
+	}
+	wg.Wait()
+	snapshot := counters.snapshot()
+	if got := snapshot.Requests[apiMetricKey{"LIST", "pods", "200"}]; got != 2000 {
+		t.Fatalf("requests = %d, want 2000", got)
+	}
+	if got := snapshot.Objects["pods"]; got != 2000 {
+		t.Fatalf("objects = %d, want 2000", got)
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestMeasuringTransportSeparatesScanAndCumulative(t *testing.T) {
+	cumulative, scan := newAPICounters(), newAPICounters()
+	body := `{"kind":"PodList","items":[{},{}]}`
+	base := roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
+	})
+	transport := &measuringTransport{base: base, cumulative: cumulative, scan: scan}
+	req := httptest.NewRequest("GET", "https://cluster/api/v1/pods", nil)
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	interactive := &measuringTransport{base: base, cumulative: cumulative}
+	resp, err = interactive.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	if got, _ := cumulative.snapshot().totals(); got != 2 {
+		t.Fatalf("cumulative requests = %d, want 2", got)
+	}
+	if got, _ := scan.snapshot().totals(); got != 1 {
+		t.Fatalf("scan requests = %d, want 1", got)
+	}
+	if got := cumulative.snapshot().Objects["pods"]; got != 4 {
+		t.Fatalf("cumulative pods = %d, want 4", got)
+	}
+	if got := scan.snapshot().Objects["pods"]; got != 2 {
+		t.Fatalf("scan pods = %d, want 2", got)
+	}
+}
+
+func TestMeasuringTransportRecordsErrors(t *testing.T) {
+	counters := newAPICounters()
+	transport := &measuringTransport{base: roundTripperFunc(func(*http.Request) (*http.Response, error) { return nil, errors.New("boom") }), cumulative: counters}
+	_, _ = transport.RoundTrip(httptest.NewRequest("GET", "https://cluster/api/v1/nodes/node-a", nil))
+	if got := counters.snapshot().Requests[apiMetricKey{"GET", "nodes", "error"}]; got != 1 {
+		t.Fatalf("errors = %d, want 1", got)
+	}
+}
+
+func TestWritePrometheusMetrics(t *testing.T) {
+	cumulative := newAPICounters()
+	cumulative.recordRequest("LIST", "pods", "200")
+	local := newAPICounters()
+	local.recordRequest("LIST", "events", "500")
+	local.recordObjects("events", 3)
+	var output strings.Builder
+	writePrometheusMetrics(&output, cumulative.snapshot(), map[string]scanObservation{"cluster-a": {CompletedAt: time.Unix(123, 0), Duration: 1500 * time.Millisecond, API: local.snapshot()}})
+	for _, want := range []string{
+		`opscart_kubernetes_api_requests_total{operation="LIST",resource="pods",status="200"} 1`,
+		`opscart_scanner_last_scan_duration_seconds{cluster="cluster-a"} 1.5`,
+		`opscart_scanner_last_scan_timestamp_seconds{cluster="cluster-a"} 123`,
+		`opscart_scanner_last_scan_api_requests{cluster="cluster-a"} 1`,
+		`opscart_scanner_last_scan_api_errors{cluster="cluster-a"} 1`,
+		`opscart_scanner_last_scan_objects_examined{cluster="cluster-a",resource="events"} 3`,
+	} {
+		if !strings.Contains(output.String(), want) {
+			t.Errorf("output missing %q\n%s", want, output.String())
+		}
+	}
+}
+
+func TestDiagnosticsAndMetricsRequireAuthentication(t *testing.T) {
+	t.Setenv("OPSCART_AUTH_USER", "tester")
+	t.Setenv("OPSCART_AUTH_PASS", "secret")
+	srv := newServer([]string{"cluster-a"}, nil, 90, false)
+	handler := srv.newMux()
+	for _, path := range []string{"/metrics", "/diagnostics"} {
+		t.Run(path, func(t *testing.T) {
+			unauthorized := httptest.NewRecorder()
+			handler.ServeHTTP(unauthorized, httptest.NewRequest("GET", path, nil))
+			if unauthorized.Code != http.StatusUnauthorized {
+				t.Fatalf("unauthorized status = %d", unauthorized.Code)
+			}
+			authorizedReq := httptest.NewRequest("GET", path, nil)
+			authorizedReq.SetBasicAuth("tester", "secret")
+			authorized := httptest.NewRecorder()
+			handler.ServeHTTP(authorized, authorizedReq)
+			if authorized.Code != http.StatusOK {
+				t.Fatalf("authorized status = %d: %s", authorized.Code, authorized.Body.String())
+			}
+		})
+	}
+}

--- a/cmd/opscart-dashboard/observability_test.go
+++ b/cmd/opscart-dashboard/observability_test.go
@@ -51,7 +51,6 @@ func TestAPICountersConcurrent(t *testing.T) {
 			defer wg.Done()
 			for j := 0; j < 100; j++ {
 				counters.recordRequest("LIST", "pods", "200")
-				counters.recordObjects("pods", 1)
 			}
 		}()
 	}
@@ -59,9 +58,6 @@ func TestAPICountersConcurrent(t *testing.T) {
 	snapshot := counters.snapshot()
 	if got := snapshot.Requests[apiMetricKey{"LIST", "pods", "200"}]; got != 2000 {
 		t.Fatalf("requests = %d, want 2000", got)
-	}
-	if got := snapshot.Objects["pods"]; got != 2000 {
-		t.Fatalf("objects = %d, want 2000", got)
 	}
 }
 
@@ -98,20 +94,18 @@ func TestMeasuringTransportSeparatesScanAndCumulative(t *testing.T) {
 	if got, _ := scan.snapshot().totals(); got != 1 {
 		t.Fatalf("scan requests = %d, want 1", got)
 	}
-	if got := cumulative.snapshot().Objects["pods"]; got != 4 {
-		t.Fatalf("cumulative pods = %d, want 4", got)
-	}
-	if got := scan.snapshot().Objects["pods"]; got != 2 {
-		t.Fatalf("scan pods = %d, want 2", got)
-	}
 }
 
 func TestMeasuringTransportRecordsErrors(t *testing.T) {
 	counters := newAPICounters()
 	transport := &measuringTransport{base: roundTripperFunc(func(*http.Request) (*http.Response, error) { return nil, errors.New("boom") }), cumulative: counters}
 	_, _ = transport.RoundTrip(httptest.NewRequest("GET", "https://cluster/api/v1/nodes/node-a", nil))
-	if got := counters.snapshot().Requests[apiMetricKey{"GET", "nodes", "error"}]; got != 1 {
+	snapshot := counters.snapshot()
+	if got := snapshot.Requests[apiMetricKey{"GET", "nodes", "error"}]; got != 1 {
 		t.Fatalf("errors = %d, want 1", got)
+	}
+	if got := snapshot.RequestDuration[apiOperationKey{"GET", "nodes"}]; got <= 0 {
+		t.Fatalf("transport error duration = %s, want positive", got)
 	}
 }
 
@@ -136,12 +130,35 @@ func TestMeasuringTransportRecordsResponseCostAndThrottling(t *testing.T) {
 	if snapshot.RequestDuration[key] <= 0 || snapshot.MaxDuration[key] <= 0 {
 		t.Fatalf("request durations were not recorded: total=%s max=%s", snapshot.RequestDuration[key], snapshot.MaxDuration[key])
 	}
-	if got := snapshot.Objects["pods"]; got != 2 {
-		t.Fatalf("objects = %d, want 2", got)
-	}
 	_, _, _, throttles := snapshot.costTotals()
 	if throttles != 1 {
 		t.Fatalf("throttles = %d, want 1", throttles)
+	}
+}
+
+func TestMeasuringTransportRecordsPartialBodyOnClose(t *testing.T) {
+	counters := newAPICounters()
+	transport := &measuringTransport{base: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("abcdefghij")), Header: make(http.Header)}, nil
+	}), cumulative: counters}
+	resp, err := transport.RoundTrip(httptest.NewRequest(http.MethodGet, "https://cluster/api/v1/pods", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(resp.Body, buf); err != nil {
+		t.Fatal(err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	snapshot := counters.snapshot()
+	key := apiOperationKey{"LIST", "pods"}
+	if got := snapshot.ResponseBytes[key]; got != 4 {
+		t.Fatalf("partial response bytes = %d, want 4", got)
+	}
+	if snapshot.RequestDuration[key] <= 0 {
+		t.Fatalf("partial response duration = %s, want positive", snapshot.RequestDuration[key])
 	}
 }
 
@@ -150,7 +167,6 @@ func TestWritePrometheusMetrics(t *testing.T) {
 	cumulative.recordRequest("LIST", "pods", "200")
 	local := newAPICounters()
 	local.recordRequest("LIST", "events", "500")
-	local.recordObjects("events", 3)
 	local.recordResponseBytes("LIST", "events", 512)
 	local.recordRequestDuration("LIST", "events", 250*time.Millisecond)
 	var output strings.Builder
@@ -168,7 +184,6 @@ func TestWritePrometheusMetrics(t *testing.T) {
 		`opscart_scanner_last_scan_api_operation_requests{cluster="cluster-a",operation="LIST",resource="events"} 1`,
 		`opscart_scanner_last_scan_api_operation_response_bytes{cluster="cluster-a",operation="LIST",resource="events"} 512`,
 		`opscart_scanner_last_scan_api_operation_request_duration_seconds{cluster="cluster-a",operation="LIST",resource="events"} 0.25`,
-		`opscart_scanner_last_scan_objects_examined{cluster="cluster-a",resource="events"} 3`,
 	} {
 		if !strings.Contains(output.String(), want) {
 			t.Errorf("output missing %q\n%s", want, output.String())
@@ -323,7 +338,6 @@ func TestDiagnosticsRendersScannerAPICost(t *testing.T) {
 	srv := newTestServer()
 	counters := newAPICounters()
 	counters.recordRequest("LIST", "pods", "200")
-	counters.recordObjects("pods", 148)
 	counters.recordResponseBytes("LIST", "pods", 420*1024)
 	counters.recordRequestDuration("LIST", "pods", 84*time.Millisecond)
 	state := srv.getState(bogusClusterCtx)
@@ -336,7 +350,7 @@ func TestDiagnosticsRendersScannerAPICost(t *testing.T) {
 		"Response data: <strong>420.0 KB</strong>",
 		"Total API time: <strong>84ms</strong>",
 		"Slowest API request: <strong>84ms</strong>",
-		"LIST</strong> pods — 1 calls · 148 objects · 420.0 KB · 84ms total · 84ms average",
+		"LIST</strong> pods — 1 calls · 420.0 KB · 84ms total · 84ms average",
 	} {
 		if !strings.Contains(rec.Body.String(), want) {
 			t.Errorf("Diagnostics page missing %q", want)

--- a/cmd/opscart-dashboard/observability_test.go
+++ b/cmd/opscart-dashboard/observability_test.go
@@ -191,6 +191,40 @@ func TestWritePrometheusMetrics(t *testing.T) {
 	}
 }
 
+func TestScannerDiagnosticOperationsSortsByBytesThenDurationAndShowsAll(t *testing.T) {
+	counters := newAPICounters()
+	record := func(operation, resource string, responseBytes uint64, duration time.Duration) {
+		counters.recordRequest(operation, resource, "200")
+		counters.recordResponseBytes(operation, resource, responseBytes)
+		counters.recordRequestDuration(operation, resource, duration)
+	}
+	record("LIST", "pods", 1000, 10*time.Millisecond)
+	record("LIST", "jobs", 500, 30*time.Millisecond)
+	record("LIST", "events", 500, 20*time.Millisecond)
+	record("GET", "nodes", 250, 10*time.Millisecond)
+	record("LIST", "namespaces", 250, 10*time.Millisecond)
+	for i := 0; i < 7; i++ {
+		record("LIST", fmt.Sprintf("small-%d", i), uint64(100-i), time.Millisecond)
+	}
+
+	got := scannerDiagnosticOperations(counters.snapshot())
+	if len(got) != 12 {
+		t.Fatalf("scanner operations = %d, want all 12", len(got))
+	}
+	want := []apiOperationKey{
+		{"LIST", "pods"},
+		{"LIST", "jobs"},
+		{"LIST", "events"},
+		{"GET", "nodes"},
+		{"LIST", "namespaces"},
+	}
+	for i, key := range want {
+		if got[i].Operation != key.Operation || got[i].Resource != key.Resource {
+			t.Fatalf("operation %d = %s/%s, want %s/%s", i, got[i].Operation, got[i].Resource, key.Operation, key.Resource)
+		}
+	}
+}
+
 func TestDiagnosticsAndMetricsRequireAuthentication(t *testing.T) {
 	t.Setenv("OPSCART_AUTH_USER", "tester")
 	t.Setenv("OPSCART_AUTH_PASS", "secret")
@@ -354,6 +388,28 @@ func TestDiagnosticsRendersScannerAPICost(t *testing.T) {
 	} {
 		if !strings.Contains(rec.Body.String(), want) {
 			t.Errorf("Diagnostics page missing %q", want)
+		}
+	}
+}
+
+func TestDiagnosticsRendersEveryScannerOperation(t *testing.T) {
+	srv := newTestServer()
+	counters := newAPICounters()
+	for i := 0; i < 12; i++ {
+		resource := fmt.Sprintf("resource-%02d", i)
+		counters.recordRequest("LIST", resource, "200")
+		counters.recordResponseBytes("LIST", resource, uint64(i+1))
+		counters.recordRequestDuration("LIST", resource, time.Millisecond)
+	}
+	state := srv.getState(bogusClusterCtx)
+	state.observation = scanObservation{CompletedAt: time.Now(), API: counters.snapshot()}
+
+	rec := httptest.NewRecorder()
+	srv.handleDiagnostics(rec, httptest.NewRequest(http.MethodGet, "/settings/diagnostics?cluster="+bogusClusterCtx, nil))
+	for i := 0; i < 12; i++ {
+		resource := fmt.Sprintf("resource-%02d", i)
+		if !strings.Contains(rec.Body.String(), resource) {
+			t.Errorf("Diagnostics omitted scanner operation %q", resource)
 		}
 	}
 }

--- a/cmd/opscart-dashboard/observability_test.go
+++ b/cmd/opscart-dashboard/observability_test.go
@@ -115,12 +115,44 @@ func TestMeasuringTransportRecordsErrors(t *testing.T) {
 	}
 }
 
+func TestMeasuringTransportRecordsResponseCostAndThrottling(t *testing.T) {
+	const body = `{"kind":"PodList","items":[{},{}]}`
+	counters := newAPICounters()
+	transport := &measuringTransport{base: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusTooManyRequests, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
+	}), cumulative: counters}
+	resp, err := transport.RoundTrip(httptest.NewRequest(http.MethodGet, "https://cluster/api/v1/pods", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	snapshot := counters.snapshot()
+	key := apiOperationKey{"LIST", "pods"}
+	if got := snapshot.ResponseBytes[key]; got != uint64(len(body)) {
+		t.Fatalf("response bytes = %d, want %d", got, len(body))
+	}
+	if snapshot.RequestDuration[key] <= 0 || snapshot.MaxDuration[key] <= 0 {
+		t.Fatalf("request durations were not recorded: total=%s max=%s", snapshot.RequestDuration[key], snapshot.MaxDuration[key])
+	}
+	if got := snapshot.Objects["pods"]; got != 2 {
+		t.Fatalf("objects = %d, want 2", got)
+	}
+	_, _, _, throttles := snapshot.costTotals()
+	if throttles != 1 {
+		t.Fatalf("throttles = %d, want 1", throttles)
+	}
+}
+
 func TestWritePrometheusMetrics(t *testing.T) {
 	cumulative := newAPICounters()
 	cumulative.recordRequest("LIST", "pods", "200")
 	local := newAPICounters()
 	local.recordRequest("LIST", "events", "500")
 	local.recordObjects("events", 3)
+	local.recordResponseBytes("LIST", "events", 512)
+	local.recordRequestDuration("LIST", "events", 250*time.Millisecond)
 	var output strings.Builder
 	writePrometheusMetrics(&output, cumulative.snapshot(), map[string]scanObservation{"cluster-a": {CompletedAt: time.Unix(123, 0), Duration: 1500 * time.Millisecond, API: local.snapshot()}})
 	for _, want := range []string{
@@ -129,6 +161,13 @@ func TestWritePrometheusMetrics(t *testing.T) {
 		`opscart_scanner_last_scan_timestamp_seconds{cluster="cluster-a"} 123`,
 		`opscart_scanner_last_scan_api_requests{cluster="cluster-a"} 1`,
 		`opscart_scanner_last_scan_api_errors{cluster="cluster-a"} 1`,
+		`opscart_scanner_last_scan_api_throttles{cluster="cluster-a"} 0`,
+		`opscart_scanner_last_scan_api_response_bytes{cluster="cluster-a"} 512`,
+		`opscart_scanner_last_scan_api_request_duration_seconds{cluster="cluster-a"} 0.25`,
+		`opscart_scanner_last_scan_api_request_max_duration_seconds{cluster="cluster-a"} 0.25`,
+		`opscart_scanner_last_scan_api_operation_requests{cluster="cluster-a",operation="LIST",resource="events"} 1`,
+		`opscart_scanner_last_scan_api_operation_response_bytes{cluster="cluster-a",operation="LIST",resource="events"} 512`,
+		`opscart_scanner_last_scan_api_operation_request_duration_seconds{cluster="cluster-a",operation="LIST",resource="events"} 0.25`,
 		`opscart_scanner_last_scan_objects_examined{cluster="cluster-a",resource="events"} 3`,
 	} {
 		if !strings.Contains(output.String(), want) {
@@ -215,10 +254,10 @@ func TestInvestigationObservationIsRequestScopedAndReplaced(t *testing.T) {
 		t.Fatalf("first totals = %d requests/%d errors, want 3/1", got, errors)
 	}
 	operations := diagnosticOperations(first.API)
-	for _, want := range []diagnosticOperation{{"GET", "pods", 1}, {"GET", "replicasets", 1}, {"LIST", "events", 1}} {
+	for _, want := range []diagnosticOperation{{Operation: "GET", Resource: "pods", Count: 1}, {Operation: "GET", Resource: "replicasets", Count: 1}, {Operation: "LIST", Resource: "events", Count: 1}} {
 		found := false
 		for _, got := range operations {
-			found = found || got == want
+			found = found || (got.Operation == want.Operation && got.Resource == want.Resource && got.Count == want.Count)
 		}
 		if !found {
 			t.Errorf("operation breakdown missing %+v: %+v", want, operations)
@@ -236,7 +275,7 @@ func TestInvestigationObservationIsRequestScopedAndReplaced(t *testing.T) {
 	if got, errors := second.API.totals(); got != 1 || errors != 0 {
 		t.Fatalf("replacement totals = %d requests/%d errors, want 1/0", got, errors)
 	}
-	if got := diagnosticOperations(second.API); len(got) != 1 || got[0] != (diagnosticOperation{"LIST", "services", 1}) {
+	if got := diagnosticOperations(second.API); len(got) != 1 || got[0].Operation != "LIST" || got[0].Resource != "services" || got[0].Count != 1 {
 		t.Fatalf("replacement operations = %+v", got)
 	}
 }
@@ -275,6 +314,31 @@ func TestSettingsDiscoversDiagnosticsAndDiagnosticsHasEmptyInvestigationState(t 
 	srv.handleDiagnostics(diagnostics, httptest.NewRequest(http.MethodGet, "/settings/diagnostics?cluster="+bogusClusterCtx, nil))
 	for _, want := range []string{"Diagnostics", "Scanner Diagnostics", "Investigation Diagnostics", "No Pod Investigation request has completed yet", "<aside class=\"sidebar\">"} {
 		if !strings.Contains(diagnostics.Body.String(), want) {
+			t.Errorf("Diagnostics page missing %q", want)
+		}
+	}
+}
+
+func TestDiagnosticsRendersScannerAPICost(t *testing.T) {
+	srv := newTestServer()
+	counters := newAPICounters()
+	counters.recordRequest("LIST", "pods", "200")
+	counters.recordObjects("pods", 148)
+	counters.recordResponseBytes("LIST", "pods", 420*1024)
+	counters.recordRequestDuration("LIST", "pods", 84*time.Millisecond)
+	state := srv.getState(bogusClusterCtx)
+	state.observation = scanObservation{CompletedAt: time.Now(), API: counters.snapshot()}
+
+	rec := httptest.NewRecorder()
+	srv.handleDiagnostics(rec, httptest.NewRequest(http.MethodGet, "/settings/diagnostics?cluster="+bogusClusterCtx, nil))
+	for _, want := range []string{
+		"API throttles: <strong>0</strong>",
+		"Response data: <strong>420.0 KB</strong>",
+		"Total API time: <strong>84ms</strong>",
+		"Slowest API request: <strong>84ms</strong>",
+		"LIST</strong> pods — 1 calls · 148 objects · 420.0 KB · 84ms total · 84ms average",
+	} {
+		if !strings.Contains(rec.Body.String(), want) {
 			t.Errorf("Diagnostics page missing %q", want)
 		}
 	}

--- a/cmd/opscart-dashboard/observability_test.go
+++ b/cmd/opscart-dashboard/observability_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,9 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestClassifyKubernetesRequest(t *testing.T) {
@@ -71,7 +75,7 @@ func TestMeasuringTransportSeparatesScanAndCumulative(t *testing.T) {
 	base := roundTripperFunc(func(*http.Request) (*http.Response, error) {
 		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
 	})
-	transport := &measuringTransport{base: base, cumulative: cumulative, scan: scan}
+	transport := &measuringTransport{base: base, cumulative: cumulative, local: scan}
 	req := httptest.NewRequest("GET", "https://cluster/api/v1/pods", nil)
 	resp, err := transport.RoundTrip(req)
 	if err != nil {
@@ -138,7 +142,7 @@ func TestDiagnosticsAndMetricsRequireAuthentication(t *testing.T) {
 	t.Setenv("OPSCART_AUTH_PASS", "secret")
 	srv := newServer([]string{"cluster-a"}, nil, 90, false)
 	handler := srv.newMux()
-	for _, path := range []string{"/metrics", "/diagnostics"} {
+	for _, path := range []string{"/metrics", "/settings/diagnostics"} {
 		t.Run(path, func(t *testing.T) {
 			unauthorized := httptest.NewRecorder()
 			handler.ServeHTTP(unauthorized, httptest.NewRequest("GET", path, nil))
@@ -153,5 +157,159 @@ func TestDiagnosticsAndMetricsRequireAuthentication(t *testing.T) {
 				t.Fatalf("authorized status = %d: %s", authorized.Code, authorized.Body.String())
 			}
 		})
+	}
+
+	unauthorized := httptest.NewRecorder()
+	handler.ServeHTTP(unauthorized, httptest.NewRequest("GET", "/diagnostics", nil))
+	if unauthorized.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthorized legacy diagnostics status = %d", unauthorized.Code)
+	}
+	authorizedReq := httptest.NewRequest("GET", "/diagnostics?cluster=cluster-a", nil)
+	authorizedReq.SetBasicAuth("tester", "secret")
+	authorized := httptest.NewRecorder()
+	handler.ServeHTTP(authorized, authorizedReq)
+	if authorized.Code != http.StatusPermanentRedirect {
+		t.Fatalf("legacy diagnostics status = %d, want %d", authorized.Code, http.StatusPermanentRedirect)
+	}
+	if got := authorized.Header().Get("Location"); got != "/settings/diagnostics?cluster=cluster-a" {
+		t.Fatalf("legacy diagnostics redirect = %q", got)
+	}
+}
+
+func TestInvestigationObservationIsRequestScopedAndReplaced(t *testing.T) {
+	srv := newTestServer()
+	srv.logsEnabled = false
+	state := srv.getState(bogusClusterCtx)
+	scanCounters := newAPICounters()
+	scanCounters.recordRequest("LIST", "nodes", "200")
+	state.observation = scanObservation{CompletedAt: time.Now(), API: scanCounters.snapshot()}
+
+	requestNumber := 0
+	srv.kubeClientFor = func(_ string, local *apiCounters) (kubernetes.Interface, error) {
+		requestNumber++
+		if local == nil {
+			t.Fatal("Pod Investigation HTML request received no local counters")
+		}
+		if requestNumber == 1 {
+			local.recordRequest("GET", "pods", "200")
+			local.recordRequest("GET", "replicasets", "200")
+			local.recordRequest("LIST", "events", "500")
+		} else {
+			local.recordRequest("LIST", "services", "200")
+		}
+		return fake.NewSimpleClientset(investigationOwnedPod("payments", fmt.Sprintf("api-%d", requestNumber), "StatefulSet", "api")), nil
+	}
+
+	requestInvestigation := func(pod string) {
+		req := httptest.NewRequest(http.MethodGet, "/investigate?cluster="+bogusClusterCtx+"&ns=payments&pod="+pod+"&type=crash_loop", nil)
+		rec := httptest.NewRecorder()
+		srv.handleInvestigationPage(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("investigation status = %d: %s", rec.Code, rec.Body.String())
+		}
+	}
+
+	requestInvestigation("api-1")
+	first := srv.investigationSnapshot()
+	if got, errors := first.API.totals(); got != 3 || errors != 1 {
+		t.Fatalf("first totals = %d requests/%d errors, want 3/1", got, errors)
+	}
+	operations := diagnosticOperations(first.API)
+	for _, want := range []diagnosticOperation{{"GET", "pods", 1}, {"GET", "replicasets", 1}, {"LIST", "events", 1}} {
+		found := false
+		for _, got := range operations {
+			found = found || got == want
+		}
+		if !found {
+			t.Errorf("operation breakdown missing %+v: %+v", want, operations)
+		}
+	}
+	if got, _ := state.observation.API.totals(); got != 1 {
+		t.Fatalf("Investigation changed scan requests to %d", got)
+	}
+
+	requestInvestigation("api-2")
+	second := srv.investigationSnapshot()
+	if second.Pod != "api-2" {
+		t.Fatalf("latest target pod = %q, want api-2", second.Pod)
+	}
+	if got, errors := second.API.totals(); got != 1 || errors != 0 {
+		t.Fatalf("replacement totals = %d requests/%d errors, want 1/0", got, errors)
+	}
+	if got := diagnosticOperations(second.API); len(got) != 1 || got[0] != (diagnosticOperation{"LIST", "services", 1}) {
+		t.Fatalf("replacement operations = %+v", got)
+	}
+}
+
+func TestNonInvestigationTrafficDoesNotReplaceObservation(t *testing.T) {
+	srv := newTestServer()
+	local := newAPICounters()
+	local.recordRequest("GET", "pods", "200")
+	srv.completeInvestigation("payments", "api", time.Now().Add(-time.Second), local)
+	want := srv.investigationSnapshot()
+
+	scan := newAPICounters()
+	scan.recordRequest("LIST", "nodes", "200")
+	state := srv.getState(bogusClusterCtx)
+	state.observation = scanObservation{CompletedAt: time.Now(), API: scan.snapshot()}
+	rec := httptest.NewRecorder()
+	srv.handleSettingsPage(rec, httptest.NewRequest(http.MethodGet, "/settings", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("settings status = %d", rec.Code)
+	}
+	got := srv.investigationSnapshot()
+	if got.CompletedAt != want.CompletedAt || got.Pod != want.Pod {
+		t.Fatalf("non-Investigation traffic replaced observation: got %+v, want %+v", got, want)
+	}
+}
+
+func TestSettingsDiscoversDiagnosticsAndDiagnosticsHasEmptyInvestigationState(t *testing.T) {
+	srv := newTestServer()
+	settings := httptest.NewRecorder()
+	srv.handleSettingsPage(settings, httptest.NewRequest(http.MethodGet, "/settings?cluster="+bogusClusterCtx, nil))
+	if settings.Code != http.StatusOK || !strings.Contains(settings.Body.String(), `/settings/diagnostics?cluster=`) {
+		t.Fatalf("Settings does not link to cluster-aware Diagnostics: status=%d body=%s", settings.Code, settings.Body.String())
+	}
+
+	diagnostics := httptest.NewRecorder()
+	srv.handleDiagnostics(diagnostics, httptest.NewRequest(http.MethodGet, "/settings/diagnostics?cluster="+bogusClusterCtx, nil))
+	for _, want := range []string{"Diagnostics", "Scanner Diagnostics", "Investigation Diagnostics", "No Pod Investigation request has completed yet", "<aside class=\"sidebar\">"} {
+		if !strings.Contains(diagnostics.Body.String(), want) {
+			t.Errorf("Diagnostics page missing %q", want)
+		}
+	}
+}
+
+func TestConcurrentTransportTrafficCannotEnterInvestigationCounters(t *testing.T) {
+	cumulative := newAPICounters()
+	investigation := newAPICounters()
+	base := roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"items":[]}`)), Header: make(http.Header)}, nil
+	})
+	measured := &measuringTransport{base: base, cumulative: cumulative, local: investigation}
+	unrelated := &measuringTransport{base: base, cumulative: cumulative}
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			resp, _ := measured.RoundTrip(httptest.NewRequest("GET", "https://cluster/api/v1/namespaces/x/pods/p", nil))
+			_ = resp.Body.Close()
+		}()
+		go func() {
+			defer wg.Done()
+			resp, _ := unrelated.RoundTrip(httptest.NewRequest("GET", "https://cluster/api/v1/events", nil))
+			_ = resp.Body.Close()
+		}()
+	}
+	wg.Wait()
+	if got, _ := investigation.snapshot().totals(); got != 50 {
+		t.Fatalf("Investigation requests = %d, want 50", got)
+	}
+	if got := investigation.snapshot().Requests[apiMetricKey{"LIST", "events", "200"}]; got != 0 {
+		t.Fatalf("unrelated Event requests attributed to Investigation: %d", got)
+	}
+	if got, _ := cumulative.snapshot().totals(); got != 100 {
+		t.Fatalf("cumulative requests = %d, want 100", got)
 	}
 }

--- a/cmd/opscart-dashboard/pages.go
+++ b/cmd/opscart-dashboard/pages.go
@@ -18,20 +18,21 @@ import (
 // ── Stub pages ────────────────────────────────────────────────────────────────
 
 type stubPageData struct {
-	Title         string
-	ActivePage    string
-	DashHref      string
-	WrHref        string
-	CostsHref     string
-	InfraHref     string
-	NsHref        string
-	OptHref       string
-	WasteHref     string
-	SecurityHref  string
-	IncidentsHref string
-	ClusterName   string
-	CriticalCount int
-	Clusters      []sidebarCluster
+	Title           string
+	ActivePage      string
+	DashHref        string
+	WrHref          string
+	CostsHref       string
+	InfraHref       string
+	NsHref          string
+	OptHref         string
+	WasteHref       string
+	SecurityHref    string
+	IncidentsHref   string
+	ClusterName     string
+	CriticalCount   int
+	Clusters        []sidebarCluster
+	DiagnosticsHref string
 }
 
 var getStubTmpl = sync.OnceValue(func() *template.Template {
@@ -75,6 +76,36 @@ func (srv *server) handleStubPage(page, title string) http.HandlerFunc {
 			return
 		}
 		w.Write([]byte(buf.String()))
+	}
+}
+
+var getSettingsTmpl = sync.OnceValue(func() *template.Template {
+	return template.Must(
+		template.New("settings.html").
+			ParseFS(templateFS, "templates/base.html", "templates/sidebar.html", "templates/settings.html"),
+	)
+})
+
+func (srv *server) handleSettingsPage(w http.ResponseWriter, r *http.Request) {
+	ctx := srv.activeCtx(r)
+	state := srv.getState(ctx)
+	state.mu.RLock()
+	scan := state.scan
+	state.mu.RUnlock()
+	q := "?cluster=" + url.QueryEscape(ctx)
+	data := stubPageData{
+		Title: "Settings", ActivePage: "settings", DashHref: "/" + q, WrHref: "/warroom" + q,
+		CostsHref: "/costs" + q, InfraHref: "/infrastructure" + q, NsHref: "/namespaces" + q,
+		OptHref: "/optimizations" + q, WasteHref: "/waste" + q, SecurityHref: "/security" + q,
+		IncidentsHref: "/incidents" + q, ClusterName: displayName(ctx), CriticalCount: countCriticalIssues(scan),
+		Clusters:        convertToSidebarClusters(srv.clusterList, ctx, "/settings"),
+		DiagnosticsHref: "/settings/diagnostics" + q,
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+	if err := getSettingsTmpl().Execute(w, data); err != nil {
+		log.Printf("settings template: %v", err)
+		http.Error(w, "template error", http.StatusInternalServerError)
 	}
 }
 

--- a/cmd/opscart-dashboard/scan.go
+++ b/cmd/opscart-dashboard/scan.go
@@ -51,6 +51,7 @@ type dashboardState struct {
 	scanning      atomic.Bool
 	db            store.Store
 	retentionDays int
+	observation   scanObservation
 }
 
 func (s *dashboardState) refresh(clusterList []string) error {
@@ -65,7 +66,8 @@ func (s *dashboardState) refresh(clusterList []string) error {
 	// the recorded duration measured only the persistence block below.
 	start := time.Now()
 
-	scan, err := runFullScan(s.ctx)
+	scanCounters := newAPICounters()
+	scan, err := runFullScan(s.ctx, scanCounters)
 	if err != nil {
 		return err
 	}
@@ -135,6 +137,10 @@ func (s *dashboardState) refresh(clusterList []string) error {
 			Version:    Version,
 		})
 	}
+
+	s.mu.Lock()
+	s.observation = scanObservation{CompletedAt: time.Now(), Duration: time.Since(start), API: scanCounters.snapshot()}
+	s.mu.Unlock()
 
 	log.Printf("[%s] scan complete: %d namespaces, $%s/month, %d critical issues", displayName(s.ctx), len(scan.report.NamespaceCosts), formatMoney(scan.report.TotalMonthlyCost), countCriticalIssues(scan))
 	return nil

--- a/cmd/opscart-dashboard/server.go
+++ b/cmd/opscart-dashboard/server.go
@@ -247,6 +247,8 @@ func (srv *server) newMux() http.Handler {
 	mux.HandleFunc("/security", srv.handleSecurityPage)
 	mux.HandleFunc("/waste", srv.handleWastePage)
 	mux.HandleFunc("/settings", srv.handleStubPage("settings", "Settings"))
+	mux.HandleFunc("/metrics", srv.handleMetrics)
+	mux.HandleFunc("/diagnostics", srv.handleDiagnostics)
 
 	// /healthz is registered on the unwrapped top-level mux so kubelet
 	// liveness/readiness probes succeed without credentials; every other
@@ -1888,8 +1890,8 @@ func formatMoney(amount float64) string {
 // runFullScan runs all five analyzers against a cluster. The cost analysis is
 // required (returns error on failure). Security, waste, network, and CIS are
 // best-effort — failures are logged and leave the corresponding field nil.
-func runFullScan(ctx string) (*clusterScan, error) {
-	clientset, err := kubeClient(ctx)
+func runFullScan(ctx string, scanCounters *apiCounters) (*clusterScan, error) {
+	clientset, err := kubeClientWithCounters(ctx, scanCounters)
 	if err != nil {
 		return nil, err
 	}
@@ -2066,6 +2068,10 @@ func pricingCoverageWarnings(warnings []string, matched, total int) []string {
 }
 
 func kubeClient(ctx string) (*kubernetes.Clientset, error) {
+	return kubeClientWithCounters(ctx, nil)
+}
+
+func kubeClientWithCounters(ctx string, scanCounters *apiCounters) (*kubernetes.Clientset, error) {
 	// In-cluster deployments have no context name and typically no
 	// kubeconfig file at all — authenticate via the mounted ServiceAccount
 	// instead of trying to resolve a named context.
@@ -2073,6 +2079,7 @@ func kubeClient(ctx string) (*kubernetes.Clientset, error) {
 		if cfg, err := rest.InClusterConfig(); err == nil {
 			cfg.QPS = 50
 			cfg.Burst = 100
+			wrapKubernetesTransport(cfg, scanCounters)
 			return kubernetes.NewForConfig(cfg)
 		}
 	}
@@ -2088,5 +2095,16 @@ func kubeClient(ctx string) (*kubernetes.Clientset, error) {
 	// skipped sub-scans ("context deadline exceeded") on large clusters.
 	cfg.QPS = 50
 	cfg.Burst = 100
+	wrapKubernetesTransport(cfg, scanCounters)
 	return kubernetes.NewForConfig(cfg)
+}
+
+func wrapKubernetesTransport(cfg *rest.Config, scanCounters *apiCounters) {
+	previous := cfg.WrapTransport
+	cfg.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
+		if previous != nil {
+			rt = previous(rt)
+		}
+		return &measuringTransport{base: rt, cumulative: processAPICounters, scan: scanCounters}
+	}
 }

--- a/cmd/opscart-dashboard/server.go
+++ b/cmd/opscart-dashboard/server.go
@@ -2016,6 +2016,7 @@ func runFullScan(ctx string, scanCounters *apiCounters) (*clusterScan, error) {
 	// ── 3. Waste audit (best effort) ──────────────────────────────────
 	wasteAuditor, cancel := analyzer.NewWasteAuditor(clientset, dashboardWasteMinAgeDays)
 	defer cancel()
+	wasteAuditor.WithPodSnapshot(ra.PodSnapshot(), namespace == "")
 	if wasteAudit, err := wasteAuditor.AuditWaste(""); err == nil {
 		scan.wasteAudit = wasteAudit
 	} else {

--- a/cmd/opscart-dashboard/server.go
+++ b/cmd/opscart-dashboard/server.go
@@ -2024,10 +2024,19 @@ func runFullScan(ctx string, scanCounters *apiCounters) (*clusterScan, error) {
 
 	// ── 4. Network policy audit (best effort) ─────────────────────────
 	netAuditor := analyzer.NewNetworkPolicyAuditor(clientset)
-	if netAudit, err := netAuditor.AuditNetworkPolicies(""); err == nil {
+	var netAudit *analyzer.NetworkPolicyAudit
+	var netErr error
+	if namespace == "" {
+		netAudit, netErr = netAuditor.AuditNetworkPoliciesWithPods("", ra.PodSnapshot())
+	} else {
+		// ResourceAnalyzer honored a namespace filter, so its snapshot is not
+		// cluster-wide and cannot preserve the network audit's all-namespace scope.
+		netAudit, netErr = netAuditor.AuditNetworkPolicies("")
+	}
+	if netErr == nil {
 		scan.netAudit = netAudit
 	} else {
-		log.Printf("[%s] network audit skipped: %v", displayName(ctx), err)
+		log.Printf("[%s] network audit skipped: %v", displayName(ctx), netErr)
 	}
 
 	// ── 5. CIS score (derived from security + network audits) ─────────

--- a/cmd/opscart-dashboard/server.go
+++ b/cmd/opscart-dashboard/server.go
@@ -2012,7 +2012,7 @@ func runFullScan(ctx string, scanCounters *apiCounters) (*clusterScan, error) {
 
 	// ── 2. Security audit (best effort) ──────────────────────────────
 	sa := analyzer.NewSecurityAuditor(clientset)
-	if secAudit, err := sa.AuditClusterSecurity(""); err == nil {
+	if secAudit, err := sa.AuditClusterSecurityWithPodSnapshot("", ra.PodSnapshot(), namespace == ""); err == nil {
 		scan.secAudit = secAudit
 	} else {
 		log.Printf("[%s] security audit skipped: %v", displayName(ctx), err)

--- a/cmd/opscart-dashboard/server.go
+++ b/cmd/opscart-dashboard/server.go
@@ -78,18 +78,20 @@ func (s *clusterScan) securityScore() int {
 // ── Server ────────────────────────────────────────────────────────────────────
 
 type server struct {
-	clusterList   []string
-	mu            sync.RWMutex
-	states        map[string]*dashboardState
-	db            store.Store
-	retentionDays int
-	dbPersistent  bool
-	auth          *authConfig
-	refreshState  func(*dashboardState, []string) error
-	backgroundWG  sync.WaitGroup
-	logsEnabled   bool
-	kubeClientFor kubeClientFactory
-	podLogReader  podLogReaderFunc
+	clusterList         []string
+	mu                  sync.RWMutex
+	states              map[string]*dashboardState
+	db                  store.Store
+	retentionDays       int
+	dbPersistent        bool
+	auth                *authConfig
+	refreshState        func(*dashboardState, []string) error
+	backgroundWG        sync.WaitGroup
+	logsEnabled         bool
+	kubeClientFor       kubeClientFactory
+	podLogReader        podLogReaderFunc
+	investigationMu     sync.RWMutex
+	latestInvestigation investigationObservation
 }
 
 func newServer(clusterList []string, db store.Store, retentionDays int, dbPersistent bool) *server {
@@ -106,8 +108,10 @@ func newServer(clusterList []string, db store.Store, retentionDays int, dbPersis
 		dbPersistent:  dbPersistent,
 		auth:          auth,
 		logsEnabled:   logPreviewEnabledFromEnv(),
-		kubeClientFor: func(ctx string) (kubernetes.Interface, error) { return kubeClient(ctx) },
-		podLogReader:  readPodLogs,
+		kubeClientFor: func(ctx string, localCounters *apiCounters) (kubernetes.Interface, error) {
+			return kubeClientWithCounters(ctx, localCounters)
+		},
+		podLogReader: readPodLogs,
 		refreshState: func(state *dashboardState, clusters []string) error {
 			return state.refresh(clusters)
 		},
@@ -246,9 +250,10 @@ func (srv *server) newMux() http.Handler {
 	mux.HandleFunc("/incidents", srv.handleIncidentsPage)
 	mux.HandleFunc("/security", srv.handleSecurityPage)
 	mux.HandleFunc("/waste", srv.handleWastePage)
-	mux.HandleFunc("/settings", srv.handleStubPage("settings", "Settings"))
+	mux.HandleFunc("/settings", srv.handleSettingsPage)
+	mux.HandleFunc("/settings/diagnostics", srv.handleDiagnostics)
 	mux.HandleFunc("/metrics", srv.handleMetrics)
-	mux.HandleFunc("/diagnostics", srv.handleDiagnostics)
+	mux.HandleFunc("/diagnostics", srv.handleDiagnosticsRedirect)
 
 	// /healthz is registered on the unwrapped top-level mux so kubelet
 	// liveness/readiness probes succeed without credentials; every other
@@ -2109,12 +2114,12 @@ func kubeClientWithCounters(ctx string, scanCounters *apiCounters) (*kubernetes.
 	return kubernetes.NewForConfig(cfg)
 }
 
-func wrapKubernetesTransport(cfg *rest.Config, scanCounters *apiCounters) {
+func wrapKubernetesTransport(cfg *rest.Config, localCounters *apiCounters) {
 	previous := cfg.WrapTransport
 	cfg.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
 		if previous != nil {
 			rt = previous(rt)
 		}
-		return &measuringTransport{base: rt, cumulative: processAPICounters, scan: scanCounters}
+		return &measuringTransport{base: rt, cumulative: processAPICounters, local: localCounters}
 	}
 }

--- a/cmd/opscart-dashboard/templates/diagnostics.html
+++ b/cmd/opscart-dashboard/templates/diagnostics.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>Scanner Diagnostics — OpsCart</title>{{template "base" .}}</head><body>
+<main class="main">
+  <div class="page-hdr"><div><h1>Scanner Diagnostics</h1><p>Measurement from the latest completed background-compatible full scan.</p></div></div>
+  <section class="section"><h2 class="section-title">{{.Cluster}}</h2>
+    <p>Last completed scan: <strong>{{.CompletedAt}}</strong></p><p>Scan duration: <strong>{{.Duration}}</strong></p><p>Current scan interval: <strong>{{.Interval}}</strong></p>
+  </section>
+  <section class="section"><h2 class="section-title">Latest scan measurements</h2>
+    <p>Kubernetes API calls: <strong>{{.Requests}}</strong> · API errors: <strong>{{.Errors}}</strong></p>
+    <p>Pods examined: <strong>{{.Pods}}</strong> · Nodes: <strong>{{.Nodes}}</strong> · Namespaces: <strong>{{.Namespaces}}</strong> · Events: <strong>{{.Events}}</strong></p>
+  </section>
+  <section class="section"><h2 class="section-title">Top API operations</h2>{{range .TopOperations}}<p><strong>{{.Operation}}</strong> {{.Resource}} — {{.Count}}</p>{{else}}<p class="muted">No completed scan data.</p>{{end}}</section>
+</main></body></html>

--- a/cmd/opscart-dashboard/templates/diagnostics.html
+++ b/cmd/opscart-dashboard/templates/diagnostics.html
@@ -5,9 +5,10 @@
   <section class="section" style="border-left:4px solid var(--accent)"><h2 class="section-title">Scanner Diagnostics</h2>
     <p>Cluster: <strong>{{.Cluster}}</strong></p>
     <p>Last completed scan: <strong>{{.CompletedAt}}</strong> · Scan duration: <strong>{{if .Duration}}{{.Duration}}{{else}}—{{end}}</strong> · Current scan interval: <strong>{{.Interval}}</strong></p>
-    <p>Kubernetes API calls: <strong>{{.Requests}}</strong> · API errors: <strong>{{.Errors}}</strong></p>
+    <p>Kubernetes API calls: <strong>{{.Requests}}</strong> · API errors: <strong>{{.Errors}}</strong> · API throttles: <strong>{{.Throttles}}</strong></p>
+    <p>Response data: <strong>{{.ResponseData}}</strong> · Total API time: <strong>{{.TotalAPITime}}</strong> · Slowest API request: <strong>{{.MaxAPITime}}</strong></p>
     <p>Objects examined — Pods: <strong>{{.Pods}}</strong> · Nodes: <strong>{{.Nodes}}</strong> · Namespaces: <strong>{{.Namespaces}}</strong> · Events: <strong>{{.Events}}</strong></p>
-    <h3>Top API operations</h3>{{range .TopOperations}}<p><strong>{{.Operation}}</strong> {{.Resource}} — {{.Count}}</p>{{else}}<p class="muted">No completed scan data.</p>{{end}}
+    <h3>Top API operations</h3>{{range .TopOperations}}<p><strong>{{.Operation}}</strong> {{.Resource}} — {{.Count}} calls{{if .Objects}} · {{.Objects}} objects{{end}} · {{.Bytes}} · {{.TotalTime}} total · {{.Average}} average</p>{{else}}<p class="muted">No completed scan data.</p>{{end}}
   </section>
   <section class="section" style="border-left:4px solid var(--warning)"><h2 class="section-title">Investigation Diagnostics</h2>
     {{if .Investigation.HasData}}

--- a/cmd/opscart-dashboard/templates/diagnostics.html
+++ b/cmd/opscart-dashboard/templates/diagnostics.html
@@ -1,13 +1,20 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>Scanner Diagnostics — OpsCart</title>{{template "base" .}}</head><body>
-<main class="main">
-  <div class="page-hdr"><div><h1>Scanner Diagnostics</h1><p>Measurement from the latest completed background-compatible full scan.</p></div></div>
-  <section class="section"><h2 class="section-title">{{.Cluster}}</h2>
-    <p>Last completed scan: <strong>{{.CompletedAt}}</strong></p><p>Scan duration: <strong>{{.Duration}}</strong></p><p>Current scan interval: <strong>{{.Interval}}</strong></p>
-  </section>
-  <section class="section"><h2 class="section-title">Latest scan measurements</h2>
+<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><title>Diagnostics — OpsCart</title>{{template "base" .}}</head><body>
+<div class="layout">{{template "sidebar.html" .}}<main class="main">
+  <div class="page-hdr"><div><h1>Diagnostics</h1><p>Request-scoped Kubernetes API measurements for scanner and interactive activity.</p></div></div>
+  <section class="section" style="border-left:4px solid var(--accent)"><h2 class="section-title">Scanner Diagnostics</h2>
+    <p>Cluster: <strong>{{.Cluster}}</strong></p>
+    <p>Last completed scan: <strong>{{.CompletedAt}}</strong> · Scan duration: <strong>{{if .Duration}}{{.Duration}}{{else}}—{{end}}</strong> · Current scan interval: <strong>{{.Interval}}</strong></p>
     <p>Kubernetes API calls: <strong>{{.Requests}}</strong> · API errors: <strong>{{.Errors}}</strong></p>
-    <p>Pods examined: <strong>{{.Pods}}</strong> · Nodes: <strong>{{.Nodes}}</strong> · Namespaces: <strong>{{.Namespaces}}</strong> · Events: <strong>{{.Events}}</strong></p>
+    <p>Objects examined — Pods: <strong>{{.Pods}}</strong> · Nodes: <strong>{{.Nodes}}</strong> · Namespaces: <strong>{{.Namespaces}}</strong> · Events: <strong>{{.Events}}</strong></p>
+    <h3>Top API operations</h3>{{range .TopOperations}}<p><strong>{{.Operation}}</strong> {{.Resource}} — {{.Count}}</p>{{else}}<p class="muted">No completed scan data.</p>{{end}}
   </section>
-  <section class="section"><h2 class="section-title">Top API operations</h2>{{range .TopOperations}}<p><strong>{{.Operation}}</strong> {{.Resource}} — {{.Count}}</p>{{else}}<p class="muted">No completed scan data.</p>{{end}}</section>
-</main></body></html>
+  <section class="section" style="border-left:4px solid var(--warning)"><h2 class="section-title">Investigation Diagnostics</h2>
+    {{if .Investigation.HasData}}
+    <p>Target namespace/pod: <strong>{{.Investigation.Target}}</strong></p>
+    <p>Completed: <strong>{{.Investigation.CompletedAt}}</strong> · Request duration: <strong>{{.Investigation.Duration}}</strong></p>
+    <p>Kubernetes API calls: <strong>{{.Investigation.Requests}}</strong> · API errors: <strong>{{.Investigation.Errors}}</strong></p>
+    <h3>Top API operations</h3>{{range .Investigation.TopOperations}}<p><strong>{{.Operation}}</strong> {{.Resource}} — {{.Count}}</p>{{else}}<p class="muted">No Kubernetes API calls were made.</p>{{end}}
+    {{else}}<p class="muted">No Pod Investigation request has completed yet.</p>{{end}}
+  </section>
+</main></div></body></html>

--- a/cmd/opscart-dashboard/templates/diagnostics.html
+++ b/cmd/opscart-dashboard/templates/diagnostics.html
@@ -7,8 +7,7 @@
     <p>Last completed scan: <strong>{{.CompletedAt}}</strong> · Scan duration: <strong>{{if .Duration}}{{.Duration}}{{else}}—{{end}}</strong> · Current scan interval: <strong>{{.Interval}}</strong></p>
     <p>Kubernetes API calls: <strong>{{.Requests}}</strong> · API errors: <strong>{{.Errors}}</strong> · API throttles: <strong>{{.Throttles}}</strong></p>
     <p>Response data: <strong>{{.ResponseData}}</strong> · Total API time: <strong>{{.TotalAPITime}}</strong> · Slowest API request: <strong>{{.MaxAPITime}}</strong></p>
-    <p>Objects examined — Pods: <strong>{{.Pods}}</strong> · Nodes: <strong>{{.Nodes}}</strong> · Namespaces: <strong>{{.Namespaces}}</strong> · Events: <strong>{{.Events}}</strong></p>
-    <h3>Top API operations</h3>{{range .TopOperations}}<p><strong>{{.Operation}}</strong> {{.Resource}} — {{.Count}} calls{{if .Objects}} · {{.Objects}} objects{{end}} · {{.Bytes}} · {{.TotalTime}} total · {{.Average}} average</p>{{else}}<p class="muted">No completed scan data.</p>{{end}}
+    <h3>Top API operations</h3>{{range .TopOperations}}<p><strong>{{.Operation}}</strong> {{.Resource}} — {{.Count}} calls · {{.Bytes}} · {{.TotalTime}} total · {{.Average}} average</p>{{else}}<p class="muted">No completed scan data.</p>{{end}}
   </section>
   <section class="section" style="border-left:4px solid var(--warning)"><h2 class="section-title">Investigation Diagnostics</h2>
     {{if .Investigation.HasData}}

--- a/cmd/opscart-dashboard/templates/settings.html
+++ b/cmd/opscart-dashboard/templates/settings.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>Settings — OpsCart</title>
+{{template "base" .}}
+</head>
+<body>
+<div class="layout">
+{{template "sidebar.html" .}}
+<main class="main">
+  <div class="page-hdr"><div><h1>Settings</h1><p>Operator and administrative capabilities.</p></div></div>
+  <section class="section">
+    <h2 class="section-title">Diagnostics</h2>
+    <p class="muted">Inspect the latest background scanner and interactive Pod Investigation API measurements.</p>
+    <p><a class="back-link" href="{{.DiagnosticsHref}}">Open Diagnostics →</a></p>
+  </section>
+</main>
+</div>
+</body>
+</html>

--- a/pkg/analyzer/network.go
+++ b/pkg/analyzer/network.go
@@ -123,6 +123,24 @@ func (n *NetworkPolicyAuditor) WithSkipNamespaces(namespaces []string) *NetworkP
 // ================================================================
 
 func (n *NetworkPolicyAuditor) AuditNetworkPolicies(filterNamespace string) (*NetworkPolicyAudit, error) {
+	return n.auditNetworkPolicies(filterNamespace, nil)
+}
+
+// AuditNetworkPoliciesWithPods performs the same audit using a previously
+// successful cluster-wide Pod snapshot. NetworkPolicies remain fetched once
+// per eligible namespace so their existing failure behavior is unchanged.
+func (n *NetworkPolicyAuditor) AuditNetworkPoliciesWithPods(filterNamespace string, pods []corev1.Pod) (*NetworkPolicyAudit, error) {
+	podsByNamespace := make(map[string][]corev1.Pod)
+	for _, pod := range pods {
+		podsByNamespace[pod.Namespace] = append(podsByNamespace[pod.Namespace], pod)
+	}
+	return n.auditNetworkPolicies(filterNamespace, podsByNamespace)
+}
+
+// A nil podsByNamespace retains the original behavior of listing Pods in
+// each namespace. A non-nil map, including an empty map, is a supplied
+// snapshot and therefore performs no Pod LIST calls.
+func (n *NetworkPolicyAuditor) auditNetworkPolicies(filterNamespace string, podsByNamespace map[string][]corev1.Pod) (*NetworkPolicyAudit, error) {
 	audit := &NetworkPolicyAudit{}
 
 	// Get namespaces
@@ -152,12 +170,18 @@ func (n *NetworkPolicyAuditor) AuditNetworkPolicies(filterNamespace string) (*Ne
 
 		// Get pods — needed for real coverage (which pods each policy
 		// selector actually matches), not just a count.
-		pods, err := n.clientset.CoreV1().Pods(nsName).List(n.ctx, metav1.ListOptions{})
-		if err != nil {
-			audit.Warnings = append(audit.Warnings, NetworkAuditWarning{
-				Namespace: nsName, Operation: "list Pods", Message: err.Error(),
-			})
-			continue // no pod data means coverage can't be computed at all for this namespace
+		var namespacePods []corev1.Pod
+		if podsByNamespace == nil {
+			pods, err := n.clientset.CoreV1().Pods(nsName).List(n.ctx, metav1.ListOptions{})
+			if err != nil {
+				audit.Warnings = append(audit.Warnings, NetworkAuditWarning{
+					Namespace: nsName, Operation: "list Pods", Message: err.Error(),
+				})
+				continue // no pod data means coverage can't be computed at all for this namespace
+			}
+			namespacePods = pods.Items
+		} else {
+			namespacePods = podsByNamespace[nsName]
 		}
 
 		// Get NetworkPolicies in this namespace
@@ -173,15 +197,15 @@ func (n *NetworkPolicyAuditor) AuditNetworkPolicies(filterNamespace string) (*Ne
 		status := NamespaceNetworkStatus{
 			Name:                nsName,
 			Environment:         env,
-			PodCount:            len(pods.Items),
+			PodCount:            len(namespacePods),
 			PolicyCount:         len(policies.Items),
-			UncoveredPodCount:   len(pods.Items),
-			CoverageGapPodCount: len(pods.Items),
+			UncoveredPodCount:   len(namespacePods),
+			CoverageGapPodCount: len(namespacePods),
 		}
 
 		if len(policies.Items) > 0 {
 			audit.TotalPolicies += len(policies.Items)
-			n.analyzeCoverage(&status, pods.Items, policies.Items)
+			n.analyzeCoverage(&status, namespacePods, policies.Items)
 		}
 		n.analyzeRisk(&status)
 		if status.RiskLevel == "HIGH" {

--- a/pkg/analyzer/network.go
+++ b/pkg/analyzer/network.go
@@ -123,7 +123,7 @@ func (n *NetworkPolicyAuditor) WithSkipNamespaces(namespaces []string) *NetworkP
 // ================================================================
 
 func (n *NetworkPolicyAuditor) AuditNetworkPolicies(filterNamespace string) (*NetworkPolicyAudit, error) {
-	return n.auditNetworkPolicies(filterNamespace, nil)
+	return n.auditNetworkPolicies(filterNamespace, nil, true)
 }
 
 // AuditNetworkPoliciesWithPods performs the same audit using a previously
@@ -134,19 +134,32 @@ func (n *NetworkPolicyAuditor) AuditNetworkPoliciesWithPods(filterNamespace stri
 	for _, pod := range pods {
 		podsByNamespace[pod.Namespace] = append(podsByNamespace[pod.Namespace], pod)
 	}
-	return n.auditNetworkPolicies(filterNamespace, podsByNamespace)
+	return n.auditNetworkPolicies(filterNamespace, podsByNamespace, true)
 }
 
 // A nil podsByNamespace retains the original behavior of listing Pods in
 // each namespace. A non-nil map, including an empty map, is a supplied
 // snapshot and therefore performs no Pod LIST calls.
-func (n *NetworkPolicyAuditor) auditNetworkPolicies(filterNamespace string, podsByNamespace map[string][]corev1.Pod) (*NetworkPolicyAudit, error) {
+// When usePolicySnapshot is true, a successful cluster-wide NetworkPolicy
+// LIST supplies every namespace. If it fails, the loop retains the original
+// namespace-scoped retrieval and warning behavior.
+func (n *NetworkPolicyAuditor) auditNetworkPolicies(filterNamespace string, podsByNamespace map[string][]corev1.Pod, usePolicySnapshot bool) (*NetworkPolicyAudit, error) {
 	audit := &NetworkPolicyAudit{}
 
 	// Get namespaces
 	nsList, err := n.clientset.CoreV1().Namespaces().List(n.ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("listing namespaces: %w", err)
+	}
+
+	var policiesByNamespace map[string][]networkingv1.NetworkPolicy
+	if usePolicySnapshot {
+		if policies, listErr := n.clientset.NetworkingV1().NetworkPolicies("").List(n.ctx, metav1.ListOptions{}); listErr == nil {
+			policiesByNamespace = make(map[string][]networkingv1.NetworkPolicy)
+			for _, policy := range policies.Items {
+				policiesByNamespace[policy.Namespace] = append(policiesByNamespace[policy.Namespace], policy)
+			}
+		}
 	}
 
 	for _, ns := range nsList.Items {
@@ -185,12 +198,18 @@ func (n *NetworkPolicyAuditor) auditNetworkPolicies(filterNamespace string, pods
 		}
 
 		// Get NetworkPolicies in this namespace
-		policies, err := n.clientset.NetworkingV1().NetworkPolicies(nsName).List(n.ctx, metav1.ListOptions{})
-		if err != nil {
-			audit.Warnings = append(audit.Warnings, NetworkAuditWarning{
-				Namespace: nsName, Operation: "list NetworkPolicies", Message: err.Error(),
-			})
-			continue
+		var namespacePolicies []networkingv1.NetworkPolicy
+		if policiesByNamespace == nil {
+			policies, err := n.clientset.NetworkingV1().NetworkPolicies(nsName).List(n.ctx, metav1.ListOptions{})
+			if err != nil {
+				audit.Warnings = append(audit.Warnings, NetworkAuditWarning{
+					Namespace: nsName, Operation: "list NetworkPolicies", Message: err.Error(),
+				})
+				continue
+			}
+			namespacePolicies = policies.Items
+		} else {
+			namespacePolicies = policiesByNamespace[nsName]
 		}
 
 		env := detectEnvironment(nsName)
@@ -198,14 +217,14 @@ func (n *NetworkPolicyAuditor) auditNetworkPolicies(filterNamespace string, pods
 			Name:                nsName,
 			Environment:         env,
 			PodCount:            len(namespacePods),
-			PolicyCount:         len(policies.Items),
+			PolicyCount:         len(namespacePolicies),
 			UncoveredPodCount:   len(namespacePods),
 			CoverageGapPodCount: len(namespacePods),
 		}
 
-		if len(policies.Items) > 0 {
-			audit.TotalPolicies += len(policies.Items)
-			n.analyzeCoverage(&status, namespacePods, policies.Items)
+		if len(namespacePolicies) > 0 {
+			audit.TotalPolicies += len(namespacePolicies)
+			n.analyzeCoverage(&status, namespacePods, namespacePolicies)
 		}
 		n.analyzeRisk(&status)
 		if status.RiskLevel == "HIGH" {

--- a/pkg/analyzer/network_test.go
+++ b/pkg/analyzer/network_test.go
@@ -2,8 +2,10 @@ package analyzer
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -330,6 +332,100 @@ func TestAuditNetworkPoliciesAPIFailureRecordsWarning(t *testing.T) {
 	}
 	if _, ok := findStatus(audit.UnprotectedNamespaces, "broken"); ok {
 		t.Error("a namespace with an audit warning must not appear in UnprotectedNamespaces either — its coverage is unknown, not confirmed bad")
+	}
+}
+
+func TestAuditNetworkPoliciesSharedPodsPreservesFindings(t *testing.T) {
+	objects := []interface{}{
+		nsObj("payments"),
+		podWithLabels("payments", "api", map[string]string{"app": "api"}),
+		podWithLabels("payments", "worker", map[string]string{"app": "worker"}),
+		policy("payments", "api-only", metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+			[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+			[]networkingv1.NetworkPolicyIngressRule{{From: []networkingv1.NetworkPolicyPeer{{}}}},
+			[]networkingv1.NetworkPolicyEgressRule{{To: []networkingv1.NetworkPolicyPeer{{}}}}),
+	}
+	legacy, err := newTestNetworkAuditor(objects...).AuditNetworkPolicies("")
+	if err != nil {
+		t.Fatalf("legacy audit: %v", err)
+	}
+	shared, err := newTestNetworkAuditor(objects...).AuditNetworkPoliciesWithPods("", []corev1.Pod{
+		*objects[1].(*corev1.Pod), *objects[2].(*corev1.Pod),
+	})
+	if err != nil {
+		t.Fatalf("shared audit: %v", err)
+	}
+	if !reflect.DeepEqual(shared, legacy) {
+		t.Fatalf("shared snapshot changed findings:\nshared=%+v\nlegacy=%+v", shared, legacy)
+	}
+}
+
+func TestAuditNetworkPoliciesSharedPodsPreservesEmptyNamespace(t *testing.T) {
+	na := newTestNetworkAuditor(nsObj("empty"))
+	audit, err := na.AuditNetworkPoliciesWithPods("", []corev1.Pod{})
+	if err != nil {
+		t.Fatalf("AuditNetworkPoliciesWithPods: %v", err)
+	}
+	status, ok := findStatus(audit.ProtectedNamespaces, "empty")
+	if !ok || status.PodCount != 0 || status.CoverageGapPodCount != 0 {
+		t.Fatalf("empty eligible namespace behavior changed: %+v", audit)
+	}
+}
+
+func TestAuditNetworkPoliciesSharedPodsPreservesSelectorBehavior(t *testing.T) {
+	na := newTestNetworkAuditor(
+		nsObj("payments"),
+		policy("payments", "api-only", metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+			[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+			[]networkingv1.NetworkPolicyIngressRule{{From: []networkingv1.NetworkPolicyPeer{{}}}},
+			[]networkingv1.NetworkPolicyEgressRule{{To: []networkingv1.NetworkPolicyPeer{{}}}}),
+	)
+	audit, err := na.AuditNetworkPoliciesWithPods("", []corev1.Pod{
+		*podWithLabels("payments", "api", map[string]string{"app": "api"}),
+		*podWithLabels("payments", "worker", map[string]string{"app": "worker"}),
+	})
+	if err != nil {
+		t.Fatalf("AuditNetworkPoliciesWithPods: %v", err)
+	}
+	status, ok := findStatus(audit.UnprotectedNamespaces, "payments")
+	if !ok || status.PodCount != 2 || status.CoveredPodCount != 1 || status.UncoveredPodCount != 1 || status.FullyCoveredPodCount != 1 {
+		t.Fatalf("selector behavior changed with shared Pods: %+v", audit)
+	}
+}
+
+func TestAuditNetworkPoliciesSharedPodsRetainsNetworkPolicyErrors(t *testing.T) {
+	na := newTestNetworkAuditor(nsObj("broken"))
+	na.clientset.(*fake.Clientset).PrependReactor("list", "networkpolicies", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, context.DeadlineExceeded
+	})
+	audit, err := na.AuditNetworkPoliciesWithPods("", []corev1.Pod{})
+	if err != nil {
+		t.Fatalf("AuditNetworkPoliciesWithPods: %v", err)
+	}
+	if len(audit.Warnings) != 1 || audit.Warnings[0].Namespace != "broken" || audit.Warnings[0].Operation != "list NetworkPolicies" {
+		t.Fatalf("NetworkPolicy error behavior changed: %+v", audit.Warnings)
+	}
+	if _, ok := findStatus(audit.ProtectedNamespaces, "broken"); ok {
+		t.Fatal("namespace with a NetworkPolicy error appeared protected")
+	}
+	if _, ok := findStatus(audit.UnprotectedNamespaces, "broken"); ok {
+		t.Fatal("namespace with a NetworkPolicy error appeared unprotected")
+	}
+}
+
+func TestAuditNetworkPoliciesSharedPodsPerformsNoPodLists(t *testing.T) {
+	na := newTestNetworkAuditor(nsObj("one"), nsObj("two"))
+	podLists := 0
+	na.clientset.(*fake.Clientset).PrependReactor("list", "pods", func(ktesting.Action) (bool, runtime.Object, error) {
+		podLists++
+		return true, nil, errors.New("unexpected Pod LIST")
+	})
+	_, err := na.AuditNetworkPoliciesWithPods("", []corev1.Pod{*podWithLabels("one", "api", nil)})
+	if err != nil {
+		t.Fatalf("AuditNetworkPoliciesWithPods: %v", err)
+	}
+	if podLists != 0 {
+		t.Fatalf("Pod LIST calls = %d, want 0", podLists)
 	}
 }
 

--- a/pkg/analyzer/network_test.go
+++ b/pkg/analyzer/network_test.go
@@ -429,6 +429,152 @@ func TestAuditNetworkPoliciesSharedPodsPerformsNoPodLists(t *testing.T) {
 	}
 }
 
+func TestAuditNetworkPoliciesClusterPolicySnapshotMatchesLegacy(t *testing.T) {
+	objects := []interface{}{
+		nsObj("payments-prod"), nsObj("workers"), nsObj("empty"), nsObj("kube-system"),
+		podWithLabels("payments-prod", "api", map[string]string{"app": "api"}),
+		podWithLabels("payments-prod", "worker", map[string]string{"app": "worker"}),
+		podWithLabels("workers", "worker", map[string]string{"app": "worker"}),
+		policy("payments-prod", "api-ingress", metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+			[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress}, nil, nil),
+		policy("payments-prod", "api-egress", metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+			[]networkingv1.PolicyType{networkingv1.PolicyTypeEgress}, nil, nil),
+		policy("workers", "worker-deny-all", metav1.LabelSelector{},
+			[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress}, nil, nil),
+		policy("kube-system", "ignored", metav1.LabelSelector{},
+			[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress}, nil, nil),
+	}
+	pods := map[string][]corev1.Pod{
+		"payments-prod": {*objects[4].(*corev1.Pod), *objects[5].(*corev1.Pod)},
+		"workers":       {*objects[6].(*corev1.Pod)},
+	}
+	legacy, err := newTestNetworkAuditor(objects...).auditNetworkPolicies("", pods, false)
+	if err != nil {
+		t.Fatalf("legacy audit: %v", err)
+	}
+	fast, err := newTestNetworkAuditor(objects...).auditNetworkPolicies("", pods, true)
+	if err != nil {
+		t.Fatalf("snapshot audit: %v", err)
+	}
+	if !reflect.DeepEqual(fast, legacy) {
+		t.Fatalf("cluster policy snapshot changed results:\nfast=%+v\nlegacy=%+v", fast, legacy)
+	}
+}
+
+func TestAuditNetworkPoliciesClusterPolicySnapshotIsolatesNamespaces(t *testing.T) {
+	na := newTestNetworkAuditor(
+		nsObj("open"), nsObj("locked"),
+		policy("locked", "deny-all", metav1.LabelSelector{},
+			[]networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress}, nil, nil),
+	)
+	audit, err := na.AuditNetworkPoliciesWithPods("", []corev1.Pod{
+		*podWithLabels("open", "api", nil), *podWithLabels("locked", "api", nil),
+	})
+	if err != nil {
+		t.Fatalf("AuditNetworkPoliciesWithPods: %v", err)
+	}
+	if _, ok := findStatus(audit.UnprotectedNamespaces, "open"); !ok {
+		t.Fatalf("policy from another namespace protected open: %+v", audit)
+	}
+	if _, ok := findStatus(audit.ProtectedNamespaces, "locked"); !ok {
+		t.Fatalf("locked namespace was not protected: %+v", audit)
+	}
+}
+
+func TestAuditNetworkPoliciesClusterPolicySnapshotPreservesNamespaceFiltering(t *testing.T) {
+	na := newTestNetworkAuditor(nsObj("payments"), nsObj("billing"), nsObj("kube-system"))
+	audit, err := na.AuditNetworkPoliciesWithPods("payments", []corev1.Pod{
+		*podWithLabels("payments", "api", nil), *podWithLabels("billing", "api", nil),
+	})
+	if err != nil {
+		t.Fatalf("AuditNetworkPoliciesWithPods: %v", err)
+	}
+	if audit.TotalNamespaces != 1 {
+		t.Fatalf("TotalNamespaces = %d, want 1", audit.TotalNamespaces)
+	}
+	if _, ok := findStatus(audit.UnprotectedNamespaces, "payments"); !ok {
+		t.Fatalf("filtered namespace missing: %+v", audit)
+	}
+	if _, ok := findStatus(audit.UnprotectedNamespaces, "billing"); ok {
+		t.Fatalf("non-target namespace included: %+v", audit)
+	}
+}
+
+func TestAuditNetworkPoliciesClusterPolicySnapshotUsesOneClusterList(t *testing.T) {
+	na := newTestNetworkAuditor(nsObj("one"), nsObj("two"))
+	if _, err := na.AuditNetworkPoliciesWithPods("", nil); err != nil {
+		t.Fatalf("AuditNetworkPoliciesWithPods: %v", err)
+	}
+	clusterLists, namespaceLists := 0, 0
+	for _, action := range na.clientset.(*fake.Clientset).Actions() {
+		if action.GetVerb() != "list" || action.GetResource().Resource != "networkpolicies" {
+			continue
+		}
+		if action.GetNamespace() == "" {
+			clusterLists++
+		} else {
+			namespaceLists++
+		}
+	}
+	if clusterLists != 1 || namespaceLists != 0 {
+		t.Fatalf("NetworkPolicy LISTs: cluster=%d namespace=%d, want 1/0", clusterLists, namespaceLists)
+	}
+}
+
+func TestAuditNetworkPoliciesClusterListFailureFallsBack(t *testing.T) {
+	na := newTestNetworkAuditor(nsObj("one"), nsObj("two"))
+	na.clientset.(*fake.Clientset).PrependReactor("list", "networkpolicies", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetNamespace() == "" {
+			return true, nil, errors.New("cluster-wide list forbidden")
+		}
+		return false, nil, nil
+	})
+	if _, err := na.AuditNetworkPoliciesWithPods("", nil); err != nil {
+		t.Fatalf("AuditNetworkPoliciesWithPods: %v", err)
+	}
+	clusterLists, namespaceLists := 0, 0
+	for _, action := range na.clientset.(*fake.Clientset).Actions() {
+		if action.GetVerb() != "list" || action.GetResource().Resource != "networkpolicies" {
+			continue
+		}
+		if action.GetNamespace() == "" {
+			clusterLists++
+		} else {
+			namespaceLists++
+		}
+	}
+	if clusterLists != 1 || namespaceLists != 2 {
+		t.Fatalf("fallback NetworkPolicy LISTs: cluster=%d namespace=%d, want 1/2", clusterLists, namespaceLists)
+	}
+}
+
+func TestAuditNetworkPoliciesFallbackPreservesPartialResultsAndWarnings(t *testing.T) {
+	na := newTestNetworkAuditor(nsObj("healthy"), nsObj("broken"))
+	na.clientset.(*fake.Clientset).PrependReactor("list", "networkpolicies", func(action ktesting.Action) (bool, runtime.Object, error) {
+		switch action.GetNamespace() {
+		case "":
+			return true, nil, errors.New("cluster-wide list forbidden")
+		case "broken":
+			return true, nil, context.DeadlineExceeded
+		default:
+			return false, nil, nil
+		}
+	})
+	audit, err := na.AuditNetworkPoliciesWithPods("", nil)
+	if err != nil {
+		t.Fatalf("AuditNetworkPoliciesWithPods: %v", err)
+	}
+	if audit.TotalNamespaces != 2 || len(audit.Warnings) != 1 || audit.Warnings[0].Namespace != "broken" || audit.Warnings[0].Operation != "list NetworkPolicies" {
+		t.Fatalf("fallback warnings changed: %+v", audit)
+	}
+	if _, ok := findStatus(audit.ProtectedNamespaces, "healthy"); !ok {
+		t.Fatalf("successful namespace result was lost: %+v", audit)
+	}
+	if _, ok := findStatus(audit.ProtectedNamespaces, "broken"); ok {
+		t.Fatalf("failed namespace appeared in partial results: %+v", audit)
+	}
+}
+
 func TestAuditNetworkPoliciesPodListFailureRecordsWarning(t *testing.T) {
 	na := newTestNetworkAuditor(nsObj("broken"))
 	na.clientset.(*fake.Clientset).PrependReactor("list", "pods", func(ktesting.Action) (bool, runtime.Object, error) {

--- a/pkg/analyzer/resources.go
+++ b/pkg/analyzer/resources.go
@@ -17,6 +17,7 @@ import (
 type ResourceAnalyzer struct {
 	clientset *kubernetes.Clientset
 	ctx       context.Context
+	pods      []corev1.Pod
 }
 
 // NewResourceAnalyzer creates a new resource analyzer
@@ -46,6 +47,9 @@ func (ra *ResourceAnalyzer) AnalyzeClusterResources(namespace string) (*models.C
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pods: %w", err)
 	}
+	// Retain the successful snapshot so later analyzers in the same full-scan
+	// pipeline can examine the identical Pods without another API request.
+	ra.pods = append(ra.pods[:0], podList.Items...)
 
 	// Roll the same pod list up to one entry per owning workload — no
 	// second cluster fetch, just a different view of data already in hand.
@@ -119,6 +123,12 @@ func (ra *ResourceAnalyzer) AnalyzeClusterResources(namespace string) (*models.C
 	analysis.Optimizations = ra.generateOptimizations(namespaces)
 
 	return analysis, nil
+}
+
+// PodSnapshot returns a copy of the Pod snapshot successfully retrieved by
+// the most recent AnalyzeClusterResources call.
+func (ra *ResourceAnalyzer) PodSnapshot() []corev1.Pod {
+	return append([]corev1.Pod(nil), ra.pods...)
 }
 
 // getClusterCapacity calculates total cluster capacity

--- a/pkg/analyzer/security.go
+++ b/pkg/analyzer/security.go
@@ -13,7 +13,7 @@ import (
 
 // SecurityAuditor performs security analysis on cluster workloads
 type SecurityAuditor struct {
-	clientset *kubernetes.Clientset
+	clientset kubernetes.Interface
 	ctx       context.Context
 }
 
@@ -27,22 +27,31 @@ func NewSecurityAuditor(clientset *kubernetes.Clientset) *SecurityAuditor {
 
 // AuditClusterSecurity performs comprehensive security audit
 func (sa *SecurityAuditor) AuditClusterSecurity(namespace string) (*models.SecurityAudit, error) {
-	audit := &models.SecurityAudit{
-		TotalPodsAudited: 0,
-		Risks:            models.SecurityRisks{},
-		Issues:           []models.SecurityIssue{},
-	}
-
-	// Get all pods
 	podList, err := sa.clientset.CoreV1().Pods(namespace).List(sa.ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pods: %w", err)
 	}
+	return sa.auditPods(podList.Items), nil
+}
 
-	audit.TotalPodsAudited = len(podList.Items)
+// AuditClusterSecurityWithPodSnapshot reuses Pods only when the caller
+// explicitly confirms that the snapshot covers the entire cluster.
+func (sa *SecurityAuditor) AuditClusterSecurityWithPodSnapshot(namespace string, pods []corev1.Pod, clusterWide bool) (*models.SecurityAudit, error) {
+	if !clusterWide {
+		return sa.AuditClusterSecurity(namespace)
+	}
+	return sa.auditPods(pods), nil
+}
+
+func (sa *SecurityAuditor) auditPods(pods []corev1.Pod) *models.SecurityAudit {
+	audit := &models.SecurityAudit{
+		TotalPodsAudited: len(pods),
+		Risks:            models.SecurityRisks{},
+		Issues:           []models.SecurityIssue{},
+	}
 
 	// Audit each pod
-	for _, pod := range podList.Items {
+	for _, pod := range pods {
 		issues := sa.auditPod(pod)
 		audit.Issues = append(audit.Issues, issues...)
 
@@ -55,7 +64,7 @@ func (sa *SecurityAuditor) AuditClusterSecurity(namespace string) (*models.Secur
 	// Generate priority actions
 	audit.PriorityActions = sa.generatePriorityActions(audit)
 
-	return audit, nil
+	return audit
 }
 
 // auditPod checks a single pod for security issues

--- a/pkg/analyzer/security_test.go
+++ b/pkg/analyzer/security_test.go
@@ -1,13 +1,106 @@
 package analyzer
 
 import (
+	"context"
+	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/opscart/opscart-k8s-watcher/pkg/models"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
 )
+
+func securityTestPod(name, namespace string, privileged bool) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name: "app",
+			SecurityContext: &corev1.SecurityContext{
+				Privileged: &privileged,
+			},
+		}}},
+	}
+}
+
+func securityPodListCount(client *fake.Clientset) int {
+	count := 0
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "list" && action.GetResource().Resource == "pods" {
+			count++
+		}
+	}
+	return count
+}
+
+func TestSecurityClusterWidePodSnapshotAvoidsListAndPreservesFindings(t *testing.T) {
+	pods := []corev1.Pod{
+		*securityTestPod("privileged", "app", true),
+		*securityTestPod("ordinary", "other", false),
+	}
+	legacyClient := fake.NewSimpleClientset(&pods[0], &pods[1])
+	legacy := &SecurityAuditor{clientset: legacyClient, ctx: context.Background()}
+	legacyAudit, err := legacy.AuditClusterSecurity("")
+	if err != nil {
+		t.Fatalf("legacy security audit: %v", err)
+	}
+
+	sharedClient := fake.NewSimpleClientset()
+	shared := &SecurityAuditor{clientset: sharedClient, ctx: context.Background()}
+	sharedAudit, err := shared.AuditClusterSecurityWithPodSnapshot("", pods, true)
+	if err != nil {
+		t.Fatalf("shared security audit: %v", err)
+	}
+	if got := securityPodListCount(sharedClient); got != 0 {
+		t.Fatalf("Pod LISTs with cluster-wide snapshot = %d, want 0", got)
+	}
+	if !reflect.DeepEqual(sharedAudit, legacyAudit) {
+		t.Fatalf("shared snapshot changed security findings:\nshared=%+v\nlegacy=%+v", sharedAudit, legacyAudit)
+	}
+}
+
+func TestSecurityNamespaceScopedSnapshotUsesLegacyClusterList(t *testing.T) {
+	apiPod := securityTestPod("cluster-pod", "other", false)
+	client := fake.NewSimpleClientset(apiPod)
+	sa := &SecurityAuditor{clientset: client, ctx: context.Background()}
+	snapshotPod := securityTestPod("namespace-only", "selected", true)
+	audit, err := sa.AuditClusterSecurityWithPodSnapshot("", []corev1.Pod{*snapshotPod}, false)
+	if err != nil {
+		t.Fatalf("security audit: %v", err)
+	}
+	if got := securityPodListCount(client); got != 1 {
+		t.Fatalf("legacy Pod LISTs = %d, want 1", got)
+	}
+	if audit.TotalPodsAudited != 1 || len(audit.Issues) == 0 {
+		t.Fatalf("unexpected legacy audit: %+v", audit)
+	}
+	for _, issue := range audit.Issues {
+		if issue.Name == "namespace-only" || strings.HasPrefix(issue.Name, "namespace-only/") {
+			t.Fatalf("namespace-scoped snapshot leaked into cluster audit: %+v", issue)
+		}
+	}
+}
+
+func TestSecuritySnapshotFallbackPreservesListError(t *testing.T) {
+	wantErr := errors.New("pods forbidden")
+	client := fake.NewSimpleClientset()
+	client.PrependReactor("list", "pods", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, wantErr
+	})
+	sa := &SecurityAuditor{clientset: client, ctx: context.Background()}
+	audit, err := sa.AuditClusterSecurityWithPodSnapshot("", nil, false)
+	if audit != nil || !errors.Is(err, wantErr) || !strings.Contains(err.Error(), "failed to list pods") {
+		t.Fatalf("fallback result = audit:%+v err:%v", audit, err)
+	}
+	if got := securityPodListCount(client); got != 1 {
+		t.Fatalf("failed fallback Pod LISTs = %d, want 1", got)
+	}
+}
 
 func TestDetectEnvironment(t *testing.T) {
 	tests := []struct {

--- a/pkg/analyzer/waste.go
+++ b/pkg/analyzer/waste.go
@@ -22,9 +22,10 @@ import (
 // ================================================================
 
 type WasteAuditor struct {
-	clientset  kubernetes.Interface
-	ctx        context.Context
-	minAgeDays int
+	clientset       kubernetes.Interface
+	ctx             context.Context
+	minAgeDays      int
+	podsByNamespace map[string][]corev1.Pod
 }
 
 type WasteAudit struct {
@@ -217,6 +218,21 @@ func NewWasteAuditor(clientset kubernetes.Interface, minAgeDays int) (*WasteAudi
 	}, cancel
 }
 
+// WithPodSnapshot supplies Pods already retrieved by a preceding analyzer.
+// Only a genuinely cluster-wide snapshot is retained; namespace-scoped input
+// leaves detectors on their existing Kubernetes API retrieval paths.
+func (w *WasteAuditor) WithPodSnapshot(pods []corev1.Pod, clusterWide bool) *WasteAuditor {
+	if !clusterWide {
+		w.podsByNamespace = nil
+		return w
+	}
+	w.podsByNamespace = make(map[string][]corev1.Pod)
+	for _, pod := range pods {
+		w.podsByNamespace[pod.Namespace] = append(w.podsByNamespace[pod.Namespace], pod)
+	}
+	return w
+}
+
 // ================================================================
 // Main Audit
 // ================================================================
@@ -344,15 +360,22 @@ func (w *WasteAuditor) detectAbandonedNamespaces(audit *WasteAudit, filterNamesp
 			continue
 		}
 
-		// Count running pods
-		pods, err := w.clientset.CoreV1().Pods(nsName).List(w.ctx, metav1.ListOptions{TimeoutSeconds: int64Ptr(10)})
-		if err != nil {
-			return fmt.Errorf("list pods in namespace %q: %w", nsName, err)
+		// Count running pods. A non-nil map, including an empty map, is a
+		// cluster-wide snapshot; otherwise retain the legacy namespace LIST.
+		var namespacePods []corev1.Pod
+		if w.podsByNamespace == nil {
+			pods, err := w.clientset.CoreV1().Pods(nsName).List(w.ctx, metav1.ListOptions{TimeoutSeconds: int64Ptr(10)})
+			if err != nil {
+				return fmt.Errorf("list pods in namespace %q: %w", nsName, err)
+			}
+			namespacePods = pods.Items
+		} else {
+			namespacePods = w.podsByNamespace[nsName]
 		}
 
-		podCount := len(pods.Items)
+		podCount := len(namespacePods)
 		runningCount := 0
-		for _, p := range pods.Items {
+		for _, p := range namespacePods {
 			if p.Status.Phase == corev1.PodRunning {
 				runningCount++
 			}

--- a/pkg/analyzer/waste.go
+++ b/pkg/analyzer/waste.go
@@ -432,19 +432,24 @@ func (w *WasteAuditor) detectAbandonedNamespaces(audit *WasteAudit, filterNamesp
 // An event-list failure returns an empty map for classification and an error
 // so the audit can preserve that the pod detector was incomplete.
 func (w *WasteAuditor) probeFailurePodsByNamespace(namespace string) (map[string]bool, error) {
-	result := make(map[string]bool)
-
 	events, err := w.clientset.CoreV1().Events(namespace).List(w.ctx, metav1.ListOptions{
 		FieldSelector:  "involvedObject.kind=Pod",
 		TimeoutSeconds: int64Ptr(10),
 	})
 	if err != nil {
 		fmt.Printf("⚠️  Could not list events in namespace %q for probe-failure detection: %v\n", namespace, err)
-		return result, err
+		return map[string]bool{}, err
 	}
+	return probeFailurePodsFromEvents(events.Items), nil
+}
 
-	for _, ev := range events.Items {
+func probeFailurePodsFromEvents(events []corev1.Event) map[string]bool {
+	result := make(map[string]bool)
+	for _, ev := range events {
 		if ev.InvolvedObject.Kind != "" && ev.InvolvedObject.Kind != "Pod" {
+			continue
+		}
+		if ev.Type != corev1.EventTypeWarning {
 			continue
 		}
 		lower := strings.ToLower(ev.Message)
@@ -452,8 +457,7 @@ func (w *WasteAuditor) probeFailurePodsByNamespace(namespace string) (map[string
 			result[ev.InvolvedObject.Name] = true
 		}
 	}
-
-	return result, nil
+	return result
 }
 
 // classifyStalePodFailure translates one Kubernetes Pod snapshot into the
@@ -582,12 +586,30 @@ func dashboardPodStatus(classifiedReason string) string {
 }
 
 func (w *WasteAuditor) detectStalePods(audit *WasteAudit, filterNamespace string) error {
+	return w.detectStalePodsWithClusterEvents(audit, filterNamespace, true)
+}
+
+func (w *WasteAuditor) detectStalePodsWithClusterEvents(audit *WasteAudit, filterNamespace string, useClusterEvents bool) error {
 	pods, err := w.clientset.CoreV1().Pods(filterNamespace).List(w.ctx, metav1.ListOptions{TimeoutSeconds: int64Ptr(10)})
 	if err != nil {
 		return err
 	}
 
 	now := time.Now()
+
+	var eventsByNamespace map[string][]corev1.Event
+	if useClusterEvents {
+		events, listErr := w.clientset.CoreV1().Events("").List(w.ctx, metav1.ListOptions{
+			FieldSelector:  "involvedObject.kind=Pod,type=Warning",
+			TimeoutSeconds: int64Ptr(10),
+		})
+		if listErr == nil {
+			eventsByNamespace = make(map[string][]corev1.Event)
+			for _, event := range events.Items {
+				eventsByNamespace[event.Namespace] = append(eventsByNamespace[event.Namespace], event)
+			}
+		}
+	}
 
 	// Namespace event cache: fetched at most once per namespace encountered,
 	// not once per pod (a 350-pod cluster must not turn into hundreds of
@@ -604,10 +626,14 @@ func (w *WasteAuditor) detectStalePods(audit *WasteAudit, filterNamespace string
 		ageDays := int(now.Sub(pod.CreationTimestamp.Time).Hours() / 24)
 
 		if _, ok := probeFailurePods[pod.Namespace]; !ok {
-			var err error
-			probeFailurePods[pod.Namespace], err = w.probeFailurePodsByNamespace(pod.Namespace)
-			if err != nil && eventScanErr == nil {
-				eventScanErr = fmt.Errorf("list pod events in namespace %q: %w", pod.Namespace, err)
+			if eventsByNamespace != nil {
+				probeFailurePods[pod.Namespace] = probeFailurePodsFromEvents(eventsByNamespace[pod.Namespace])
+			} else {
+				var err error
+				probeFailurePods[pod.Namespace], err = w.probeFailurePodsByNamespace(pod.Namespace)
+				if err != nil && eventScanErr == nil {
+					eventScanErr = fmt.Errorf("list pod events in namespace %q: %w", pod.Namespace, err)
+				}
 			}
 		}
 		hasProbeFailureEvent := probeFailurePods[pod.Namespace][pod.Name]

--- a/pkg/analyzer/waste.go
+++ b/pkg/analyzer/waste.go
@@ -25,6 +25,7 @@ type WasteAuditor struct {
 	clientset       kubernetes.Interface
 	ctx             context.Context
 	minAgeDays      int
+	podSnapshot     []corev1.Pod
 	podsByNamespace map[string][]corev1.Pod
 }
 
@@ -223,14 +224,26 @@ func NewWasteAuditor(clientset kubernetes.Interface, minAgeDays int) (*WasteAudi
 // leaves detectors on their existing Kubernetes API retrieval paths.
 func (w *WasteAuditor) WithPodSnapshot(pods []corev1.Pod, clusterWide bool) *WasteAuditor {
 	if !clusterWide {
+		w.podSnapshot = nil
 		w.podsByNamespace = nil
 		return w
 	}
+	w.podSnapshot = append(w.podSnapshot[:0], pods...)
 	w.podsByNamespace = make(map[string][]corev1.Pod)
 	for _, pod := range pods {
 		w.podsByNamespace[pod.Namespace] = append(w.podsByNamespace[pod.Namespace], pod)
 	}
 	return w
+}
+
+func (w *WasteAuditor) sharedPods(filterNamespace string) ([]corev1.Pod, bool) {
+	if w.podsByNamespace == nil {
+		return nil, false
+	}
+	if filterNamespace != "" {
+		return w.podsByNamespace[filterNamespace], true
+	}
+	return w.podSnapshot, true
 }
 
 // ================================================================
@@ -590,9 +603,13 @@ func (w *WasteAuditor) detectStalePods(audit *WasteAudit, filterNamespace string
 }
 
 func (w *WasteAuditor) detectStalePodsWithClusterEvents(audit *WasteAudit, filterNamespace string, useClusterEvents bool) error {
-	pods, err := w.clientset.CoreV1().Pods(filterNamespace).List(w.ctx, metav1.ListOptions{TimeoutSeconds: int64Ptr(10)})
-	if err != nil {
-		return err
+	podItems, shared := w.sharedPods(filterNamespace)
+	if !shared {
+		pods, err := w.clientset.CoreV1().Pods(filterNamespace).List(w.ctx, metav1.ListOptions{TimeoutSeconds: int64Ptr(10)})
+		if err != nil {
+			return err
+		}
+		podItems = pods.Items
 	}
 
 	now := time.Now()
@@ -617,7 +634,7 @@ func (w *WasteAuditor) detectStalePodsWithClusterEvents(audit *WasteAudit, filte
 	probeFailurePods := make(map[string]map[string]bool)
 	var eventScanErr error
 
-	for _, pod := range pods.Items {
+	for _, pod := range podItems {
 		// Skip system namespaces
 		if isInfraPattern(pod.Namespace) {
 			continue
@@ -735,14 +752,18 @@ func (w *WasteAuditor) detectOrphanedPVCs(audit *WasteAudit, filterNamespace str
 		return err
 	}
 
-	// Build set of PVCs actively used by pods
-	pods, err := w.clientset.CoreV1().Pods(filterNamespace).List(w.ctx, metav1.ListOptions{TimeoutSeconds: int64Ptr(10)})
-	if err != nil {
-		return fmt.Errorf("list pods for PVC reference detection: %w", err)
+	// Build set of PVCs actively used by pods.
+	podItems, shared := w.sharedPods(filterNamespace)
+	if !shared {
+		pods, err := w.clientset.CoreV1().Pods(filterNamespace).List(w.ctx, metav1.ListOptions{TimeoutSeconds: int64Ptr(10)})
+		if err != nil {
+			return fmt.Errorf("list pods for PVC reference detection: %w", err)
+		}
+		podItems = pods.Items
 	}
 
 	usedPVCs := map[string]bool{}
-	for _, pod := range pods.Items {
+	for _, pod := range podItems {
 		for _, vol := range pod.Spec.Volumes {
 			if vol.PersistentVolumeClaim != nil {
 				key := pod.Namespace + "/" + vol.PersistentVolumeClaim.ClaimName
@@ -1114,9 +1135,13 @@ func (w *WasteAuditor) detectOrphanedServices(audit *WasteAudit, filterNamespace
 	if err != nil {
 		return err
 	}
-	pods, err := w.clientset.CoreV1().Pods(filterNamespace).List(w.ctx, metav1.ListOptions{TimeoutSeconds: int64Ptr(10)})
-	if err != nil {
-		return fmt.Errorf("list pods for Service selector matching: %w", err)
+	podItems, shared := w.sharedPods(filterNamespace)
+	if !shared {
+		pods, err := w.clientset.CoreV1().Pods(filterNamespace).List(w.ctx, metav1.ListOptions{TimeoutSeconds: int64Ptr(10)})
+		if err != nil {
+			return fmt.Errorf("list pods for Service selector matching: %w", err)
+		}
+		podItems = pods.Items
 	}
 
 	now := time.Now()
@@ -1151,7 +1176,7 @@ func (w *WasteAuditor) detectOrphanedServices(audit *WasteAudit, filterNamespace
 
 		selector := labels.SelectorFromSet(svc.Spec.Selector)
 		matchedPods := 0
-		for _, pod := range pods.Items {
+		for _, pod := range podItems {
 			if pod.Namespace == svc.Namespace && selector.Matches(labels.Set(pod.Labels)) {
 				matchedPods++
 			}

--- a/pkg/analyzer/waste_test.go
+++ b/pkg/analyzer/waste_test.go
@@ -2,6 +2,7 @@ package analyzer
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -25,6 +26,116 @@ func newTestAuditor(minAgeDays int, objs ...interface{}) *WasteAuditor {
 		clientset:  fake.NewSimpleClientset(runtimeObjs...),
 		minAgeDays: minAgeDays,
 		ctx:        context.Background(),
+	}
+}
+
+func oldNamespace(name string, ageDays int) *corev1.Namespace {
+	return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: name, CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Duration(ageDays) * 24 * time.Hour)),
+	}}
+}
+
+func namespacePod(namespace, name string, phase corev1.PodPhase) *corev1.Pod {
+	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}, Status: corev1.PodStatus{Phase: phase}}
+}
+
+func runAbandonedNamespaceDetector(t *testing.T, auditor *WasteAuditor) []AbandonedNamespace {
+	t.Helper()
+	audit := &WasteAudit{}
+	if err := auditor.detectAbandonedNamespaces(audit, ""); err != nil {
+		t.Fatalf("detectAbandonedNamespaces: %v", err)
+	}
+	return audit.AbandonedNamespaces
+}
+
+func TestAbandonedNamespacesSharedSnapshotMatchesLegacy(t *testing.T) {
+	objects := []interface{}{
+		oldNamespace("empty", 30), oldNamespace("stopped", 20), oldNamespace("active", 15),
+		namespacePod("stopped", "failed", corev1.PodFailed),
+		namespacePod("stopped", "pending", corev1.PodPending),
+		namespacePod("active", "running", corev1.PodRunning),
+	}
+	legacy := runAbandonedNamespaceDetector(t, newTestAuditor(7, objects...))
+	sharedAuditor := newTestAuditor(7, objects...)
+	sharedAuditor.WithPodSnapshot([]corev1.Pod{
+		*objects[3].(*corev1.Pod), *objects[4].(*corev1.Pod), *objects[5].(*corev1.Pod),
+	}, true)
+	shared := runAbandonedNamespaceDetector(t, sharedAuditor)
+	if !reflect.DeepEqual(shared, legacy) {
+		t.Fatalf("shared snapshot changed abandoned namespaces:\nshared=%+v\nlegacy=%+v", shared, legacy)
+	}
+}
+
+func TestAbandonedNamespacesSharedSnapshotPreservesEmptyOldNamespace(t *testing.T) {
+	wa := newTestAuditor(7, oldNamespace("empty", 30))
+	wa.WithPodSnapshot([]corev1.Pod{}, true)
+	got := runAbandonedNamespaceDetector(t, wa)
+	if len(got) != 1 || got[0].Name != "empty" || got[0].PodCount != 0 || !strings.Contains(got[0].Reason, "No pods found") {
+		t.Fatalf("empty old namespace changed: %+v", got)
+	}
+}
+
+func TestAbandonedNamespacesSharedSnapshotExcludesNamespaceWithRunningPods(t *testing.T) {
+	wa := newTestAuditor(7, oldNamespace("active", 30))
+	wa.WithPodSnapshot([]corev1.Pod{*namespacePod("active", "api", corev1.PodRunning)}, true)
+	if got := runAbandonedNamespaceDetector(t, wa); len(got) != 0 {
+		t.Fatalf("namespace with running Pods reported abandoned: %+v", got)
+	}
+}
+
+func TestAbandonedNamespacesSharedSnapshotIncludesOnlyNonRunningPods(t *testing.T) {
+	wa := newTestAuditor(7, oldNamespace("stopped", 30))
+	wa.WithPodSnapshot([]corev1.Pod{
+		*namespacePod("stopped", "failed", corev1.PodFailed),
+		*namespacePod("stopped", "pending", corev1.PodPending),
+	}, true)
+	got := runAbandonedNamespaceDetector(t, wa)
+	if len(got) != 1 || got[0].PodCount != 2 || !strings.Contains(got[0].Reason, "none are Running") {
+		t.Fatalf("non-running Pod classification changed: %+v", got)
+	}
+}
+
+func TestAbandonedNamespacesSharedSnapshotPreservesEligibilityFiltering(t *testing.T) {
+	wa := newTestAuditor(7,
+		oldNamespace("eligible", 30), oldNamespace("default", 30),
+		oldNamespace("kube-system", 30), oldNamespace("young", 2),
+	)
+	wa.WithPodSnapshot([]corev1.Pod{}, true)
+	got := runAbandonedNamespaceDetector(t, wa)
+	if len(got) != 1 || got[0].Name != "eligible" {
+		t.Fatalf("namespace eligibility filtering changed: %+v", got)
+	}
+}
+
+func TestAbandonedNamespacesClusterWideSnapshotPerformsNoPodLists(t *testing.T) {
+	wa := newTestAuditor(7, oldNamespace("one", 30), oldNamespace("two", 30))
+	wa.WithPodSnapshot([]corev1.Pod{}, true)
+	runAbandonedNamespaceDetector(t, wa)
+	for _, action := range wa.clientset.(*fake.Clientset).Actions() {
+		if action.GetVerb() == "list" && action.GetResource().Resource == "pods" {
+			t.Fatalf("unexpected Pod LIST for namespace %q", action.GetNamespace())
+		}
+	}
+}
+
+func TestAbandonedNamespacesNamespaceScopedSnapshotFallsBackToPodLists(t *testing.T) {
+	apiPod := namespacePod("stopped", "failed", corev1.PodFailed)
+	wa := newTestAuditor(7, oldNamespace("stopped", 30), apiPod)
+	// This deliberately conflicts with the API Pod. A namespace-scoped
+	// snapshot must be ignored, leaving the legacy request and result intact.
+	wa.WithPodSnapshot([]corev1.Pod{*namespacePod("stopped", "running", corev1.PodRunning)}, false)
+	got := runAbandonedNamespaceDetector(t, wa)
+	if len(got) != 1 || got[0].PodCount != 1 {
+		t.Fatalf("namespace-scoped snapshot did not use legacy result: %+v", got)
+	}
+	podLists := 0
+	for _, action := range wa.clientset.(*fake.Clientset).Actions() {
+		if action.GetVerb() == "list" && action.GetResource().Resource == "pods" {
+			podLists++
+		}
+	}
+	if podLists != 1 {
+		t.Fatalf("Pod LIST calls = %d, want 1", podLists)
 	}
 }
 

--- a/pkg/analyzer/waste_test.go
+++ b/pkg/analyzer/waste_test.go
@@ -691,6 +691,182 @@ func TestEventsFetchedOncePerNamespaceNotPerPod(t *testing.T) {
 	}
 }
 
+func eventListScopes(actions []ktesting.Action) (cluster, namespace int) {
+	for _, action := range actions {
+		if action.GetVerb() != "list" || action.GetResource().Resource != "events" {
+			continue
+		}
+		if action.GetNamespace() == "" {
+			cluster++
+		} else {
+			namespace++
+		}
+	}
+	return
+}
+
+func TestClusterEventSnapshotUsesOneRequestWithRequiredSelector(t *testing.T) {
+	wa := newTestAuditor(1, crashLoopPod("pod-a", "app"), crashLoopPod("pod-b", "other"))
+	audit := &WasteAudit{}
+	if err := wa.detectStalePods(audit, ""); err != nil {
+		t.Fatalf("detectStalePods: %v", err)
+	}
+	client := wa.clientset.(*fake.Clientset)
+	cluster, namespace := eventListScopes(client.Actions())
+	if cluster != 1 || namespace != 0 {
+		t.Fatalf("Event LISTs: cluster=%d namespace=%d, want 1/0", cluster, namespace)
+	}
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "list" && action.GetResource().Resource == "events" {
+			selector := action.(ktesting.ListAction).GetListRestrictions().Fields.String()
+			if selector != "involvedObject.kind=Pod,type=Warning" {
+				t.Fatalf("aggregate Event selector = %q", selector)
+			}
+		}
+	}
+}
+
+func TestClusterEventSnapshotMatchesLegacyResults(t *testing.T) {
+	podA := crashLoopPod("api", "payments")
+	podB := crashLoopPod("worker", "workers")
+	eventA := probeFailureEvent("api.probe", "api", "payments")
+	objects := []interface{}{podA, podB, eventA}
+	legacyAudit := &WasteAudit{}
+	if err := newTestAuditor(1, objects...).detectStalePodsWithClusterEvents(legacyAudit, "", false); err != nil {
+		t.Fatalf("legacy detection: %v", err)
+	}
+	aggregateAudit := &WasteAudit{}
+	if err := newTestAuditor(1, objects...).detectStalePodsWithClusterEvents(aggregateAudit, "", true); err != nil {
+		t.Fatalf("aggregate detection: %v", err)
+	}
+	if !reflect.DeepEqual(aggregateAudit.StalePods, legacyAudit.StalePods) {
+		t.Fatalf("aggregate Events changed findings:\naggregate=%+v\nlegacy=%+v", aggregateAudit.StalePods, legacyAudit.StalePods)
+	}
+}
+
+func TestClusterEventSnapshotKeepsPodNamesNamespaceIsolated(t *testing.T) {
+	wa := newTestAuditor(1,
+		crashLoopPod("api", "with-probe"), crashLoopPod("api", "without-probe"),
+		probeFailureEvent("api.probe", "api", "with-probe"),
+	)
+	audit := &WasteAudit{}
+	if err := wa.detectStalePods(audit, ""); err != nil {
+		t.Fatalf("detectStalePods: %v", err)
+	}
+	withProbe, _ := findStalePod(audit.StalePods, "with-probe", "api")
+	withoutProbe, _ := findStalePod(audit.StalePods, "without-probe", "api")
+	if withProbe.Status != "ProbeFailure" || withoutProbe.Status != "CrashLoopBackOff" {
+		t.Fatalf("cross-namespace evidence contamination: with=%+v without=%+v", withProbe, withoutProbe)
+	}
+}
+
+func TestClusterEventSnapshotExcludesInfraNamespaces(t *testing.T) {
+	wa := newTestAuditor(1,
+		crashLoopPod("api", "kube-system"),
+		probeFailureEvent("api.probe", "api", "kube-system"),
+	)
+	audit := &WasteAudit{}
+	if err := wa.detectStalePods(audit, ""); err != nil {
+		t.Fatalf("detectStalePods: %v", err)
+	}
+	if len(audit.StalePods) != 0 {
+		t.Fatalf("infrastructure Pod was analyzed: %+v", audit.StalePods)
+	}
+}
+
+func TestProbeFailureEvidenceFiltersEventKindTypeAndMessage(t *testing.T) {
+	matching := probeFailureEvent("matching", "matching", "app")
+	secondSignature := probeFailureEvent("second", "second", "app")
+	secondSignature.Message = "Startup probe, will be restarted after failure"
+	normal := probeFailureEvent("normal", "normal", "app")
+	normal.Type = corev1.EventTypeNormal
+	nonPod := probeFailureEvent("node", "node", "app")
+	nonPod.InvolvedObject.Kind = "Node"
+	nonMatching := probeFailureEvent("other", "other", "app")
+	nonMatching.Message = "Container image pull failed"
+	got := probeFailurePodsFromEvents([]corev1.Event{*matching, *secondSignature, *normal, *nonPod, *nonMatching})
+	if !got["matching"] || !got["second"] {
+		t.Fatalf("probe signatures not recognized: %+v", got)
+	}
+	for _, excluded := range []string{"normal", "node", "other"} {
+		if got[excluded] {
+			t.Fatalf("Event %q incorrectly supplied probe evidence: %+v", excluded, got)
+		}
+	}
+}
+
+func TestClusterEventSnapshotNoMatchingEventsLeavesEvidenceEmpty(t *testing.T) {
+	wa := newTestAuditor(1, crashLoopPod("api", "app"))
+	audit := &WasteAudit{}
+	if err := wa.detectStalePods(audit, ""); err != nil {
+		t.Fatalf("detectStalePods: %v", err)
+	}
+	finding, ok := findStalePod(audit.StalePods, "app", "api")
+	if !ok || finding.Status != "CrashLoopBackOff" {
+		t.Fatalf("empty Event evidence changed classification: %+v", audit.StalePods)
+	}
+}
+
+func TestProbeFailureEvidenceIgnoresDuplicatesCountOrderAndSeries(t *testing.T) {
+	event := probeFailureEvent("api.probe", "api", "app")
+	event.Count = 37
+	event.Series = &corev1.EventSeries{Count: 91, LastObservedTime: metav1.MicroTime{Time: time.Now()}}
+	duplicate := event.DeepCopy()
+	duplicate.Name = "api.probe.duplicate"
+	forward := probeFailurePodsFromEvents([]corev1.Event{*event, *duplicate})
+	reverse := probeFailurePodsFromEvents([]corev1.Event{*duplicate, *event})
+	if !reflect.DeepEqual(forward, map[string]bool{"api": true}) || !reflect.DeepEqual(reverse, forward) {
+		t.Fatalf("count/order/series affected boolean evidence: forward=%+v reverse=%+v", forward, reverse)
+	}
+}
+
+func TestClusterEventListFailureFallsBackToNamespaceLists(t *testing.T) {
+	wa := newTestAuditor(1, crashLoopPod("api", "one"), crashLoopPod("worker", "two"))
+	wa.clientset.(*fake.Clientset).PrependReactor("list", "events", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetNamespace() == "" {
+			return true, nil, context.DeadlineExceeded
+		}
+		return false, nil, nil
+	})
+	audit := &WasteAudit{}
+	if err := wa.detectStalePods(audit, ""); err != nil {
+		t.Fatalf("fallback detection: %v", err)
+	}
+	cluster, namespace := eventListScopes(wa.clientset.(*fake.Clientset).Actions())
+	if cluster != 1 || namespace != 2 {
+		t.Fatalf("fallback Event LISTs: cluster=%d namespace=%d, want 1/2", cluster, namespace)
+	}
+}
+
+func TestClusterEventFallbackPreservesPartialFindingsAndWarning(t *testing.T) {
+	goodEvent := probeFailureEvent("api.probe", "api", "good")
+	wa := newTestAuditor(1, crashLoopPod("api", "good"), crashLoopPod("api", "broken"), goodEvent)
+	wa.clientset.(*fake.Clientset).PrependReactor("list", "events", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetNamespace() == "" || action.GetNamespace() == "broken" {
+			return true, nil, context.DeadlineExceeded
+		}
+		return false, nil, nil
+	})
+	audit, err := wa.AuditWaste("")
+	if err != nil {
+		t.Fatalf("AuditWaste: %v", err)
+	}
+	good, goodFound := findStalePod(audit.StalePods, "good", "api")
+	broken, brokenFound := findStalePod(audit.StalePods, "broken", "api")
+	if !goodFound || good.Status != "ProbeFailure" || !brokenFound || broken.Status != "CrashLoopBackOff" {
+		t.Fatalf("fallback partial findings changed: good=%+v broken=%+v", good, broken)
+	}
+	foundWarning := false
+	for _, warning := range audit.DetectorWarnings {
+		if warning.Category == "Zombie and idle/unmanaged pods" && strings.Contains(warning.Error, `namespace "broken"`) {
+			foundWarning = true
+		}
+	}
+	if !foundWarning {
+		t.Fatalf("fallback detector warning missing: %+v", audit.DetectorWarnings)
+	}
+}
+
 // ── Active-vs-age-gated malfunction detection ──────────────────────────────
 //
 // Currently-broken resources (Ingress backends with no ready endpoints,

--- a/pkg/analyzer/waste_test.go
+++ b/pkg/analyzer/waste_test.go
@@ -139,6 +139,133 @@ func TestAbandonedNamespacesNamespaceScopedSnapshotFallsBackToPodLists(t *testin
 	}
 }
 
+func countPodLists(actions []ktesting.Action) int {
+	count := 0
+	for _, action := range actions {
+		if action.GetVerb() == "list" && action.GetResource().Resource == "pods" {
+			count++
+		}
+	}
+	return count
+}
+
+func TestWasteClusterWideSnapshotAvoidsThreeDetectorPodLists(t *testing.T) {
+	pod := servicePod("api-1", "app", map[string]string{"app": "api"}, corev1.PodRunning, true)
+	wa := newTestAuditor(7, pod, oldService("api", "app", map[string]string{"app": "api"}, corev1.ServiceTypeClusterIP))
+	wa.WithPodSnapshot([]corev1.Pod{*pod}, true)
+	if _, err := wa.AuditWaste(""); err != nil {
+		t.Fatalf("AuditWaste: %v", err)
+	}
+	if got := countPodLists(wa.clientset.(*fake.Clientset).Actions()); got != 0 {
+		t.Fatalf("Pod LISTs with cluster-wide snapshot = %d, want 0", got)
+	}
+}
+
+func TestWasteSharedPodSnapshotPreservesDetectorResults(t *testing.T) {
+	t.Run("stale pods", func(t *testing.T) {
+		pod := crashLoopPod("api", "app")
+		event := probeFailureEvent("api.probe", "api", "app")
+		legacyAudit := &WasteAudit{}
+		if err := newTestAuditor(1, pod, event).detectStalePods(legacyAudit, ""); err != nil {
+			t.Fatalf("legacy stale pods: %v", err)
+		}
+		sharedAuditor := newTestAuditor(1, event)
+		sharedAuditor.WithPodSnapshot([]corev1.Pod{*pod}, true)
+		sharedAudit := &WasteAudit{}
+		if err := sharedAuditor.detectStalePods(sharedAudit, ""); err != nil {
+			t.Fatalf("shared stale pods: %v", err)
+		}
+		if !reflect.DeepEqual(sharedAudit.StalePods, legacyAudit.StalePods) {
+			t.Fatalf("shared snapshot changed stale Pods:\nshared=%+v\nlegacy=%+v", sharedAudit.StalePods, legacyAudit.StalePods)
+		}
+	})
+
+	t.Run("orphaned PVCs", func(t *testing.T) {
+		pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "data", Namespace: "app", CreationTimestamp: metav1.NewTime(time.Now().Add(-30 * 24 * time.Hour))}, Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound}}
+		pod := namespacePod("other", "api", corev1.PodRunning)
+		pod.Spec.Volumes = []corev1.Volume{{VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "data"}}}}
+		legacyAudit := &WasteAudit{}
+		if err := newTestAuditor(7, pvc, pod).detectOrphanedPVCs(legacyAudit, ""); err != nil {
+			t.Fatalf("legacy PVCs: %v", err)
+		}
+		sharedAuditor := newTestAuditor(7, pvc)
+		sharedAuditor.WithPodSnapshot([]corev1.Pod{*pod}, true)
+		sharedAudit := &WasteAudit{}
+		if err := sharedAuditor.detectOrphanedPVCs(sharedAudit, ""); err != nil {
+			t.Fatalf("shared PVCs: %v", err)
+		}
+		if !reflect.DeepEqual(sharedAudit.OrphanedPVCs, legacyAudit.OrphanedPVCs) {
+			t.Fatalf("shared snapshot changed orphaned PVCs:\nshared=%+v\nlegacy=%+v", sharedAudit.OrphanedPVCs, legacyAudit.OrphanedPVCs)
+		}
+	})
+
+	t.Run("orphaned services", func(t *testing.T) {
+		service := oldService("api", "app", map[string]string{"app": "api"}, corev1.ServiceTypeClusterIP)
+		pod := servicePod("api-1", "other", map[string]string{"app": "api"}, corev1.PodRunning, true)
+		legacyAudit := &WasteAudit{}
+		if err := newTestAuditor(7, service, pod).detectOrphanedServices(legacyAudit, ""); err != nil {
+			t.Fatalf("legacy services: %v", err)
+		}
+		sharedAuditor := newTestAuditor(7, service)
+		sharedAuditor.WithPodSnapshot([]corev1.Pod{*pod}, true)
+		sharedAudit := &WasteAudit{}
+		if err := sharedAuditor.detectOrphanedServices(sharedAudit, ""); err != nil {
+			t.Fatalf("shared services: %v", err)
+		}
+		if !reflect.DeepEqual(sharedAudit.OrphanedServices, legacyAudit.OrphanedServices) {
+			t.Fatalf("shared snapshot changed orphaned Services:\nshared=%+v\nlegacy=%+v", sharedAudit.OrphanedServices, legacyAudit.OrphanedServices)
+		}
+	})
+}
+
+func TestWastePodSnapshotFallbackPaths(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		configure func(*WasteAuditor)
+	}{
+		{name: "absent"},
+		{name: "namespace scoped", configure: func(wa *WasteAuditor) {
+			wa.WithPodSnapshot([]corev1.Pod{*namespacePod("app", "snapshot-only", corev1.PodRunning)}, false)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			wa := newTestAuditor(7)
+			if tc.configure != nil {
+				tc.configure(wa)
+			}
+			if _, err := wa.AuditWaste(""); err != nil {
+				t.Fatalf("AuditWaste: %v", err)
+			}
+			if got := countPodLists(wa.clientset.(*fake.Clientset).Actions()); got != 3 {
+				t.Fatalf("legacy Pod LISTs = %d, want 3", got)
+			}
+		})
+	}
+}
+
+func TestWastePodListErrorsPreserveFallbackWarnings(t *testing.T) {
+	wa := newTestAuditor(7)
+	wa.clientset.(*fake.Clientset).PrependReactor("list", "pods", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, context.DeadlineExceeded
+	})
+	audit, err := wa.AuditWaste("")
+	if err != nil {
+		t.Fatalf("AuditWaste: %v", err)
+	}
+	warnings := make(map[string]bool)
+	for _, warning := range audit.DetectorWarnings {
+		warnings[warning.Category] = true
+	}
+	for _, category := range []string{"Zombie and idle/unmanaged pods", "Unattached PVC candidates", "Orphaned services"} {
+		if !warnings[category] {
+			t.Errorf("missing legacy detector warning %q: %+v", category, audit.DetectorWarnings)
+		}
+	}
+	if got := countPodLists(wa.clientset.(*fake.Clientset).Actions()); got != 3 {
+		t.Fatalf("failed legacy Pod LISTs = %d, want 3", got)
+	}
+}
+
 func TestAuditWastePreservesDetectorWarnings(t *testing.T) {
 	wa := newTestAuditor(7)
 	wa.clientset.(*fake.Clientset).PrependReactor("list", "persistentvolumeclaims", func(ktesting.Action) (bool, runtime.Object, error) {


### PR DESCRIPTION
This change was validated against the minikube with scanner self-observability enabled.

Scanner requests reduced from 173 → 18 per scan
0 API errors
0 HTTP 429 throttles
Latest scan completed in approximately 2.8s against a 60s scan interval
Remaining high-volume reads are primarily associated with large cluster object populations rather than request fan-out.

Further API-call consolidation is intentionally deferred unless production measurements show throttling, errors, excessive scan duration, or resource pressure. The next focus is surfacing retained/wasteful cluster state more meaningfully through Waste & Drift and Cost Intelligence.